### PR TITLE
Implement sparse SVD with function handles

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -36,8 +36,8 @@ include("environments/transferpepo_environments.jl")
 include("algorithms/contractions/localoperator.jl")
 include("algorithms/contractions/ctmrg_contractions.jl")
 
-include("algorithms/ctmrg/ctmrg.jl")
 include("algorithms/ctmrg/sparse_environments.jl")
+include("algorithms/ctmrg/ctmrg.jl")
 include("algorithms/ctmrg/gaugefix.jl")
 
 include("algorithms/toolbox.jl")

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -72,6 +72,7 @@ module Defaults
     const fpgrad_maxiter = 30
     const fpgrad_tol = 1e-6
     const ctmrgscheme = :simultaneous
+    const sparse_env = false
     const reuse_env = true
     const trscheme = FixedSpaceTruncation()
     const iterscheme = :fixed

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -37,6 +37,7 @@ include("algorithms/contractions/localoperator.jl")
 include("algorithms/contractions/ctmrg_contractions.jl")
 
 include("algorithms/ctmrg/ctmrg.jl")
+include("algorithms/ctmrg/sparse_environments.jl")
 include("algorithms/ctmrg/gaugefix.jl")
 
 include("algorithms/toolbox.jl")

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -72,7 +72,7 @@ module Defaults
     const fpgrad_maxiter = 30
     const fpgrad_tol = 1e-6
     const ctmrgscheme = :simultaneous
-    const sparse_env = false
+    const sparse = false
     const reuse_env = true
     const trscheme = FixedSpaceTruncation()
     const iterscheme = :fixed

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -290,7 +290,8 @@ end
 # corners
 
 """
-    renormalize_corner(quadrant, P_left, P_right)
+    renormalize_corner(quadrant::AbstractTensorMap{S,3,3}, P_left, P_right)
+    renormalize_corner(E_1, C, E_2, P_left, P_right, ket::PEPSTensor, bra::PEPSTensor=ket)
 
 Apply projectors to each side of a quadrant.
 
@@ -302,10 +303,33 @@ Apply projectors to each side of a quadrant.
     [P_right]
         |
 ```
+
+Alternatively, provide the constituent tensors and perform the complete contraction.
+
+```
+     C  --   E_2   -- |~~~~~~|
+     |        |       |P_left| --
+    E_1 == ket-bra == |~~~~~~|
+     |        ||
+    [~~P_right~~]
+         |
+```
 """
 function renormalize_corner(quadrant::AbstractTensorMap{S,3,3}, P_left, P_right) where {S}
     return @autoopt @tensor corner[χ_in; χ_out] :=
         P_right[χ_in; χ1 D1 D2] * quadrant[χ1 D1 D2; χ2 D3 D4] * P_left[χ2 D3 D4; χ_out]
+end
+function renormalize_corner(
+    E_1, C, E_2, P_left, P_right, ket::PEPSTensor, bra::PEPSTensor=ket
+)
+    return @autoopt @tensor corner[χ_in; χ_out] :=
+        P_right[χ_in; χ1 D1 D2] *
+        E_1[χ1 D3 D4; χ2] *
+        C[χ2; χ3] *
+        E_2[χ3 D5 D6; χ4] *
+        ket[d; D5 D7 D1 D3] *
+        conj(bra[d; D6 D8 D2 D4]) *
+        P_left[χ4 D7 D8; χ_out]
 end
 
 """

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -177,9 +177,9 @@ Contract the CTMRG left projector with the higher-dimensional subspace facing to
 """
 function left_projector(E_1, C, E_2, V, isqS, ket::PEPSTensor, bra::PEPSTensor=ket)
     return @autoopt @tensor P_left[χ_in D_inabove D_inbelow; χ_out] :=
-        E_1[χ_in D1 D2; χ1] * 
-        C[χ1; χ2] * 
-        E_2[χ2 D3 D4; χ3] * 
+        E_1[χ_in D1 D2; χ1] *
+        C[χ1; χ2] *
+        E_2[χ2 D3 D4; χ3] *
         ket[d; D3 D5 D_inabove D1] *
         conj(bra[d; D4 D6 D_inbelow D2]) *
         conj(V[χ4; χ3 D5 D6]) *
@@ -204,15 +204,14 @@ function right_projector(E_1, C, E_2, U, isqS, ket::PEPSTensor, bra::PEPSTensor=
         conj(U[χ1; χ2 D1 D2]) *
         ket[d; D1 D5 D_outabove D1] *
         conj(bra[d; D2 D6 D_outbelow D2]) *
-        E_2[χ2 D3 D4; χ3] * 
-        C[χ3; χ4] * 
+        E_2[χ2 D3 D4; χ3] *
+        C[χ3; χ4] *
         E_1[χ4 D5 D6; χ_out]
 end
 
-
 """
     halfinfinite_environment(quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3})
-    halfinfinite_environment(quadrant1::EnlargedCorner{A,C,E}, quadrant2::EnlargedCorner{A,C,E})
+    
 
 Contract two quadrants (enlarged corners) to form a half-infinite environment.
 
@@ -221,6 +220,26 @@ Contract two quadrants (enlarged corners) to form a half-infinite environment.
     |quadrant1|    |quadrant2|
     |~~~~~~~~~| == |~~~~~~~~~|
       |    ||        ||    |
+```
+
+The environment can also be contracted directly from all its constituent tensors.
+
+```
+    C_1 --  E_2      --  E_3      -- C_2
+     |       ||          ||           | 
+    E_1 == ket_bra_1 == ket_bra_2 == E_4
+     |       ||          ||           |
+```
+
+Alternatively, contract environment with a vector `x` acting on it, e.g. as needed for iterative solvers.
+
+```
+    C_1 --  E_2      --  E_3      -- C_2
+     |       ||          ||           | 
+    E_1 == ket_bra_1 == ket_bra_2 == E_4
+     |       ||          ||           |
+                         [~~~~~~x~~~~~~]
+                         ||           |
 ```
 """
 function halfinfinite_environment(
@@ -231,9 +250,35 @@ function halfinfinite_environment(
         quadrant2[χ D1 D2; χ_out D_outabove D_outbelow]
 end
 function halfinfinite_environment(
-    quadrant1::EnlargedCorner{A,C,E}, quadrant2::EnlargedCorner{A,C,E}
-) where {A,C,E}
-    return HalfInfiniteEnv(quadrant1, quadrant2)()
+    E_1, C_1, E_2, E_3, C_2, E_4, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
+) where {P<:PEPSTensor}
+    return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
+        E_1[χ_in D1 D2; χ1] *
+        C_1[χ1; χ2] *
+        E_2[χ2 D3 D4; χ3] *
+        ket_1[d1; D3 D9 D_inabove D1] *
+        conj(bra_1[d1; D4 D10 D_inbelow D2]) *
+        ket_2[d2; D5 D7 D_outabove D9] *
+        conj(bra_2[d2; D6 D8 D_outbelow D10]) *
+        E_3[χ3 D5 D6; χ4] *
+        C_2[χ4; χ5] *
+        E_4[χ5 D7 D8; χ_out]
+end
+function halfinfinite_environment(
+    E_1, C_1, E_2, E_3, C_2, E_4, x, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
+) where {P<:PEPSTensor}
+    return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
+        E_1[χ_in D1 D2; χ1] *
+        C_1[χ1; χ2] *
+        E_2[χ2 D3 D4; χ3] *
+        ket_1[d1; D3 D9 D_inabove D1] *
+        conj(bra_1[d1; D4 D10 D_inbelow D2]) *
+        ket_2[d2; D5 D7 D11 D9] *
+        conj(bra_2[d2; D6 D8 D12 D10]) *
+        E_3[χ3 D5 D6; χ4] *
+        C_2[χ4; χ5] *
+        E_4[χ5 D7 D8; χ6] *
+        x[χ6 D11 D12; χ_out D_outabove D_outbelow]
 end
 
 # Renormalization contractions

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -248,14 +248,14 @@ Alternatively, contract environment with a vector `x` acting on it, e.g. as need
 function halfinfinite_environment(
     quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3}
 ) where {S}
-    return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
+    return @autoopt @tensor env[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         quadrant1[χ_in D_inabove D_inbelow; χ D1 D2] *
         quadrant2[χ D1 D2; χ_out D_outabove D_outbelow]
 end
 function halfinfinite_environment(
     C_1, C_2, E_1, E_2, E_3, E_4, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
 ) where {P<:PEPSTensor}
-    return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
+    return @autoopt @tensor env[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         E_1[χ_in D1 D2; χ1] *
         C_1[χ1; χ2] *
         E_2[χ2 D3 D4; χ3] *
@@ -268,9 +268,19 @@ function halfinfinite_environment(
         E_4[χ5 D7 D8; χ_out]
 end
 function halfinfinite_environment(
-    C_1, C_2, E_1, E_2, E_3, E_4, x, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
-) where {P<:PEPSTensor}
-    return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
+    C_1,
+    C_2,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    x::AbstractTensor{S,3},
+    ket_1::P,
+    ket_2::P,
+    bra_1::P=ket_1,
+    bra_2::P=ket_2,
+) where {S,P<:PEPSTensor}
+    return @autoopt @tensor env_x[χ_in D_inabove D_inbelow] :=
         E_1[χ_in D1 D2; χ1] *
         C_1[χ1; χ2] *
         E_2[χ2 D3 D4; χ3] *
@@ -281,7 +291,33 @@ function halfinfinite_environment(
         E_3[χ3 D5 D6; χ4] *
         C_2[χ4; χ5] *
         E_4[χ5 D7 D8; χ6] *
-        x[χ6 D11 D12; χ_out D_outabove D_outbelow]
+        x[χ6 D11 D12]
+end
+function halfinfinite_environment(
+    x::AbstractTensor{S,3},
+    C_1,
+    C_2,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    ket_1::P,
+    ket_2::P,
+    bra_1::P=ket_1,
+    bra_2::P=ket_2,
+) where {S,P<:PEPSTensor}
+    return @autoopt @tensor env_x[χ_in D_inabove D_inbelow] :=
+        x[χ1 D1 D2] *
+        conj(E_1[χ1 D3 D4; χ2]) *
+        conj(C_1[χ2; χ3]) *
+        conj(E_2[χ3 D5 D6; χ4]) *
+        conj(ket_1[d1; D5 D11 D1 D3]) *
+        bra_1[d1; D6 D12 D2 D4] *
+        conj(ket_2[d2; D7 D9 D_inabove D11]) *
+        bra_2[d2; D8 D10 D_inbelow D12] *
+        conj(E_3[χ4 D7 D8; χ5]) *
+        conj(C_2[χ5; χ6]) *
+        conj(E_4[χ6 D9 D10; χ_in])
 end
 
 # Renormalization contractions

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -165,6 +165,7 @@ end
 
 """
     halfinfinite_environment(quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3})
+    halfinfinite_environment(quadrant1::EnlargedCorner{A,C,E}, quadrant2::EnlargedCorner{A,C,E})
 
 Contract two quadrants (enlarged corners) to form a half-infinite environment.
 
@@ -181,6 +182,11 @@ function halfinfinite_environment(
     return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         quadrant1[χ_in D_inabove D_inbelow; χ D1 D2] *
         quadrant2[χ D1 D2; χ_out D_outabove D_outbelow]
+end
+function halfinfinite_environment(
+    quadrant1::EnlargedCorner{A,C,E}, quadrant2::EnlargedCorner{A,C,E}
+) where {A,C,E}
+    return HalfInfiniteEnv(quadrant1, quadrant2)()
 end
 
 # Renormalization contractions

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -164,6 +164,53 @@ end
 # ----------------------
 
 """
+    left_projector(E_1, C, E_2, V, isqS, ket::PEPSTensor, bra::PEPSTensor=ket)
+
+Contract the CTMRG left projector with the higher-dimensional subspace facing to the left.
+
+```
+     C  --  E_2    -- |~~|
+     |       ||       |V'| -- isqS --
+    E_1 == ket-bra == |~~|
+     |       ||
+```
+"""
+function left_projector(E_1, C, E_2, V, isqS, ket::PEPSTensor, bra::PEPSTensor=ket)
+    return @autoopt @tensor P_left[χ_in D_inabove D_inbelow; χ_out] :=
+        E_1[χ_in D1 D2; χ1] * 
+        C[χ1; χ2] * 
+        E_2[χ2 D3 D4; χ3] * 
+        ket[d; D3 D5 D_inabove D1] *
+        conj(bra[d; D4 D6 D_inbelow D2]) *
+        conj(V[χ4; χ3 D5 D6]) *
+        isqS[χ4; χ_out]
+end
+
+"""
+    right_projector(E_1, C, E_2, U, isqS, ket::PEPSTensor, bra::PEPSTensor=ket)
+
+Contract the CTMRG right projector with the higher-dimensional subspace facing to the right.
+
+```
+               |~~| --   E_2   --  C
+    -- isqS -- |U'|      ||        |
+               |~~| == ket-bra == E_1
+                         ||        |
+```
+"""
+function right_projector(E_1, C, E_2, U, isqS, ket::PEPSTensor, bra::PEPSTensor=ket)
+    return @autoopt @tensor P_right[χ_in; χ_out D_outabove D_outbelow] :=
+        isqS[χ_in; χ1] *
+        conj(U[χ1; χ2 D1 D2]) *
+        ket[d; D1 D5 D_outabove D1] *
+        conj(bra[d; D2 D6 D_outbelow D2]) *
+        E_2[χ2 D3 D4; χ3] * 
+        C[χ3; χ4] * 
+        E_1[χ4 D5 D6; χ_out]
+end
+
+
+"""
     halfinfinite_environment(quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3})
     halfinfinite_environment(quadrant1::EnlargedCorner{A,C,E}, quadrant2::EnlargedCorner{A,C,E})
 

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -872,7 +872,7 @@ end
 Multiply north left singular vectors with gauge signs from the right.
 """
 function fix_gauge_north_left_vecs((row, col), U, signs)
-    return U[NORTH, row, col] * signs[NORTH, row, _next(col, end)]
+    return U[NORTH, row, col] * signs[NORTH, row, _next(col, end)]'
 end
 
 """
@@ -881,7 +881,7 @@ end
 Multiply east left singular vectors with gauge signs from the right.
 """
 function fix_gauge_east_left_vecs((row, col), U, signs)
-    return U[EAST, row, col] * signs[EAST, _next(row, end), col]
+    return U[EAST, row, col] * signs[EAST, _next(row, end), col]'
 end
 
 """
@@ -890,7 +890,7 @@ end
 Multiply south left singular vectors with gauge signs from the right.
 """
 function fix_gauge_south_left_vecs((row, col), U, signs)
-    return U[SOUTH, row, col] * signs[SOUTH, row, _prev(col, end)]
+    return U[SOUTH, row, col] * signs[SOUTH, row, _prev(col, end)]'
 end
 
 """
@@ -899,7 +899,7 @@ end
 Multiply west left singular vectors with gauge signs from the right.
 """
 function fix_gauge_west_left_vecs((row, col), U, signs)
-    return U[WEST, row, col] * signs[WEST, _prev(row, end), col]
+    return U[WEST, row, col] * signs[WEST, _prev(row, end), col]'
 end
 
 # right singular vectors
@@ -910,7 +910,7 @@ end
 Multiply north right singular vectors with gauge signs from the left.
 """
 function fix_gauge_north_right_vecs((row, col), V, signs)
-    return signs[NORTH, row, _next(col, end)]' * V[NORTH, row, col]
+    return signs[NORTH, row, _next(col, end)] * V[NORTH, row, col]
 end
 
 """
@@ -919,7 +919,7 @@ end
 Multiply east right singular vectors with gauge signs from the left.
 """
 function fix_gauge_east_right_vecs((row, col), V, signs)
-    return signs[EAST, _next(row, end), col]' * V[EAST, row, col]
+    return signs[EAST, _next(row, end), col] * V[EAST, row, col]
 end
 
 """
@@ -928,7 +928,7 @@ end
 Multiply south right singular vectors with gauge signs from the left.
 """
 function fix_gauge_south_right_vecs((row, col), V, signs)
-    return signs[SOUTH, row, _prev(col, end)]' * V[SOUTH, row, col]
+    return signs[SOUTH, row, _prev(col, end)] * V[SOUTH, row, col]
 end
 
 """
@@ -937,5 +937,5 @@ end
 Multiply west right singular vectors with gauge signs from the left.
 """
 function fix_gauge_west_right_vecs((row, col), V, signs)
-    return signs[WEST, _prev(row, end), col]' * V[WEST, row, col]
+    return signs[WEST, _prev(row, end), col] * V[WEST, row, col]
 end

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -211,10 +211,12 @@ end
 
 """
     halfinfinite_environment(quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3})
-    function halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4,
-                                      ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
-    function halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4, x,
-                                      ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
+    halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4,
+                             ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
+    halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4, x,
+                             ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
+    halfinfinite_environment(x, C_1, C_2, E_1, E_2, E_3, E_4,
+                             ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
 
 Contract two quadrants (enlarged corners) to form a half-infinite environment.
 
@@ -234,7 +236,7 @@ The environment can also be contracted directly from all its constituent tensors
      |       ||          ||           |
 ```
 
-Alternatively, contract environment with a vector `x` acting on it, e.g. as needed for iterative solvers.
+Alternatively, contract environment with a vector `x` acting on it
 
 ```
     C_1 --  E_2      --  E_3      -- C_2
@@ -244,6 +246,8 @@ Alternatively, contract environment with a vector `x` acting on it, e.g. as need
                          [~~~~~~x~~~~~~]
                          ||           |
 ```
+
+or contract the adjoint environment with `x`, e.g. as needed for iterative solvers.
 """
 function halfinfinite_environment(
     quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3}

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -211,7 +211,10 @@ end
 
 """
     halfinfinite_environment(quadrant1::AbstractTensorMap{S,3,3}, quadrant2::AbstractTensorMap{S,3,3})
-    
+    function halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4,
+                                      ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
+    function halfinfinite_environment(C_1, C_2, E_1, E_2, E_3, E_4, x,
+                                      ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2) where {P<:PEPSTensor}
 
 Contract two quadrants (enlarged corners) to form a half-infinite environment.
 
@@ -250,7 +253,7 @@ function halfinfinite_environment(
         quadrant2[χ D1 D2; χ_out D_outabove D_outbelow]
 end
 function halfinfinite_environment(
-    E_1, C_1, E_2, E_3, C_2, E_4, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
+    C_1, C_2, E_1, E_2, E_3, E_4, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
 ) where {P<:PEPSTensor}
     return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         E_1[χ_in D1 D2; χ1] *
@@ -265,7 +268,7 @@ function halfinfinite_environment(
         E_4[χ5 D7 D8; χ_out]
 end
 function halfinfinite_environment(
-    E_1, C_1, E_2, E_3, C_2, E_4, x, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
+    C_1, C_2, E_1, E_2, E_3, E_4, x, ket_1::P, ket_2::P, bra_1::P=ket_1, bra_2::P=ket_2
 ) where {P<:PEPSTensor}
     return @autoopt @tensor half[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         E_1[χ_in D1 D2; χ1] *

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -80,11 +80,7 @@ function CTMRG(;
     ctmrgscheme::Symbol=Defaults.ctmrgscheme,
 )
     return CTMRG{ctmrgscheme}(
-        tol,
-        maxiter,
-        miniter,
-        verbosity,
-        ProjectorAlg(; svd_alg, trscheme, verbosity),
+        tol, maxiter, miniter, verbosity, ProjectorAlg(; svd_alg, trscheme, verbosity)
     )
 end
 
@@ -200,7 +196,6 @@ end
 # end
 function ctmrg_expand(dirs, state, envs::CTMRGEnv{C,T}) where {C,T}
     Qtype = tensormaptype(spacetype(C), 3, 3, storagetype(C))
-    # Qtype = EnlargedCorner{C,T,eltype(state),eltype(state)}
     Q = Zygote.Buffer(Array{Qtype,3}(undef, size(envs.corners)))
     drc_combinations = collect(Iterators.product(dirs, axes(state)...))
     @fwdthreads for (dir, r, c) in drc_combinations

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -73,7 +73,7 @@ struct CTMRG{M,S}
     maxiter::Int
     miniter::Int
     verbosity::Int
-    projector_alg::P
+    projector_alg::ProjectorAlg
 end
 function CTMRG(;
     tol=Defaults.ctmrg_tol,
@@ -189,13 +189,13 @@ There are two modes of expansion: `M = :sequential` and `M = :simultaneous`.
 The first mode expands the environment in one direction at a time, for convenience towards
 the left. The second mode expands the environment in all four directions simultaneously.
 """
-function ctmrg_expand(state, envs::CTMRGEnv, ::SequentialCTMRG)
+function ctmrg_expand(state, envs::CTMRGEnv, alg::SequentialCTMRG)
     drc_combinations = collect(Iterators.product([4, 1], axes(state)...))
     return map(drc_combinations) do (dir, r, c)
         enlarge_corner(Val(dir), (r, c), envs, state, alg)
     end
 end
-function ctmrg_expand(state, envs::CTMRGEnv, ::SimultaneousCTMRG)
+function ctmrg_expand(state, envs::CTMRGEnv, alg::SimultaneousCTMRG)
     drc_combinations = collect(Iterators.product(1:4, axes(state)...))
     return map(drc_combinations) do (dir, r, c)
         enlarge_corner(Val(dir), (r, c), envs, state, alg)

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -202,6 +202,7 @@ function ctmrg_expand(state, envs::CTMRGEnv{C,T}, ::SimultaneousCTMRG) where {C,
     Q = Zygote.Buffer(Array{Qtype,3}(undef, size(envs.corners)))
     drc_combinations = collect(Iterators.product(axes(envs.corners)...))
     @fwdthreads for (dir, r, c) in drc_combinations
+        # TODO: generalize the corner computation to make it compatible with EnlargedCorners
         Q[dir, r, c] = if dir == NORTHWEST
             enlarge_northwest_corner((r, c), envs, state)
         elseif dir == NORTHEAST
@@ -214,6 +215,9 @@ function ctmrg_expand(state, envs::CTMRGEnv{C,T}, ::SimultaneousCTMRG) where {C,
     end
 
     return copy(Q)
+end
+
+function enlarge_corner((dir, r, c), envs, state, alg::CTMRG)  # TODO: find a way to dispatch on CTMRG struct to switch on function handles
 end
 
 # ======================================================================================== #

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -196,11 +196,12 @@ end
 # end
 function ctmrg_expand(dirs, state, envs::CTMRGEnv{C,T}) where {C,T}
     Qtype = tensormaptype(spacetype(C), 3, 3, storagetype(C))
-    Q = Zygote.Buffer(Array{Qtype,3}(undef, size(envs.corners)))
-    drc_combinations = collect(Iterators.product(dirs, axes(state)...))
-    @fwdthreads for (dir, r, c) in drc_combinations
-        ec = enlarge_corner((dir, r, c), state, envs)
-        Q[dir, r, c] = ec(dir)  # Explicitly construct EnlargedCorner for now
+    Q = Zygote.Buffer(Array{Qtype,3}(undef, length(dirs), size(state)...))
+    dirs_enum = [(i, dir) for (i, dir) in enumerate(dirs)]
+    drc_combinations = collect(Iterators.product(dirs_enum, axes(state)...))
+    @fwdthreads for (d, r, c) in drc_combinations
+        ec = enlarge_corner((d[2], r, c), state, envs)
+        Q[d[1], r, c] = ec(d[2])  # Explicitly construct EnlargedCorner for now
     end
     return copy(Q)
 end

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -192,7 +192,7 @@ function ctmrg_expand(state, envs::CTMRGEnv, ::SimultaneousCTMRG)
 end
 # function ctmrg_expand(dirs, state, envs::CTMRGEnv)  # TODO: This doesn't AD due to length(::Nothing)...
 #     drc_combinations = collect(Iterators.product(dirs, axes(state)...))
-#     return map(idx -> EnlargedCorner(state, envs, idx)(idx[1]), drc_combinations)
+#     return map(idx -> TensorMap(EnlargedCorner(state, envs, idx), idx[1]), drc_combinations)
 # end
 function ctmrg_expand(dirs, state, envs::CTMRGEnv{C,T}) where {C,T}
     Qtype = tensormaptype(spacetype(C), 3, 3, storagetype(C))
@@ -201,7 +201,7 @@ function ctmrg_expand(dirs, state, envs::CTMRGEnv{C,T}) where {C,T}
     drc_combinations = collect(Iterators.product(dirs_enum, axes(state)...))
     @fwdthreads for (d, r, c) in drc_combinations
         ec = EnlargedCorner(state, envs, (d[2], r, c))
-        Q[d[1], r, c] = ec(d[2])  # Explicitly construct EnlargedCorner for now
+        Q[d[1], r, c] = TensorMap(ec, d[2])  # Explicitly construct EnlargedCorner for now
     end
     return copy(Q)
 end

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -1,3 +1,4 @@
+const SparseCTMRG = CTMRG{M,true} where {M}  # TODO: Is this really a good way to dispatch on the sparse CTMRG methods?
 
 """
     struct EnlargedCorner{Ct,E,A,A′}

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -16,6 +16,49 @@ struct EnlargedCorner{Ct,E,A,A′}
 end
 
 """
+    EnlargedCorner(state, envs, coordinates)
+
+Construct an enlarged corner with the correct row and column indices based on the given
+`coordinates` which are of the form `(dir, row, col)`.
+"""
+function EnlargedCorner(state, envs, coordinates)
+    dir, r, c = coordinates
+    if dir == NORTHWEST
+        return EnlargedCorner(
+            envs.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+            envs.edges[WEST, r, _prev(c, end)],
+            envs.edges[NORTH, _prev(r, end), c],
+            state[r, c],
+            state[r, c],
+        )
+    elseif dir == NORTHEAST
+        return EnlargedCorner(
+            envs.corners[NORTHEAST, _prev(r, end), _next(c, end)],
+            envs.edges[NORTH, _prev(r, end), c],
+            envs.edges[EAST, r, _next(c, end)],
+            state[r, c],
+            state[r, c],
+        )
+    elseif dir == SOUTHEAST
+        return EnlargedCorner(
+            envs.corners[SOUTHEAST, _next(r, end), _next(c, end)],
+            envs.edges[EAST, r, _next(c, end)],
+            envs.edges[SOUTH, _next(r, end), c],
+            state[r, c],
+            state[r, c],
+        )
+    elseif dir == SOUTHWEST
+        return EnlargedCorner(
+            envs.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
+            envs.edges[SOUTH, _next(r, end), c],
+            envs.edges[WEST, r, _prev(c, end)],
+            state[r, c],
+            state[r, c],
+        )
+    end
+end
+
+"""
     (Q::EnlargedCorner)(dir::Int)
 
 Contract enlarged corner where `dir` selects the correct contraction direction,

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -60,7 +60,7 @@ struct EnlargedCorner{A,A′,Ct,E}
     E_2::E
 end
 
-# Contract enlarged corner
+# Contract enlarged corner (use NW corner as convention for connecting environment to PEPS tensor)
 function (Q::EnlargedCorner)()
     return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
 end
@@ -74,6 +74,9 @@ function build_projectors(
     Q_next::EnlargedCorner,
 ) where {E<:ElementarySpace}
     isqS = sdiag_inv_sqrt(S)
-    # TODO
+    P_left = left_projector(Q.E_1, Q.C, Q.E_2, V, isqS, Q.ket, Q.bra)
+    P_right = right_projector(
+        Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.ket, Q_next.bra
+    )
     return P_left, P_right
 end

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -23,6 +23,48 @@ Contract enlarged corner where `Val(1)` dispatches the north-west, `Val(2)` the 
 (Q::EnlargedCorner)(::Val{3}) = enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
 (Q::EnlargedCorner)(::Val{4}) = enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
 
+"""
+    enlarge_corner(::Val{<:Int}, (r, c), envs, state, alg::SparseCTMRG)
+
+Enlarge corner but return as a `EnlargedCorner` struct used in sparse CTMRG.
+"""
+function enlarge_corner(::Val{1}, (r, c), envs, state, alg::SparseCTMRG)
+    return EnlargedCorner(
+        envs.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+        envs.edges[WEST, r, _prev(c, end)],
+        envs.edges[NORTH, _prev(r, end), c],
+        state[r, c],
+        state[r, c],
+    )
+end
+function enlarge_corner(::Val{2}, (r, c), envs, state, alg::SparseCTMRG)
+    return EnlargedCorner(
+        envs.corners[NORTHEAST, _prev(r, end), _next(c, end)],
+        envs.edges[NORTH, _prev(r, end), c],
+        envs.edges[EAST, r, _next(c, end)],
+        state[r, c],
+        state[r, c],
+    )
+end
+function enlarge_corner(::Val{3}, (r, c), envs, state, alg::SparseCTMRG)
+    return EnlargedCorner(
+        envs.corners[SOUTHEAST, _next(r, end), _next(c, end)],
+        envs.edges[EAST, r, _next(c, end)],
+        envs.edges[SOUTH, _next(r, end), c],
+        state[r, c],
+        state[r, c],
+    )
+end
+function enlarge_corner(::Val{4}, (r, c), envs, state, alg::SparseCTMRG)
+    return EnlargedCorner(
+        envs.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
+        envs.edges[SOUTH, _next(r, end), c],
+        envs.edges[WEST, r, _prev(c, end)],
+        state[r, c],
+        state[r, c],
+    )
+end
+
 # Compute left & right projectors from enlarged corner struct
 function build_projectors(
     U::AbstractTensorMap{E,3,1},
@@ -37,6 +79,10 @@ function build_projectors(
         Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.ket, Q_next.bra
     )
     return P_left, P_right
+end
+
+function renormalize_corner(ec::EnlargedCorner, P_left, P_right)
+    return renormalize_corner(ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra)
 end
 
 """

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -2,13 +2,6 @@
     struct HalfInfiniteEnv{A,C,E}
 
 Half-infinite CTMRG environment tensor storage.
-
-```
-    C_2 --  E_2      --  E_3      -- C_3
-     |       ||          ||           | 
-    E_1 == ket_bra_1 == ket_bra_2 == E_4
-     |       ||          ||           |
-```
 """
 struct HalfInfiniteEnv{A,A′,C,E}
     ket_1::A
@@ -37,8 +30,41 @@ function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
     )
 end
 
-# Contract half-infinite environment
-function (env::HalfInfiniteEnv)() end
+"""
+    (env::HalfInfiniteEnv)() 
+    (env::HalfInfiniteEnv)(x) 
+
+Contract half-infinite environment without or with a vector `x`.
+"""
+function (env::HalfInfiniteEnv)()
+    return halfinfinite_environment(
+        env.E_1,
+        env.C_1,
+        env.E_2,
+        env.E_3,
+        env.C_2,
+        env.E_4,
+        env.ket_1,
+        env.ket_2,
+        env.bra_1,
+        env.bra_2,
+    )
+end
+function (env::HalfInfiniteEnv)(x)
+    return halfinfinite_environment(
+        env.E_1,
+        env.C_1,
+        env.E_2,
+        env.E_3,
+        env.C_2,
+        env.E_4,
+        x,
+        env.ket_1,
+        env.ket_2,
+        env.bra_1,
+        env.bra_2,
+    )
+end
 
 """
     struct EnlargedCorner{A,C,E}

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -59,12 +59,12 @@ function EnlargedCorner(state, envs, coordinates)
 end
 
 """
-    (Q::EnlargedCorner)(dir::Int)
+    TensorKit.TensorMap(Q::EnlargedCorner, dir::Int)
 
-Contract enlarged corner where `dir` selects the correct contraction direction,
-i.e. the way the environment and PEPS tensors connect.
+Instantiate enlarged corner as `TensorMap` where `dir` selects the correct contraction
+direction, i.e. the way the environment and PEPS tensors connect.
 """
-function (Q::EnlargedCorner)(dir::Int)
+function TensorKit.TensorMap(Q::EnlargedCorner, dir::Int)
     if dir == NORTHWEST
         return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
     elseif dir == NORTHEAST
@@ -134,14 +134,11 @@ function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
 end
 
 """
-    (env::HalfInfiniteEnv)() 
-    (env::HalfInfiniteEnv)(x, ::Val{false}) 
-    (env::HalfInfiniteEnv)(x, ::Val{true}) 
+    TensorKit.TensorMap(env::HalfInfiniteEnv)
 
-Contract half-infinite environment. If a vector `x` is provided, the environment acts as a
-linear map or adjoint linear map on `x` if `Val(true)` or `Val(false)` is passed, respectively.
+Instantiate half-infinite environment as `TensorMap` explicitly.
 """
-function (env::HalfInfiniteEnv)()  # Dense operator
+function TensorKit.TensorMap(env::HalfInfiniteEnv)  # Dense operator
     return halfinfinite_environment(
         env.C_1,
         env.C_2,
@@ -155,6 +152,14 @@ function (env::HalfInfiniteEnv)()  # Dense operator
         env.bra_2,
     )
 end
+
+"""
+    (env::HalfInfiniteEnv)(x, ::Val{false}) 
+    (env::HalfInfiniteEnv)(x, ::Val{true}) 
+
+Contract half-infinite environment with a vector `x`, such that the environment acts as a
+linear map or adjoint linear map on `x` if `Val(true)` or `Val(false)` is passed, respectively.
+"""
 function (env::HalfInfiniteEnv)(x, ::Val{false})  # Linear map: env() * x
     return halfinfinite_environment(
         env.C_1,

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -24,16 +24,45 @@ i.e. the way the environment and PEPS tensors connect.
 function (Q::EnlargedCorner)(dir::Int)
     if dir == NORTHWEST
         return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == NORTHWEST
-        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == NORTHWEST
-        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == NORTHWEST
-        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == NORTHEAST
+        return enlarge_northeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == SOUTHEAST
+        return enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == SOUTHWEST
+        return enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
     end
 end
-function renormalize_corner(ec::EnlargedCorner, P_left, P_right)
-    return renormalize_corner(ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra)
+function construct_corner(Q::EnlargedCorner, dir::Int)
+    if dir == NORTHWEST
+        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == NORTHEAST
+        return enlarge_northeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == SOUTHEAST
+        return enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == SOUTHWEST
+        return enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    end
+end
+
+function renormalize_northwest_corner(ec::EnlargedCorner, P_left, P_right)
+    return renormalize_northwest_corner(
+        ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra
+    )
+end
+function renormalize_northeast_corner(ec::EnlargedCorner, P_left, P_right)
+    return renormalize_northeast_corner(
+        ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra
+    )
+end
+function renormalize_southeast_corner(ec::EnlargedCorner, P_left, P_right)
+    return renormalize_southeast_corner(
+        ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra
+    )
+end
+function renormalize_southwest_corner(ec::EnlargedCorner, P_left, P_right)
+    return renormalize_southwest_corner(
+        ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra
+    )
 end
 
 # ------------------

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -1,0 +1,79 @@
+"""
+    struct HalfInfiniteEnv{A,C,E}
+
+Half-infinite CTMRG environment tensor storage.
+
+```
+    C_2 --  E_2      --  E_3      -- C_3
+     |       ||          ||           | 
+    E_1 == ket_bra_1 == ket_bra_2 == E_4
+     |       ||          ||           |
+```
+"""
+struct HalfInfiniteEnv{A,A′,C,E}
+    ket_1::A
+    bra_1::A′
+    ket_2::A
+    bra_2::A′
+    C_1::C
+    C_2::C
+    E_1::E
+    E_2::E
+    E_3::E
+    E_4::E
+end
+
+# Construct environment from two enlarged corners
+function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
+    return HalfInfiniteEnv(
+        quadrant1.ket_bra,
+        quadrant2.ket_bra,
+        quadrant1.C,
+        quadrant2.C,
+        quadrant1.E_1,
+        quadrant1.E_2,
+        quadrant2.E_1,
+        quadrant2.E_2,
+    )
+end
+
+# Contract half-infinite environment
+function (env::HalfInfiniteEnv)() end
+
+"""
+    struct EnlargedCorner{A,C,E}
+
+Enlarged CTMRG corner tensor storage.
+
+```
+     C  --  E_2    --
+     |       ||      
+    E_1 == ket-bra ==
+     |       ||      
+```
+"""
+struct EnlargedCorner{A,A′,Ct,E}
+    ket::A
+    bra::A′
+    C::Ct
+    E_1::E
+    E_2::E
+end
+
+# Contract enlarged corner
+function (Q::EnlargedCorner)()
+    return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+end
+
+# Compute left & right projectors from enlarged corner struct
+function build_projectors(
+    U::AbstractTensorMap{E,3,1},
+    S::AbstractTensorMap{E,1,1},
+    V::AbstractTensorMap{E,1,3},
+    Q::EnlargedCorner,
+    Q_next::EnlargedCorner,
+) where {E<:ElementarySpace}
+    isqS = sdiag_inv_sqrt(S)
+    # TODO
+    return P_left, P_right
+end

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -1,5 +1,5 @@
 """
-    struct HalfInfiniteEnv{A,C,E}
+    struct HalfInfiniteEnv{A,A′,C,E}
 
 Half-infinite CTMRG environment tensor storage.
 """
@@ -67,16 +67,9 @@ function (env::HalfInfiniteEnv)(x)
 end
 
 """
-    struct EnlargedCorner{A,C,E}
+    struct EnlargedCorner{A,A′,Ct,E}
 
 Enlarged CTMRG corner tensor storage.
-
-```
-     C  --  E_2    --
-     |       ||      
-    E_1 == ket-bra ==
-     |       ||      
-```
 """
 struct EnlargedCorner{A,A′,Ct,E}
     ket::A
@@ -86,10 +79,16 @@ struct EnlargedCorner{A,A′,Ct,E}
     E_2::E
 end
 
-# Contract enlarged corner (use NW corner as convention for connecting environment to PEPS tensor)
-function (Q::EnlargedCorner)()
-    return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-end
+"""
+    (Q::EnlargedCorner)(::Val{<:Int})
+
+Contract enlarged corner where `Val(1)` dispatches the north-west, `Val(2)` the north-east
+`Val(3)` the south-east and `Val(4)` the south-west contraction.
+"""
+(Q::EnlargedCorner)(::Val{1}) = enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+(Q::EnlargedCorner)(::Val{2}) = enlarge_northeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+(Q::EnlargedCorner)(::Val{3}) = enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+(Q::EnlargedCorner)(::Val{4}) = enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
 
 # Compute left & right projectors from enlarged corner struct
 function build_projectors(

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -32,17 +32,6 @@ function (Q::EnlargedCorner)(dir::Int)
         return enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
     end
 end
-function construct_corner(Q::EnlargedCorner, dir::Int)
-    if dir == NORTHWEST
-        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == NORTHEAST
-        return enlarge_northeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == SOUTHEAST
-        return enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    elseif dir == SOUTHWEST
-        return enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-    end
-end
 
 function renormalize_northwest_corner(ec::EnlargedCorner, P_left, P_right)
     return renormalize_northwest_corner(

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -1,5 +1,3 @@
-const SparseCTMRG = CTMRG{M,true} where {M}  # TODO: Is this really a good way to dispatch on the sparse CTMRG methods?
-
 # --------------------------------------------------------
 # Sparse enlarged corner as building block for environment
 # --------------------------------------------------------
@@ -18,77 +16,22 @@ struct EnlargedCorner{Ct,E,A,A′}
 end
 
 """
-    (Q::EnlargedCorner)(::Val{<:Int})
+    (Q::EnlargedCorner)(dir::Int)
 
-Contract enlarged corner where `Val(1)` dispatches the north-west, `Val(2)` the north-east
-`Val(3)` the south-east and `Val(4)` the south-west contraction.
+Contract enlarged corner where `dir` selects the correct contraction direction,
+i.e. the way the environment and PEPS tensors connect.
 """
-(Q::EnlargedCorner)(::Val{1}) = enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-(Q::EnlargedCorner)(::Val{2}) = enlarge_northeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-(Q::EnlargedCorner)(::Val{3}) = enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-(Q::EnlargedCorner)(::Val{4}) = enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
-
-# -------------------------
-# CTMRG compatibility layer
-# -------------------------
-
-"""
-    enlarge_corner(::Val{<:Int}, (r, c), envs, state, alg::SparseCTMRG)
-
-Enlarge corner but return as a `EnlargedCorner` struct used in sparse CTMRG.
-"""
-function enlarge_corner(::Val{1}, (r, c), envs, state, alg::SparseCTMRG)
-    return EnlargedCorner(
-        envs.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
-        envs.edges[WEST, r, _prev(c, end)],
-        envs.edges[NORTH, _prev(r, end), c],
-        state[r, c],
-        state[r, c],
-    )
+function (Q::EnlargedCorner)(dir::Int)
+    if dir == NORTHWEST
+        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == NORTHWEST
+        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == NORTHWEST
+        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    elseif dir == NORTHWEST
+        return enlarge_northwest_corner(Q.E_1, Q.C, Q.E_2, Q.ket, Q.bra)
+    end
 end
-function enlarge_corner(::Val{2}, (r, c), envs, state, alg::SparseCTMRG)
-    return EnlargedCorner(
-        envs.corners[NORTHEAST, _prev(r, end), _next(c, end)],
-        envs.edges[NORTH, _prev(r, end), c],
-        envs.edges[EAST, r, _next(c, end)],
-        state[r, c],
-        state[r, c],
-    )
-end
-function enlarge_corner(::Val{3}, (r, c), envs, state, alg::SparseCTMRG)
-    return EnlargedCorner(
-        envs.corners[SOUTHEAST, _next(r, end), _next(c, end)],
-        envs.edges[EAST, r, _next(c, end)],
-        envs.edges[SOUTH, _next(r, end), c],
-        state[r, c],
-        state[r, c],
-    )
-end
-function enlarge_corner(::Val{4}, (r, c), envs, state, alg::SparseCTMRG)
-    return EnlargedCorner(
-        envs.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
-        envs.edges[SOUTH, _next(r, end), c],
-        envs.edges[WEST, r, _prev(c, end)],
-        state[r, c],
-        state[r, c],
-    )
-end
-
-function build_projectors(
-    U::AbstractTensorMap{E,3,1},
-    S::AbstractTensorMap{E,1,1},
-    V::AbstractTensorMap{E,1,3},
-    Q::EnlargedCorner,
-    Q_next::EnlargedCorner,
-) where {E<:ElementarySpace}
-    isqS = sdiag_inv_sqrt(S)
-    P_left = left_projector(Q.E_1, Q.C, Q.E_2, V, isqS, Q.ket, Q.bra)
-    P_right = right_projector(
-        Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.ket, Q_next.bra
-    )
-    return P_left, P_right
-end
-
 function renormalize_corner(ec::EnlargedCorner, P_left, P_right)
     return renormalize_corner(ec.E_1, ec.C, ec.E_2, P_left, P_right, ec.ket, ec.bra)
 end

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -1,82 +1,15 @@
-"""
-    struct HalfInfiniteEnv{A,A′,C,E}
-
-Half-infinite CTMRG environment tensor storage.
-"""
-struct HalfInfiniteEnv{A,A′,C,E}
-    ket_1::A
-    bra_1::A′
-    ket_2::A
-    bra_2::A′
-    C_1::C
-    C_2::C
-    E_1::E
-    E_2::E
-    E_3::E
-    E_4::E
-end
-
-# Construct environment from two enlarged corners
-function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
-    return HalfInfiniteEnv(
-        quadrant1.ket_bra,
-        quadrant2.ket_bra,
-        quadrant1.C,
-        quadrant2.C,
-        quadrant1.E_1,
-        quadrant1.E_2,
-        quadrant2.E_1,
-        quadrant2.E_2,
-    )
-end
 
 """
-    (env::HalfInfiniteEnv)() 
-    (env::HalfInfiniteEnv)(x) 
-
-Contract half-infinite environment without or with a vector `x`.
-"""
-function (env::HalfInfiniteEnv)()
-    return halfinfinite_environment(
-        env.E_1,
-        env.C_1,
-        env.E_2,
-        env.E_3,
-        env.C_2,
-        env.E_4,
-        env.ket_1,
-        env.ket_2,
-        env.bra_1,
-        env.bra_2,
-    )
-end
-function (env::HalfInfiniteEnv)(x)
-    return halfinfinite_environment(
-        env.E_1,
-        env.C_1,
-        env.E_2,
-        env.E_3,
-        env.C_2,
-        env.E_4,
-        x,
-        env.ket_1,
-        env.ket_2,
-        env.bra_1,
-        env.bra_2,
-    )
-end
-
-"""
-    struct EnlargedCorner{A,A′,Ct,E}
+    struct EnlargedCorner{Ct,E,A,A′}
 
 Enlarged CTMRG corner tensor storage.
 """
-struct EnlargedCorner{A,A′,Ct,E}
-    ket::A
-    bra::A′
+struct EnlargedCorner{Ct,E,A,A′}
     C::Ct
     E_1::E
     E_2::E
+    ket::A
+    bra::A′
 end
 
 """
@@ -104,4 +37,120 @@ function build_projectors(
         Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.ket, Q_next.bra
     )
     return P_left, P_right
+end
+
+"""
+    struct HalfInfiniteEnv{C,E,A,A′}
+
+Half-infinite CTMRG environment tensor storage.
+"""
+struct HalfInfiniteEnv{C,E,A,A′}
+    C_1::C
+    C_2::C
+    E_1::E
+    E_2::E
+    E_3::E
+    E_4::E
+    ket_1::A
+    bra_1::A′
+    ket_2::A
+    bra_2::A′
+end
+
+# Construct environment from two enlarged corners
+function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
+    return HalfInfiniteEnv(
+        quadrant1.C,
+        quadrant2.C,
+        quadrant1.E_1,
+        quadrant1.E_2,
+        quadrant2.E_1,
+        quadrant2.E_2,
+        quadrant1.ket_bra,
+        quadrant2.ket_bra,
+    )
+end
+
+"""
+    (env::HalfInfiniteEnv)() 
+    (env::HalfInfiniteEnv)(x) 
+
+Contract half-infinite environment without or with a vector `x`.
+"""
+function (env::HalfInfiniteEnv)()
+    return halfinfinite_environment(
+        env.C_1,
+        env.C_2,
+        env.E_1,
+        env.E_2,
+        env.E_3,
+        env.E_4,
+        env.ket_1,
+        env.ket_2,
+        env.bra_1,
+        env.bra_2,
+    )
+end
+function (env::HalfInfiniteEnv)(x)
+    return halfinfinite_environment(
+        env.C_1,
+        env.C_2,
+        env.E_1,
+        env.E_2,
+        env.E_3,
+        env.E_4,
+        x,
+        env.ket_1,
+        env.ket_2,
+        env.bra_1,
+        env.bra_2,
+    )
+end
+
+# TensorKit methods to make struct compatible with sparse SVD
+TensorKit.InnerProductStyle(::HalfInfiniteEnv) = EuclideanProduct()
+TensorKit.sectortype(::HalfInfiniteEnv) = Trivial
+TensorKit.storagetype(env::HalfInfiniteEnv) = storagetype(env.ket_1)
+TensorKit.spacetype(env::HalfInfiniteEnv) = spacetype(env.ket_1)
+
+function TensorKit.blocks(env::HalfInfiniteEnv)
+    return TensorKit.SingletonDict(Trivial() => env)
+end
+function TensorKit.blocksectors(::HalfInfiniteEnv)
+    return TensorKit.OneOrNoneIterator{Trivial}(true, Trivial())
+end
+
+function TensorKit.MatrixAlgebra.svd!(env::HalfInfiniteEnv, args...)
+    return TensorKit.MatrixAlgebra.svd!(env(), args...)
+end
+
+Base.eltype(env::HalfInfiniteEnv) = eltype(env.ket_1)
+function Base.size(env::HalfInfiniteEnv)  # Treat environment as matrix
+    χ_in = dim(space(env.E_1, 1))
+    D_inabove = dim(space(env.ket_1, 2))
+    D_inbelow = dim(space(env.bra_1, 2))
+    χ_out = dim(space(env.E_4, 1))
+    D_outabove = dim(space(env.ket_2, 2))
+    D_outbelow = dim(space(env.bra_2, 2))
+    return (χ_in * D_inabove * D_inbelow, χ_out * D_outabove * D_outbelow)
+end
+Base.size(env::HalfInfiniteEnv, i::Int) = size(env)[i]
+
+# TODO: implement VectorInterface
+VectorInterface.scalartype(env::HalfInfiniteEnv) = scalartype(env.ket_1)
+
+# Wrapper around halfinfinite_environment contraction using EnlargedCorners (used in ctmrg_projectors)
+function halfinfinite_environment(ec_1::EnlargedCorner, ec_2::EnlargedCorner)
+    return HalfInfiniteEnv(
+        ec_1.C,
+        ec_2.C,
+        ec_1.E_1,
+        ec_1.E_2,
+        ec_2.E_1,
+        ec_2.E_2,
+        ec_1.ket,
+        ec_2.ket,
+        ec_1.bra,
+        ec_2.bra,
+    )
 end

--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -103,9 +103,6 @@ struct PEPSOptimize{G}
         if gradient_alg isa GradMode
             if S === :sequential && iterscheme(gradient_alg) === :fixed
                 throw(ArgumentError(":sequential and :fixed are not compatible"))
-            elseif boundary_alg.projector_alg.svd_alg.fwd_alg isa IterSVD &&
-                iterscheme(gradient_alg) === :fixed
-                throw(ArgumentError("IterSVD and :fixed are currently not compatible"))
             end
         end
         return new{G}(boundary_alg, optimizer, reuse_env, gradient_alg)

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -105,6 +105,7 @@ function TensorKit._compute_svddata!(
             Udata[c] = U[:, 1:howmany]
             Vdata[c] = V[1:howmany, :]
         else
+            # TODO: find better initial guess that leads to element-wise convergence
             # x₀ = randn(eltype(b), size(b, 1))  # Leads to erroneous gauge fixing of U, S, V and thus failing element-wise conv.
             # u, = TensorKit.MatrixAlgebra.svd!(deepcopy(b), TensorKit.SVD())
             # x₀ = sum(u[:, i] for i in 1:howmany)  # Element-wise convergence works fine

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -36,9 +36,6 @@ PEPSKit.tsvd(t, alg; kwargs...) = PEPSKit.tsvd!(copy(t), alg; kwargs...)
 function PEPSKit.tsvd!(t, alg::SVDAdjoint; trunc::TruncationScheme=notrunc(), p::Real=2)
     return TensorKit.tsvd!(t; alg=alg.fwd_alg, trunc, p)
 end
-function TensorKit.tsvd!(f::HalfInfiniteEnv; trunc=NoTruncation(), p::Real=2, alg=IterSVD())
-    return _tsvd!(f, alg, trunc, p)
-end
 
 """
     struct FixedSVD
@@ -74,8 +71,8 @@ the iterative SVD didn't converge, the algorithm falls back to a dense SVD.
 end
 
 # TODO: find better initial guess that leads to element-wise convergence and is compatible with function handles
-function random_start_vector(f)
-    return randn(eltype(f), size(f, 1))  # Leads to erroneous gauge fixing of U, S, V and thus failing element-wise conv.
+function random_start_vector(t::Matrix)
+    return randn(eltype(t), size(t, 1))  # Leads to erroneous gauge fixing of U, S, V and thus failing element-wise conv.
     # u, = TensorKit.MatrixAlgebra.svd!(deepcopy(t), TensorKit.SVD())
     # return sum(u[:, i] for i in 1:howmany)  # Element-wise convergence works fine
     # return dropdims(sum(t[:, 1:3]; dims=2); dims=2)  # Summing too many columns also makes gauge fixing fail

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -70,13 +70,8 @@ the iterative SVD didn't converge, the algorithm falls back to a dense SVD.
     start_vector = random_start_vector
 end
 
-# TODO: find better initial guess that leads to element-wise convergence and is compatible with function handles
 function random_start_vector(t::Matrix)
-    return randn(eltype(t), size(t, 1))  # Leads to erroneous gauge fixing of U, S, V and thus failing element-wise conv.
-    # u, = TensorKit.MatrixAlgebra.svd!(deepcopy(t), TensorKit.SVD())
-    # return sum(u[:, i] for i in 1:howmany)  # Element-wise convergence works fine
-    # return dropdims(sum(t[:, 1:3]; dims=2); dims=2)  # Summing too many columns also makes gauge fixing fail
-    # return t[:, 1]  # Leads so slower convergence of SVD than randn, but correct element-wise convergence
+    return randn(eltype(t), size(t, 1))
 end
 
 # Compute SVD data block-wise using KrylovKit algorithm

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -105,7 +105,11 @@ function TensorKit._compute_svddata!(
             Udata[c] = U[:, 1:howmany]
             Vdata[c] = V[1:howmany, :]
         else
-            x₀ = randn(eltype(b), size(b, 1))
+            # x₀ = randn(eltype(b), size(b, 1))  # Leads to erroneous gauge fixing of U, S, V and thus failing element-wise conv.
+            # u, = TensorKit.MatrixAlgebra.svd!(deepcopy(b), TensorKit.SVD())
+            # x₀ = sum(u[:, i] for i in 1:howmany)  # Element-wise convergence works fine
+            # x₀ = dropdims(sum(b[:, 1:3]; dims=2); dims=2)  # Summing too many columns also makes gauge fixing fail
+            x₀ = b[:, 1]  # Leads so slower convergence of SVD than randn, but correct element-wise convergence
             S, lvecs, rvecs, info = KrylovKit.svdsolve(b, x₀, howmany, :LR, alg.alg)
             if info.converged < howmany  # Fall back to dense SVD if not properly converged
                 @warn "Iterative SVD did not converge for block $c, falling back to dense SVD"

--- a/test/ctmrg/fixed_iterscheme.jl
+++ b/test/ctmrg/fixed_iterscheme.jl
@@ -13,7 +13,7 @@ using PEPSKit:
 # initialize parameters
 χbond = 2
 χenv = 16
-svd_algs = [SVDAdjoint(; fwd_alg=TensorKit.SVD())]  #, SVDAdjoint(; fwd_alg=IterSVD())]
+svd_algs = [SVDAdjoint(; fwd_alg=TensorKit.SVD()), SVDAdjoint(; fwd_alg=IterSVD())]
 unitcells = [(1, 1), (3, 4)]
 
 # test for element-wise convergence after application of fixed step

--- a/test/ctmrg/fixed_iterscheme.jl
+++ b/test/ctmrg/fixed_iterscheme.jl
@@ -1,5 +1,6 @@
 using Test
 using Random
+using LinearAlgebra
 using TensorKit, KrylovKit
 using PEPSKit
 using PEPSKit:
@@ -66,7 +67,6 @@ end
     psi = InfinitePEPS(2, χbond)
     env_init = CTMRGEnv(psi, ComplexSpace(χenv))
     env_conv1 = leading_boundary(env_init, psi, ctm_alg_iter)
-    # env_conv1 = leading_boundary(env_init, psi, ctm_alg_full);
 
     # do extra iteration to get SVD
     env_conv2_iter, info_iter = ctmrg_iter(psi, env_conv1, ctm_alg_iter)
@@ -94,12 +94,10 @@ end
     env_fixedsvd_iter, = ctmrg_iter(psi, env_conv1, ctm_alg_fix_iter)
     env_fixedsvd_iter = fix_global_phases(env_conv1, env_fixedsvd_iter)
     @test calc_elementwise_convergence(env_conv1, env_fixedsvd_iter) ≈ 0 atol = 1e-6  # This doesn't work for x₀ = rand(size(b, 1))?
-    # @show calc_elementwise_convergence(env_conv1, env_fixedsvd_iter)
 
     env_fixedsvd_full, = ctmrg_iter(psi, env_conv1, ctm_alg_fix_full)
     env_fixedsvd_full = fix_global_phases(env_conv1, env_fixedsvd_full)
     @test calc_elementwise_convergence(env_conv1, env_fixedsvd_full) ≈ 0 atol = 1e-6
-    # @show calc_elementwise_convergence(env_conv1, env_fixedsvd_full)
 
     # check matching decompositions
     atol = 1e-12

--- a/test/ctmrg/svd_wrapper.jl
+++ b/test/ctmrg/svd_wrapper.jl
@@ -100,7 +100,7 @@ ctm_alg = CTMRG(; tol=1e-10, verbosity=2, svd_alg=SVDAdjoint())
 Random.seed!(91283219347)
 H = heisenberg_XYZ(InfiniteSquare())
 psi = InfinitePEPS(2, χbond)
-env = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg)
+env = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg);
 hienv = HalfInfiniteEnv(
     env.corners[1],
     env.corners[2],
@@ -114,12 +114,27 @@ hienv = HalfInfiniteEnv(
     psi[1],
 )
 hienv_dense = hienv()
-env_R = TensorMap(randn, space(hienv_dense))
-PEPSKit.tsvd!(hienv, iter_alg)
+env_R = TensorMap(randn, space(hienv))
+
+PEPSKit.tsvd!(hienv, iter_alg)  # TODO: make the space mismatches work
 
 @testset "IterSVD with HalfInfiniteEnv function handle" begin
-    l_fullsvd, g_fullsvd = withgradient(A -> lossfun(A, full_alg, env_R), hienv_dense)
-    l_itersvd, g_itersvd = withgradient(A -> lossfun(A, iter_alg, env_R), hienv)
-    @test l_itersvd ≈ l_fullsvd
-    @test g_fullsvd[1] ≈ g_itersvd[1] rtol = rtol
+    # Equivalence of dense and sparse contractions
+    x₀ = PEPSKit.random_start_vector(hienv)
+    x′ = hienv(x₀, Val(false))
+    x″ = hienv(x′, Val(true))
+    x‴ = hienv(x″, Val(false))
+
+    a = hienv_dense * x₀
+    b = hienv_dense' * a
+    c = hienv_dense * b
+    @test a ≈ x′
+    @test b ≈ x″
+    @test c ≈ x‴
+
+    # TODO: code up pullback
+    # l_fullsvd, g_fullsvd = withgradient(A -> lossfun(A, full_alg, env_R), hienv_dense)
+    # l_itersvd, g_itersvd = withgradient(A -> lossfun(A, iter_alg, env_R), hienv)
+    # @test l_itersvd ≈ l_fullsvd
+    # @test g_fullsvd[1] ≈ g_itersvd[1] rtol = rtol
 end

--- a/test/ctmrg/svd_wrapper.jl
+++ b/test/ctmrg/svd_wrapper.jl
@@ -6,7 +6,7 @@ using KrylovKit
 using ChainRulesCore, Zygote
 using Accessors
 using PEPSKit
-using PEPSKit: HalfInfiniteEnv
+# using PEPSKit: HalfInfiniteEnv
 
 # Gauge-invariant loss function
 function lossfun(A, alg, R=TensorMap(randn, space(A)), trunc=notrunc())
@@ -94,47 +94,47 @@ symm_R = TensorMap(randn, dtype, space(symm_r))
     @test g_fullsvd_tr[1] ≈ g_itersvd_fb[1] rtol = rtol
 end
 
-χbond = 2
-χenv = 6
-ctm_alg = CTMRG(; tol=1e-10, verbosity=2, svd_alg=SVDAdjoint())
-Random.seed!(91283219347)
-H = heisenberg_XYZ(InfiniteSquare())
-psi = InfinitePEPS(2, χbond)
-env = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg);
-hienv = HalfInfiniteEnv(
-    env.corners[1],
-    env.corners[2],
-    env.edges[4],
-    env.edges[1],
-    env.edges[1],
-    env.edges[2],
-    psi[1],
-    psi[1],
-    psi[1],
-    psi[1],
-)
-hienv_dense = hienv()
-env_R = TensorMap(randn, space(hienv))
+# TODO: Add when IterSVD is implemented for HalfInfiniteEnv
+# χbond = 2
+# χenv = 6
+# ctm_alg = CTMRG(; tol=1e-10, verbosity=2, svd_alg=SVDAdjoint())
+# Random.seed!(91283219347)
+# H = heisenberg_XYZ(InfiniteSquare())
+# psi = InfinitePEPS(2, χbond)
+# env = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg);
+# hienv = HalfInfiniteEnv(
+#     env.corners[1],
+#     env.corners[2],
+#     env.edges[4],
+#     env.edges[1],
+#     env.edges[1],
+#     env.edges[2],
+#     psi[1],
+#     psi[1],
+#     psi[1],
+#     psi[1],
+# )
+# hienv_dense = hienv()
+# env_R = TensorMap(randn, space(hienv))
 
-PEPSKit.tsvd!(hienv, iter_alg)  # TODO: make the space mismatches work
+# PEPSKit.tsvd!(hienv, iter_alg)
 
-@testset "IterSVD with HalfInfiniteEnv function handle" begin
-    # Equivalence of dense and sparse contractions
-    x₀ = PEPSKit.random_start_vector(hienv)
-    x′ = hienv(x₀, Val(false))
-    x″ = hienv(x′, Val(true))
-    x‴ = hienv(x″, Val(false))
+# @testset "IterSVD with HalfInfiniteEnv function handle" begin
+#     # Equivalence of dense and sparse contractions
+#     x₀ = PEPSKit.random_start_vector(hienv)
+#     x′ = hienv(x₀, Val(false))
+#     x″ = hienv(x′, Val(true))
+#     x‴ = hienv(x″, Val(false))
 
-    a = hienv_dense * x₀
-    b = hienv_dense' * a
-    c = hienv_dense * b
-    @test a ≈ x′
-    @test b ≈ x″
-    @test c ≈ x‴
+#     a = hienv_dense * x₀
+#     b = hienv_dense' * a
+#     c = hienv_dense * b
+#     @test a ≈ x′
+#     @test b ≈ x″
+#     @test c ≈ x‴
 
-    # TODO: code up pullback
-    # l_fullsvd, g_fullsvd = withgradient(A -> lossfun(A, full_alg, env_R), hienv_dense)
-    # l_itersvd, g_itersvd = withgradient(A -> lossfun(A, iter_alg, env_R), hienv)
-    # @test l_itersvd ≈ l_fullsvd
-    # @test g_fullsvd[1] ≈ g_itersvd[1] rtol = rtol
-end
+#     # l_fullsvd, g_fullsvd = withgradient(A -> lossfun(A, full_alg, env_R), hienv_dense)
+#     # l_itersvd, g_itersvd = withgradient(A -> lossfun(A, iter_alg, env_R), hienv)
+#     # @test l_itersvd ≈ l_fullsvd
+#     # @test g_fullsvd[1] ≈ g_itersvd[1] rtol = rtol
+# end

--- a/test/heisenberg.jl
+++ b/test/heisenberg.jl
@@ -27,7 +27,7 @@ opt_alg = PEPSOptimize(;
 Random.seed!(91283219347)
 H = heisenberg_XYZ(InfiniteSquare())
 psi_init = InfinitePEPS(2, χbond)
-env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg)
+env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg);
 
 # find fixedpoint
 result = fixedpoint(psi_init, H, opt_alg, env_init)


### PR DESCRIPTION
In this PR we will use function handles to perform the iterative SVD of the half-infinite environment in CTMRG. To that end, a struct will be implemented that stores all necessary tensors for the environment contraction and on which `tsvd!` can dispatch.

Before doing that, a long-standing issue will be resolved where `IterSVD` would lead to singular vectors which, when supplied to `FixedSVD`, would not lead to element-wise converged environments and thereby making it not possible to use the iterative SVD during PEPS optimization.