### PR TITLE
Fix virtual space error for larger unit cells

### DIFF
--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -273,7 +273,7 @@ Apply bottom projector to southwest corner and south edge.
 function renormalize_bottom_corner((row, col), envs::CTMRGEnv, projectors)
     C_southwest = envs.corners[SOUTHWEST, row, _prev(col, end)]
     E_south = envs.edges[SOUTH, row, col]
-    P_bottom = projectors[1][_prev(row, end), col]
+    P_bottom = projectors[1][row, col]
     return @autoopt @tensor corner[χ_in; χ_out] :=
         E_south[χ_in D1 D2; χ1] * C_southwest[χ1; χ2] * P_bottom[χ2 D1 D2; χ_out]
 end
@@ -292,7 +292,7 @@ Apply top projector to northwest corner and north edge.
 function renormalize_top_corner((row, col), envs::CTMRGEnv, projectors)
     C_northwest = envs.corners[NORTHWEST, row, _prev(col, end)]
     E_north = envs.edges[NORTH, row, col]
-    P_top = projectors[2][row, col]
+    P_top = projectors[2][_next(row, end), col]
     return @autoopt @tensor corner[χ_in; χ_out] :=
         P_top[χ_in; χ1 D1 D2] * C_northwest[χ1; χ2] * E_north[χ2 D1 D2; χ_out]
 end

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -448,8 +448,8 @@ function renormalize_west_edge(  # For sequential CTMRG scheme
 )
     return renormalize_west_edge(
         envs.edges[WEST, row, _prev(col, end)],
-        projectors[1][_prev(row, end), col],
-        projectors[2][row, col],
+        projectors[1][row, col],
+        projectors[2][_next(row, end), col],
         ket[row, col],
         bra[row, col],
     )

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -251,7 +251,7 @@ function ctmrg_projectors(
         r′ = _next(r, size(envs.corners, 2))
         QQ = halfinfinite_environment(enlarged_envs[1][r′, c], enlarged_envs[2][r, c])
 
-        trscheme = truncation_scheme(projector_alg, envs.edges[WEST, r, c])
+        trscheme = truncation_scheme(projector_alg, envs.edges[WEST, _prev(r, end), c])
         svd_alg = svd_algorithm(projector_alg, (WEST, r, c))
         U, S, V, ϵ_local = PEPSKit.tsvd!(QQ, svd_alg; trunc=trscheme)
         ϵ = max(ϵ, ϵ_local / norm(S))
@@ -301,7 +301,7 @@ function ctmrg_projectors(
             enlarged_envs[dir, r, c], enlarged_envs[_next(dir, 4), next_rc...]
         )
 
-        trscheme = truncation_scheme(projector_alg, envs.edges[dir, r, c])
+        trscheme = truncation_scheme(projector_alg, envs.edges[dir, next_rc...])
         svd_alg = svd_algorithm(projector_alg, (dir, r, c))
         U_local, S_local, V_local, ϵ_local = PEPSKit.tsvd!(QQ, svd_alg; trunc=trscheme)
         U[dir, r, c] = U_local

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -360,22 +360,6 @@ function ctmrg_renormalize(projectors, state, envs, ::SequentialCTMRG)
 
     return CTMRGEnv(copy(corners), copy(edges))
 end
-# Apply projectors to entire left half-environment to grow SW & NW corners, and W edge
-function grow_env_left(
-    peps, P_bottom, P_top, corners_SW, corners_NW, edge_S, edge_W, edge_N
-)
-    @autoopt @tensor corner_SW′[χ_E; χ_N] :=
-        corners_SW[χ1; χ2] * edge_S[χ_E D1 D2; χ1] * P_bottom[χ2 D1 D2; χ_N]
-    @autoopt @tensor corner_NW′[χ_S; χ_E] :=
-        corners_NW[χ1; χ2] * edge_N[χ2 D1 D2; χ_E] * P_top[χ_S; χ1 D1 D2]
-    @autoopt @tensor edge_W′[χ_S D_Eabove D_Ebelow; χ_N] :=
-        edge_W[χ1 D1 D2; χ2] *
-        peps[d; D3 D_Eabove D5 D1] *
-        conj(peps[d; D4 D_Ebelow D6 D2]) *
-        P_bottom[χ2 D3 D4; χ_N] *
-        P_top[χ_S; χ1 D5 D6]
-    return corner_SW′, corner_NW′, edge_W′
-end
 function ctmrg_renormalize(enlarged_envs, projectors, state, envs, ::SimultaneousCTMRG)
     corners = Zygote.Buffer(envs.corners)
     edges = Zygote.Buffer(envs.edges)

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -237,10 +237,10 @@ function ctmrg_projectors(
     # @fwdthreads for (r, c) in directions
     for (r, c) in directions
         # SVD half-infinite environment
-        r′ = _next(r, size(envs.corners, 2))
-        QQ = halfinfinite_environment(enlarged_envs[1][r′, c], enlarged_envs[2][r, c])
+        r′ = _prev(r, size(envs.corners, 2))
+        QQ = halfinfinite_environment(enlarged_envs[1][r, c], enlarged_envs[2][r′, c])
 
-        trscheme = truncation_scheme(projector_alg, envs.edges[WEST, _prev(r, end), c])
+        trscheme = truncation_scheme(projector_alg, envs.edges[WEST, r′, c])
         svd_alg = svd_algorithm(projector_alg, (WEST, r, c))
         U, S, V, ϵ_local = PEPSKit.tsvd!(QQ, svd_alg; trunc=trscheme)
         ϵ = max(ϵ, ϵ_local / norm(S))
@@ -255,7 +255,7 @@ function ctmrg_projectors(
 
         # Compute projectors
         P_bottom[r, c], P_top[r, c] = build_projectors(
-            U, S, V, enlarged_envs[1][r′, c], enlarged_envs[2][r, c]
+            U, S, V, enlarged_envs[1][r, c], enlarged_envs[2][r′, c]
         )
     end
 

--- a/test/ctmrg/ctmrgschemes.jl
+++ b/test/ctmrg/ctmrgschemes.jl
@@ -53,7 +53,9 @@ end
 
 # test fixedspace actually fixes space
 @testset "Fixedspace truncation ($scheme)" for scheme in [:sequential, :simultaneous]
-    ctm_alg = CTMRG(; tol=1e-6, maxiter=1, verbosity=0, ctmrgscheme=scheme)
+    ctm_alg = CTMRG(;
+        tol=1e-6, maxiter=1, verbosity=0, ctmrgscheme=scheme, trscheme=FixedSpace()
+    )
     Ds = fill(2, 3, 3)
     χs = [16 17 18; 15 20 21; 14 19 22]
     psi = InfinitePEPS(Ds, Ds, Ds)
@@ -61,8 +63,6 @@ end
     env2 = leading_boundary(env, psi, ctm_alg)
 
     # check that the space is fixed
-    display(dim.(space.(env.corners[NORTH, :, :], 1)))
-    display(dim.(space.(env2.corners[NORTH, :, :], 1)))
     @test all(space.(env.corners) .== space.(env2.corners))
     @test all(space.(env.edges) .== space.(env2.edges))
 end

--- a/test/ctmrg/ctmrgschemes.jl
+++ b/test/ctmrg/ctmrgschemes.jl
@@ -50,3 +50,19 @@ unitcells = [(1, 1), (3, 4)]
     E_simultaneous = costfun(psi, env_simultaneous, H)
     @test E_sequential ≈ E_simultaneous rtol = 1e-4
 end
+
+# test fixedspace actually fixes space
+@testset "Fixedspace truncation ($scheme)" for scheme in [:sequential, :simultaneous]
+    ctm_alg = CTMRG(; tol=1e-6, maxiter=1, verbosity=0, ctmrgscheme=scheme)
+    Ds = fill(2, 3, 3)
+    χs = [16 17 18; 15 20 21; 14 19 22]
+    psi = InfinitePEPS(Ds, Ds, Ds)
+    env = CTMRGEnv(psi, rand(10:20, 3, 3), rand(10:20, 3, 3))
+    env2 = leading_boundary(env, psi, ctm_alg)
+
+    # check that the space is fixed
+    display(dim.(space.(env.corners[NORTH, :, :], 1)))
+    display(dim.(space.(env2.corners[NORTH, :, :], 1)))
+    @test all(space.(env.corners) .== space.(env2.corners))
+    @test all(space.(env.edges) .== space.(env2.edges))
+end

--- a/test/ctmrg/ctmrgschemes.jl
+++ b/test/ctmrg/ctmrgschemes.jl
@@ -54,7 +54,11 @@ end
 # test fixedspace actually fixes space
 @testset "Fixedspace truncation ($scheme)" for scheme in [:sequential, :simultaneous]
     ctm_alg = CTMRG(;
-        tol=1e-6, maxiter=1, verbosity=0, ctmrgscheme=scheme, trscheme=FixedSpace()
+        tol=1e-6,
+        maxiter=1,
+        verbosity=0,
+        ctmrgscheme=scheme,
+        trscheme=FixedSpaceTruncation(),
     )
     Ds = fill(2, 3, 3)
     χs = [16 17 18; 15 20 21; 14 19 22]


### PR DESCRIPTION
There was an error in the fixedspace truncation which cycled the spaces around, thus leading to errors in the gaugefixing.
This should now be resolved.

Additionally, I removed the gaugefixing procedure from the regular CTMRG calls, as the gaugefixing is repeated in the gradient rules anyways.

I tried to make both schemes of CTMRG use the same indexing convention for the projectors too now, this was an absolute mess so let's try and keep our coordinates the same now :laughing: 