### PR TITLE
Implement more consistent unit cell index convention

### DIFF
--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -1,4 +1,12 @@
 """
+    const PEPOTensor{S}
+
+Default type for PEPO tensors with a single incoming and outgoing physical index, and 4
+virtual indices, conventionally ordered as: O : P ⊗ P' ← N ⊗ E ⊗ S ⊗ W.
+"""
+const PEPOTensor{S} = AbstractTensorMap{S,2,4} where {S<:ElementarySpace}
+
+"""
     struct InfinitePEPO{T<:PEPOTensor}
 
 Represents an infinite projected entangled-pair operator (PEPO) on a 3D cubic lattice.
@@ -132,3 +140,12 @@ function initializePEPS(
     Espaces = repeat([vspace], size(T, 1), size(T, 2))
     return InfinitePEPS(Pspaces, Nspaces, Espaces)
 end
+
+# Rotations
+Base.rotl90(t::PEPOTensor) = permute(t, ((1, 2), (4, 5, 6, 3)))
+Base.rotr90(t::PEPOTensor) = permute(t, ((1, 2), (6, 3, 4, 5)))
+Base.rot180(t::PEPOTensor) = permute(t, ((1, 2), (5, 6, 3, 4)))
+
+Base.rotl90(T::InfinitePEPO) = InfinitePEPO(stack(rotl90, eachslice(T.A; dims=3)))
+Base.rotr90(T::InfinitePEPO) = InfinitePEPO(stack(rotr90, eachslice(T.A; dims=3)))
+Base.rot180(T::InfinitePEPO) = InfinitePEPO(stack(rot180, eachslice(T.A; dims=3)))

--- a/src/states/abstractpeps.jl
+++ b/src/states/abstractpeps.jl
@@ -40,14 +40,6 @@ function PEPSTensor(
 end
 
 """
-    const PEPOTensor{S}
-
-Default type for PEPO tensors with a single incoming and outgoing physical index, and 4
-virtual indices, conventionally ordered as: O : P ⊗ P' ← N ⊗ E ⊗ S ⊗ W.
-"""
-const PEPOTensor{S} = AbstractTensorMap{S,2,4} where {S<:ElementarySpace}
-
-"""
     abstract type AbstractPEPS end
 
 Abstract supertype for a 2D projected entangled-pair state.
@@ -60,3 +52,8 @@ abstract type AbstractPEPS end
 Abstract supertype for a 2D projected entangled-pair operator.
 """
 abstract type AbstractPEPO end
+
+# Rotations
+Base.rotl90(t::PEPSTensor) = permute(t, ((1,), (3, 4, 5, 2)))
+Base.rotr90(t::PEPSTensor) = permute(t, ((1,), (5, 2, 3, 4)))
+Base.rot180(t::PEPSTensor) = permute(t, ((1,), (4, 5, 2, 3)))

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -128,7 +128,12 @@ end
 # VectorInterface
 VectorInterface.zerovector(x::InfinitePEPS) = InfinitePEPS(zerovector(x.A))
 
-# Chainrules
+# Rotations
+Base.rotl90(t::InfinitePEPS) = InfinitePEPS(rotl90(rotl90.(t.A)))
+Base.rotr90(t::InfinitePEPS) = InfinitePEPS(rotr90(rotr90.(t.A)))
+Base.rot180(t::InfinitePEPS) = InfinitePEPS(rot180(rot180.(t.A)))
+
+# Chain rules
 function ChainRulesCore.rrule(
     ::typeof(Base.getindex), state::InfinitePEPS, row::Int, col::Int
 )

--- a/src/utility/symmetrization.jl
+++ b/src/utility/symmetrization.jl
@@ -60,22 +60,6 @@ function herm_height_inv(x::Union{PEPSTensor,PEPOTensor})
 end
 
 # rotation invariance
-Base.rotl90(t::PEPSTensor) = permute(t, ((1,), (3, 4, 5, 2)))
-Base.rotr90(t::PEPSTensor) = permute(t, ((1,), (5, 2, 3, 4)))
-Base.rot180(t::PEPSTensor) = permute(t, ((1,), (4, 5, 2, 3)))
-
-Base.rotl90(t::PEPOTensor) = permute(t, ((1, 2), (4, 5, 6, 3)))
-Base.rotr90(t::PEPOTensor) = permute(t, ((1, 2), (6, 3, 4, 5)))
-Base.rot180(t::PEPOTensor) = permute(t, ((1, 2), (5, 6, 3, 4)))
-
-Base.rotl90(t::InfinitePEPS) = InfinitePEPS(rotl90(rotl90.(t.A)))
-Base.rotr90(t::InfinitePEPS) = InfinitePEPS(rotr90(rotr90.(t.A)))
-Base.rot180(t::InfinitePEPS) = InfinitePEPS(rot180(rot180.(t.A)))
-
-Base.rotl90(T::InfinitePEPO) = InfinitePEPO(stack(rotl90, eachslice(T.A; dims=3)))
-Base.rotr90(T::InfinitePEPO) = InfinitePEPO(stack(rotr90, eachslice(T.A; dims=3)))
-Base.rot180(T::InfinitePEPO) = InfinitePEPO(stack(rot180, eachslice(T.A; dims=3)))
-
 function rot_inv(x)
     return 0.25 * (
         x +


### PR DESCRIPTION
This PR will implement a more consistent (or at least human-understandable) index convention for labeling PEPS and environment tensors in a unit cell. To that end, we will follow the convention of [Bruognolo et al.](https://scipost.org/submissions/2006.08289v3/):

![image](https://github.com/QuantumKitHub/PEPSKit.jl/assets/62562093/58c6184b-b6b5-44c8-ab2d-a9740712f305)

However, I won't use `y` and `x` to label the rows and columns. Instead I find it more helpful to use `r` and `c`, respectively, since the indexing convention is that of a matrix and not that of Cartesian coordinates. Especially when dereferencing arrays, e.g. `env.corners[NORTHWEST, y, x]`, feels annoying to me.

To test for correctness, I will add a small PEPS optimization example for the Heisenberg Hamiltonian with a 2x2 unit cell ansatz. Since I'm anyway relabeling many indices, I will replace the NCON numbers with symbols that are actually descriptive, e.g. `Dnorth`, `chiwest`, and so on.