### PR TITLE
Add `MPSKit.correlation_length` method for PEPS

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -71,7 +71,7 @@ module Defaults
 end
 
 export SVDAdjoint, IterSVD, NonTruncSVDAdjoint
-export FixedSpaceTruncation, ProjectorAlg, CTMRG, CTMRGEnv
+export FixedSpaceTruncation, ProjectorAlg, CTMRG, CTMRGEnv, correlation_length
 export LocalOperator
 export expectation_value, costfun
 export leading_boundary


### PR DESCRIPTION
This PR will add a method to compute correlation lengths of a PEPS unit cell with an CTMRG environment. To that end we're gonna extend the `MPSKit.correlation_length` function and use the MPSKit glue machinery.