### PR TITLE
Clean up symmetrization and add optimization callback

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -87,6 +87,7 @@ export InfinitePEPO, InfiniteTransferPEPO
 export initializeMPS, initializePEPS
 export symmetrize, None, Depth, Full
 export showtypeofgrad
-export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_pwave
+export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_j1j2
+export square_lattice_pwave
 
 end # module

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -85,7 +85,7 @@ export fixedpoint
 export InfinitePEPS, InfiniteTransferPEPS
 export InfinitePEPO, InfiniteTransferPEPO
 export initializeMPS, initializePEPS
-export symmetrize, None, Depth, Full
+export symmetrize!, ReflectDepth, ReflectWidth, RotateReflect, symmetrize_callback
 export showtypeofgrad
 export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_j1j2
 export square_lattice_pwave

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -85,7 +85,7 @@ export fixedpoint
 export InfinitePEPS, InfiniteTransferPEPS
 export InfinitePEPO, InfiniteTransferPEPO
 export initializeMPS, initializePEPS
-export symmetrize!, ReflectDepth, ReflectWidth, RotateReflect, symmetrize_callback
+export ReflectDepth, ReflectWidth, RotateReflect, symmetrize!, symmetrize_callback
 export showtypeofgrad
 export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_j1j2
 export square_lattice_pwave

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -85,7 +85,7 @@ export fixedpoint
 export InfinitePEPS, InfiniteTransferPEPS
 export InfinitePEPO, InfiniteTransferPEPO
 export initializeMPS, initializePEPS
-export ReflectDepth, ReflectWidth, RotateReflect, symmetrize!, symmetrize_finalize
+export ReflectDepth, ReflectWidth, RotateReflect, symmetrize!, symmetrize_finalize!
 export showtypeofgrad
 export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_j1j2
 export square_lattice_pwave

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -85,7 +85,7 @@ export fixedpoint
 export InfinitePEPS, InfiniteTransferPEPS
 export InfinitePEPO, InfiniteTransferPEPO
 export initializeMPS, initializePEPS
-export ReflectDepth, ReflectWidth, RotateReflect, symmetrize!, symmetrize_callback
+export ReflectDepth, ReflectWidth, RotateReflect, symmetrize!, symmetrize_finalize
 export showtypeofgrad
 export square_lattice_tf_ising, square_lattice_heisenberg, square_lattice_j1j2
 export square_lattice_pwave

--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -121,11 +121,15 @@ function PEPSOptimize(;
 end
 
 """
-    fixedpoint(ψ₀::InfinitePEPS{T}, H, alg::PEPSOptimize, [env₀::CTMRGEnv]; callback=identity) where {T}
+    fixedpoint(ψ₀::InfinitePEPS{T}, H, alg::PEPSOptimize, [env₀::CTMRGEnv];
+               callback=(args...) -> identity(args)) where {T}
     
 Optimize `ψ₀` with respect to the Hamiltonian `H` according to the parameters supplied
 in `alg`. The initial environment `env₀` serves as an initial guess for the first CTMRG run.
 By default, a random initial environment is used.
+
+The `callback` kwarg can be used to insert a function call after each optimization step
+which maps `peps, envs, E, grad = callback(peps, envs, E, grad)`.
 
 The function returns a `NamedTuple` which contains the following entries:
 - `peps`: final `InfinitePEPS`

--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -122,14 +122,14 @@ end
 
 """
     fixedpoint(ψ₀::InfinitePEPS{T}, H, alg::PEPSOptimize, [env₀::CTMRGEnv];
-               callback=(args...) -> identity(args)) where {T}
+               finalize=(args...) -> identity(args)) where {T}
     
 Optimize `ψ₀` with respect to the Hamiltonian `H` according to the parameters supplied
 in `alg`. The initial environment `env₀` serves as an initial guess for the first CTMRG run.
 By default, a random initial environment is used.
 
-The `callback` kwarg can be used to insert a function call after each optimization step
-which maps `peps, envs, E, grad = callback(peps, envs, E, grad)`.
+The `finalize` kwarg can be used to insert a function call after each optimization step
+which maps `peps, envs, E, grad = finalize(peps, envs, E, grad)`.
 
 The function returns a `NamedTuple` which contains the following entries:
 - `peps`: final `InfinitePEPS`
@@ -145,7 +145,7 @@ function fixedpoint(
     H,
     alg::PEPSOptimize,
     env₀::CTMRGEnv=CTMRGEnv(ψ₀, field(T)^20);
-    callback=(args...) -> identity(args),
+    finalize=(args...) -> identity(args),
 ) where {T}
     (peps, env), E, ∂E, numfg, convhistory = optimize(
         (ψ₀, env₀), alg.optimizer; retract=my_retract, inner=my_inner
@@ -164,7 +164,7 @@ function fixedpoint(
             return costfun(ψ, envs´, H)
         end
         g = only(g)  # withgradient returns tuple of gradients `g`
-        peps, envs, E, g = callback(peps, envs, E, g)
+        peps, envs, E, g = finalize(peps, envs, E, g)
         return E, g
     end
     return (;

--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -151,7 +151,7 @@ function fixedpoint(
     (peps, env), E, ∂E, numfg, convhistory = optimize(
         (ψ₀, env₀), alg.optimizer; retract=my_retract, inner=my_inner, finalize!
     ) do (peps, envs)
-        E, g = withgradient(peps) do ψ
+        E, gs = withgradient(peps) do ψ
             envs´ = hook_pullback(
                 leading_boundary,
                 envs,
@@ -164,7 +164,7 @@ function fixedpoint(
             end
             return costfun(ψ, envs´, H)
         end
-        g = only(g)  # withgradient returns tuple of gradients `g`
+        g = only(gs)  # `withgradient` returns tuple of gradients `gs`
         return E, g
     end
     return (;

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -133,6 +133,18 @@ Base.:*(α::Number, ψ::InfinitePEPS) = InfinitePEPS(α * ψ.A)
 LinearAlgebra.dot(ψ₁::InfinitePEPS, ψ₂::InfinitePEPS) = dot(ψ₁.A, ψ₂.A)
 LinearAlgebra.norm(ψ::InfinitePEPS) = norm(ψ.A)
 
+## (Approximate) equality
+function Base.:(==)(ψ₁::InfinitePEPS, ψ₂::InfinitePEPS)
+    return all(zip(ψ₁.A, ψ₂.A)) do (p₁, p₂)
+        return p₁ == p₂
+    end
+end
+function Base.isapprox(ψ₁::InfinitePEPS, ψ₂::InfinitePEPS; kwargs...)
+    return all(zip(ψ₁.A, ψ₂.A)) do (p₁, p₂)
+        return isapprox(p₁, p₂; kwargs...)
+    end
+end
+
 # Used in _scale during OptimKit.optimize
 function LinearAlgebra.rmul!(ψ::InfinitePEPS, α::Number)
     rmul!(ψ.A, α)

--- a/src/utility/symmetrization.jl
+++ b/src/utility/symmetrization.jl
@@ -64,6 +64,7 @@ function _fit_spaces(
     end
     return y
 end
+_fit_spaces(y::InfinitePEPS, x::InfinitePEPS) = InfinitePEPS(map(_fit_spaces, y.A, x.A))
 
 function herm_depth_inv(x::Union{PEPSTensor,PEPOTensor})
     return 0.5 * (x + _fit_spaces(herm_depth(x), x))

--- a/src/utility/symmetrization.jl
+++ b/src/utility/symmetrization.jl
@@ -208,12 +208,15 @@ function symmetrize!(peps::InfinitePEPS, symm::RotateReflect)
 end
 
 """
-    symmetrize_finalize(peps, envs, E, grad, symm::SymmetrizationStyle)
+    symmetrize_finalize!(symm::SymmetrizationStyle)
 
-Callback function symmetrizing both the `peps` and `grad` tensors.
+Return `finalize!` function for symmetrizing the `peps` and `grad` tensors in-place,
+which maps `(peps_symm, envs), E, grad_symm = symmetrize_finalize!((peps, envs), E, grad, numiter)`.
 """
-function symmetrize_finalize(peps, envs, E, grad, symm::SymmetrizationStyle)
-    peps_symm = symmetrize!(deepcopy(peps), symm)
-    grad_symm = symmetrize!(deepcopy(grad), symm)
-    return peps_symm, envs, E, grad_symm
+function symmetrize_finalize!(symm::SymmetrizationStyle)
+    function symmetrize_finalize!((peps, envs), E, grad, _)
+        peps_symm = symmetrize!(peps, symm)
+        grad_symm = symmetrize!(grad, symm)
+        return (peps_symm, envs), E, grad_symm
+    end
 end

--- a/src/utility/symmetrization.jl
+++ b/src/utility/symmetrization.jl
@@ -208,11 +208,11 @@ function symmetrize!(peps::InfinitePEPS, symm::RotateReflect)
 end
 
 """
-    symmetrize_callback(peps, envs, E, grad, symm::SymmetrizationStyle)
+    symmetrize_finalize(peps, envs, E, grad, symm::SymmetrizationStyle)
 
 Callback function symmetrizing both the `peps` and `grad` tensors.
 """
-function symmetrize_callback(peps, envs, E, grad, symm::SymmetrizationStyle)
+function symmetrize_finalize(peps, envs, E, grad, symm::SymmetrizationStyle)
     peps_symm = symmetrize!(deepcopy(peps), symm)
     grad_symm = symmetrize!(deepcopy(grad), symm)
     return peps_symm, envs, E, grad_symm

--- a/src/utility/symmetrization.jl
+++ b/src/utility/symmetrization.jl
@@ -169,7 +169,6 @@ function symmetrize!(peps::InfinitePEPS, symm::RotateReflect)
                 peps[depth - d + 1, width - w + 1] = _fit_spaces(
                     herm_depth(rotr90(peps[d, w])), peps[depth - d + 1, width - w + 1]
                 )
-
             elseif odd == 1 && d == ceil(Int, depth / 2)
                 peps[d, w] = symmetrize_mid_depth(peps[d, w])
                 peps[w, d] = _fit_spaces(rotr90(peps[d, w]), peps[w, d])
@@ -179,7 +178,6 @@ function symmetrize!(peps::InfinitePEPS, symm::RotateReflect)
                 peps[width - w + 1, d] = _fit_spaces(
                     herm_depth(rotr90(peps[d, w])), peps[width - w + 1, d]
                 )
-
             else
                 peps[depth - d + 1, w] = _fit_spaces(
                     herm_depth(peps[d, w]), peps[depth - d + 1, w]

--- a/test/ctmrg/gaugefix.jl
+++ b/test/ctmrg/gaugefix.jl
@@ -12,16 +12,16 @@ schemes = [:simultaneous, :sequential]
 atol = 1e-4
 verbosity = 2
 
-function _make_symmetric(psi)
+function _make_symmetric!(psi)
     if ==(size(psi)...)
-        return PEPSKit.symmetrize(psi, PEPSKit.Full())
+        return symmetrize!(psi, RotateReflect())
     else
-        return PEPSKit.symmetrize(PEPSKit.symmetrize(psi, PEPSKit.Depth()), PEPSKit.Width())
+        return symmetrize!(symmetrize!(psi, ReflectDepth()), ReflectWidth())
     end
 end
 
 # If I can't make the rng seed behave, I'll just randomly define a peps somehow
-function semi_random_peps!(psi::InfinitePEPS)
+function _semi_random_peps!(psi::InfinitePEPS)
     i = 0
     A′ = map(psi.A) do a
         for (_, b) in blocks(a)
@@ -44,8 +44,8 @@ end
     ctm_space = ComplexSpace(χ)
 
     psi = InfinitePEPS(undef, T, physical_space, peps_space; unitcell)
-    semi_random_peps!(psi)
-    psi = _make_symmetric(psi)
+    _semi_random_peps!(psi)
+    _make_symmetric!(psi)
 
     Random.seed!(987654321)  # Seed RNG to make random environment consistent
     ctm = CTMRGEnv(psi, ctm_space)
@@ -69,8 +69,8 @@ end
     ctm_space = Z2Space(0 => χ ÷ 2, 1 => χ ÷ 2)
 
     psi = InfinitePEPS(undef, T, physical_space, peps_space; unitcell)
-    semi_random_peps!(psi)
-    psi = _make_symmetric(psi)
+    _semi_random_peps!(psi)
+    _make_symmetric!(psi)
 
     Random.seed!(987654321)  # Seed RNG to make random environment consistent
     psi = InfinitePEPS(physical_space, peps_space; unitcell)

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -3,13 +3,6 @@ using PEPSKit
 using PEPSKit: herm_depth, herm_width, _fit_spaces
 using TensorKit
 
-function PEPSKit._fit_spaces(data_peps::InfinitePEPS, space_peps::InfinitePEPS)
-    fitted_tensors = map(zip(data_peps.A, space_peps.A)) do (pd, ps)
-        PEPSKit._fit_spaces(pd, ps)
-    end
-    return InfinitePEPS(fitted_tensors)
-end
-
 @testset "RotateReflect" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -1,0 +1,46 @@
+using Test
+using PEPSKit
+using TensorKit
+
+function _test_elementwise_equal(peps1::InfinitePEPS, peps2::InfinitePEPS)
+    return @test all(zip(peps1.A, peps2.A)) do (p1, p2)
+        p1.data == p2.data
+    end
+end
+
+@testset "RotateReflect" for unitcell in [(1, 1), (2, 2), (3, 3)]
+    peps = InfinitePEPS(2, 2; unitcell)
+
+    peps_rotatereflect = symmetrize!(deepcopy(peps), RotateReflect())
+    _test_elementwise_equal(peps_full, rotl90(peps_full))
+    _test_elementwise_equal(peps_full, rot180(peps_full))
+    _test_elementwise_equal(peps_full, rotr90(peps_full))
+    _test_elementwise_equal(
+        peps_full,
+        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_depth, peps_full.A); dims=1)),
+    )
+    _test_elementwise_equal(
+        peps_full,
+        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_width, peps_full.A); dims=2)),
+    )
+end
+
+@testset "ReflectDepth" for unitcell in [(1, 1), (2, 2), (3, 3)]
+    peps = InfinitePEPS(2, 2; unitcell)
+
+    peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
+    _test_elementwise_equal(
+        peps_full,
+        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_depth, peps_full.A); dims=1)),
+    )
+end
+
+@testset "ReflectWidth" for unitcell in [(1, 1), (2, 2), (3, 3)]
+    peps = InfinitePEPS(2, 2; unitcell)
+
+    peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
+    _test_elementwise_equal(
+        peps_full,
+        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_width, peps_full.A); dims=2)),
+    )
+end

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -12,7 +12,7 @@ end
 @testset "RotateReflect" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
-    peps_rotatereflect = symmetrize!(deepcopy(peps), RotateReflect())
+    peps_full = symmetrize!(deepcopy(peps), RotateReflect())
     _test_elementwise_equal(peps_full, rotl90(peps_full))
     _test_elementwise_equal(peps_full, rot180(peps_full))
     _test_elementwise_equal(peps_full, rotr90(peps_full))

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -27,17 +27,17 @@ end
 @testset "ReflectDepth" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
-    peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
+    peps_depth = symmetrize!(deepcopy(peps), ReflectDepth())
     _test_elementwise_equal(
-        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_full.A); dims=1))
+        peps_depth, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_depth.A); dims=1))
     )
 end
 
 @testset "ReflectWidth" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
-    peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
+    peps_width = symmetrize!(deepcopy(peps), ReflectWidth())
     _test_elementwise_equal(
-        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_full.A); dims=2))
+        peps_width, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_width.A); dims=2))
     )
 end

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -1,43 +1,50 @@
 using Test
 using PEPSKit
-using PEPSKit: herm_depth, herm_width
+using PEPSKit: herm_depth, herm_width, _fit_spaces
 using TensorKit
 
-function _test_elementwise_equal(peps1::InfinitePEPS, peps2::InfinitePEPS)
-    return @test all(zip(peps1.A, peps2.A)) do (p1, p2)
-        p1.data == p2.data
+function PEPSKit._fit_spaces(data_peps::InfinitePEPS, space_peps::InfinitePEPS)
+    fitted_tensors = map(zip(data_peps.A, space_peps.A)) do (pd, ps)
+        PEPSKit._fit_spaces(pd, ps)
     end
+    return InfinitePEPS(fitted_tensors)
 end
 
 @testset "RotateReflect" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
     peps_full = symmetrize!(deepcopy(peps), RotateReflect())
-    _test_elementwise_equal(peps_full, rotl90(peps_full))
-    _test_elementwise_equal(peps_full, rot180(peps_full))
-    _test_elementwise_equal(peps_full, rotr90(peps_full))
-    _test_elementwise_equal(
-        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_full.A); dims=1))
+    @test peps_full ≈ _fit_spaces(rotl90(peps_full), peps_full)
+    @test peps_full ≈ _fit_spaces(rot180(peps_full), peps_full)
+    @test peps_full ≈ _fit_spaces(rotr90(peps_full), peps_full)
+
+    peps_reflect_depth = _fit_spaces(
+        InfinitePEPS(reverse(map(herm_depth, peps_full.A); dims=1)), peps_full
     )
-    _test_elementwise_equal(
-        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_full.A); dims=2))
+    @test peps_full ≈ peps_reflect_depth
+
+    peps_reflect_width = _fit_spaces(
+        InfinitePEPS(reverse(map(herm_width, peps_full.A); dims=2)), peps_full
     )
+    @test peps_full ≈ peps_reflect_width
 end
 
 @testset "ReflectDepth" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
     peps_depth = symmetrize!(deepcopy(peps), ReflectDepth())
-    _test_elementwise_equal(
-        peps_depth, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_depth.A); dims=1))
+    peps_reflect = _fit_spaces(
+        InfinitePEPS(reverse(map(herm_depth, peps_depth.A); dims=1)), peps_depth
     )
+    @test peps_depth ≈ peps_reflect
 end
 
 @testset "ReflectWidth" for unitcell in [(1, 1), (2, 2), (3, 3)]
     peps = InfinitePEPS(2, 2; unitcell)
 
     peps_width = symmetrize!(deepcopy(peps), ReflectWidth())
-    _test_elementwise_equal(
-        peps_width, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_width.A); dims=2))
+    peps_reflect = _fit_spaces(
+        InfinitePEPS(reverse(map(herm_width, peps_width.A); dims=2)), peps_width
     )
+    @test peps_width ≈ peps_reflect
 end

--- a/test/ctmrg/symmetrization.jl
+++ b/test/ctmrg/symmetrization.jl
@@ -1,5 +1,6 @@
 using Test
 using PEPSKit
+using PEPSKit: herm_depth, herm_width
 using TensorKit
 
 function _test_elementwise_equal(peps1::InfinitePEPS, peps2::InfinitePEPS)
@@ -16,12 +17,10 @@ end
     _test_elementwise_equal(peps_full, rot180(peps_full))
     _test_elementwise_equal(peps_full, rotr90(peps_full))
     _test_elementwise_equal(
-        peps_full,
-        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_depth, peps_full.A); dims=1)),
+        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_full.A); dims=1))
     )
     _test_elementwise_equal(
-        peps_full,
-        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_width, peps_full.A); dims=2)),
+        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_full.A); dims=2))
     )
 end
 
@@ -30,8 +29,7 @@ end
 
     peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
     _test_elementwise_equal(
-        peps_full,
-        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_depth, peps_full.A); dims=1)),
+        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_depth, peps_full.A); dims=1))
     )
 end
 
@@ -40,7 +38,6 @@ end
 
     peps_reflectdepth = symmetrize!(deepcopy(peps), ReflectDepth())
     _test_elementwise_equal(
-        peps_full,
-        InfinitePEPS(reverse(map(copy ∘ PEPSKit.herm_width, peps_full.A); dims=2)),
+        peps_full, InfinitePEPS(reverse(map(copy ∘ herm_width, peps_full.A); dims=2))
     )
 end

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -7,7 +7,7 @@ using OptimKit
 
 # initialize parameters
 χbond = 2
-χenv = 16
+χenv = 32
 ctm_alg = CTMRG(;
     tol=1e-10,
     miniter=4,
@@ -25,7 +25,7 @@ opt_alg = PEPSOptimize(;
 
 # initialize states
 Random.seed!(91283219347)
-H = square_lattice_heisenberg()
+H = square_lattice_j1j2(; J2=0.25)
 psi_init = InfinitePEPS(2, χbond)
 env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg)
 
@@ -33,17 +33,5 @@ env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, c
 result = fixedpoint(psi_init, H, opt_alg, env_init)
 ξ_h, ξ_v, = correlation_length(result.peps, result.env)
 
-@test result.E ≈ -0.6694421 atol = 1e-2
+@test result.E ≈ -0.5618837021945925 atol = 1e-3
 @test all(@. ξ_h > 0 && ξ_v > 0)
-
-# same test but for 1x2 unit cell
-H_1x2 = square_lattice_heisenberg(; unitcell=(1, 2))
-psi_init_1x2 = InfinitePEPS(2, χbond; unitcell=(1, 2))
-env_init_1x2 = leading_boundary(
-    CTMRGEnv(psi_init_1x2, ComplexSpace(χenv)), psi_init_1x2, ctm_alg
-)
-result_1x2 = fixedpoint(psi_init_1x2, H_1x2, opt_alg, env_init_1x2)
-ξ_h_1x2, ξ_v_1x2, = correlation_length(result_1x2.peps, result_1x2.env)
-
-@test result_1x2.E ≈ 2 * result.E atol = 1e-2
-@test all(@. ξ_h_1x2 > 0 && ξ_v_1x2 > 0)

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -31,8 +31,8 @@ psi_init = PEPSKit.symmetrize!(psi_init, PEPSKit.RotateReflect())
 env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg);
 
 # find fixedpoint
-callback = (args...) -> PEPSKit.symmetrize_callback(args..., RotateReflect())
-result = fixedpoint(psi_init, H, opt_alg, env_init; callback)
+finalize = (args...) -> PEPSKit.symmetrize_finalize(args..., RotateReflect())
+result = fixedpoint(psi_init, H, opt_alg, env_init; finalize)
 ξ_h, ξ_v, = correlation_length(result.peps, result.env)
 
 # compare against Juraj Hasik's data:

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -27,16 +27,13 @@ opt_alg = PEPSOptimize(;
 Random.seed!(91283219347)
 H = square_lattice_j1j2(; J2=0.25)
 psi_init = InfinitePEPS(2, χbond)
-psi_init = PEPSKit.symmetrize!(psi_init, PEPSKit.Full())
-env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg)
+psi_init = PEPSKit.symmetrize!(psi_init, PEPSKit.RotateReflect())
+env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg);
 
 # find fixedpoint
-cb = (args...) -> PEPSKit.symmetrize_callback(args..., RotateReflect())
-result = fixedpoint(psi_init, H, opt_alg, env_init)#; callback=cb)
+callback = (args...) -> PEPSKit.symmetrize_callback(args..., RotateReflect())
+result = fixedpoint(psi_init, H, opt_alg, env_init; callback)
 ξ_h, ξ_v, = correlation_length(result.peps, result.env)
-
-p = symmetrize!(deepcopy(result.peps), RotateReflect())
-ξ_h, ξ_v, = correlation_length(p, leading_boundary(result.env, p, ctm_alg))
 
 # compare against Juraj Hasik's data:
 # https://github.com/jurajHasik/j1j2_ipeps_states/blob/main/single-site_pg-C4v-A1/j20.25/state_1s_A1_j20.25_D2_chi_opt48.dat

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -27,12 +27,12 @@ opt_alg = PEPSOptimize(;
 Random.seed!(91283219347)
 H = square_lattice_j1j2(; J2=0.25)
 psi_init = InfinitePEPS(2, χbond)
-psi_init = PEPSKit.symmetrize!(psi_init, PEPSKit.RotateReflect())
+psi_init = symmetrize!(psi_init, RotateReflect())
 env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg);
 
 # find fixedpoint
-finalize = (args...) -> PEPSKit.symmetrize_finalize(args..., RotateReflect())
-result = fixedpoint(psi_init, H, opt_alg, env_init; finalize)
+finalize! = symmetrize_finalize!(RotateReflect())
+result = fixedpoint(psi_init, H, opt_alg, env_init; finalize!)
 ξ_h, ξ_v, = correlation_length(result.peps, result.env)
 
 # compare against Juraj Hasik's data:

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -7,7 +7,7 @@ using OptimKit
 
 # initialize parameters
 χbond = 2
-χenv = 32
+χenv = 16
 ctm_alg = CTMRG(;
     tol=1e-10,
     miniter=4,
@@ -19,7 +19,7 @@ ctm_alg = CTMRG(;
 opt_alg = PEPSOptimize(;
     boundary_alg=ctm_alg,
     optimizer=LBFGS(4; maxiter=100, gradtol=1e-3, verbosity=2),
-    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-6), iterscheme=:fixed),
+    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-6), iterscheme=:diffgauge),
     reuse_env=true,
 )
 
@@ -27,11 +27,19 @@ opt_alg = PEPSOptimize(;
 Random.seed!(91283219347)
 H = square_lattice_j1j2(; J2=0.25)
 psi_init = InfinitePEPS(2, χbond)
+psi_init = PEPSKit.symmetrize!(psi_init, PEPSKit.Full())
 env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg)
 
 # find fixedpoint
-result = fixedpoint(psi_init, H, opt_alg, env_init)
+cb = (args...) -> PEPSKit.symmetrize_callback(args..., RotateReflect())
+result = fixedpoint(psi_init, H, opt_alg, env_init)#; callback=cb)
 ξ_h, ξ_v, = correlation_length(result.peps, result.env)
 
+p = symmetrize!(deepcopy(result.peps), RotateReflect())
+ξ_h, ξ_v, = correlation_length(p, leading_boundary(result.env, p, ctm_alg))
+
+# compare against Juraj Hasik's data:
+# https://github.com/jurajHasik/j1j2_ipeps_states/blob/main/single-site_pg-C4v-A1/j20.25/state_1s_A1_j20.25_D2_chi_opt48.dat
+ξ_ref = -1 / log(0.2723596743547324)
 @test result.E ≈ -0.5618837021945925 atol = 1e-3
-@test all(@. ξ_h > 0 && ξ_v > 0)
+@test all(@. isapprox(ξ_h, ξ_ref; atol=1e-1) && isapprox(ξ_v, ξ_ref; atol=1e-1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,9 @@ end
         @time @safetestset "Heisenberg model" begin
             include("heisenberg.jl")
         end
+        @time @safetestset "Heisenberg model" begin
+            include("j1j2_model.jl")
+        end
         @time @safetestset "P-wave superconductor" begin
             include("pwave.jl")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,9 @@ end
         @time @safetestset "CTMRG schemes" begin
             include("ctmrg/ctmrgschemes.jl")
         end
+        @time @safetestset "CTMRG schemes" begin
+            include("ctmrg/symmetrization.jl")
+        end
     end
     if GROUP == "ALL" || GROUP == "MPS"
         @time @safetestset "VUMPS" begin

--- a/test/tf_ising.jl
+++ b/test/tf_ising.jl
@@ -41,7 +41,7 @@ env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, c
 
 # find fixedpoint
 result = fixedpoint(psi_init, H, opt_alg, env_init)
-λ_h, λ_v, = correlation_length(result.peps, result.env)
+ξ_h, ξ_v, = correlation_length(result.peps, result.env)
 
 # compute magnetization
 σx = TensorMap(scalartype(psi_init)[0 1; 1 0], ℂ^2, ℂ^2)
@@ -55,6 +55,6 @@ magn = expectation_value(result.peps, M, result.env)
 # find fixedpoint in polarized phase and compute correlations lengths
 H_polar = square_lattice_tf_ising(; h=4.5)
 result_polar = fixedpoint(psi_init, H_polar, opt_alg, env_init)
-λ_h_polar, λ_v_polar, = correlation_length(result_polar.peps, result_polar.env)
-@test λ_h_polar < λ_h
-@test λ_v_polar < λ_v
+ξ_h_polar, ξ_v_polar, = correlation_length(result_polar.peps, result_polar.env)
+@test ξ_h_polar < ξ_h
+@test ξ_v_polar < ξ_v


### PR DESCRIPTION
This PR cleans up the symmetrization functionality a bit and adds a callback keyword argument for `fixedpoint` which allows to call a user-specified function after each optimization iteration. Also, I added the J1-J2 model Hamiltonian and a small test since I anyway had that code lying around.