### PR TITLE
Fix CTMRG `miniter` and `Accessors.@set`

### DIFF
--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -118,7 +118,7 @@ function MPSKit.leading_boundary(envinit, state, alg::CTMRG)
             N = norm(state, env)
             ctmrg_logiter!(log, iter, η, N)
 
-            if η ≤ alg.tol
+            if η ≤ alg.tol && iter ≥ alg.miniter
                 ctmrg_logfinish!(log, iter, η, N)
                 break
             end

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -91,6 +91,9 @@ ctmrgscheme(::CTMRG{S}) where {S} = S
 const SequentialCTMRG = CTMRG{:sequential}
 const SimultaneousCTMRG = CTMRG{:simultaneous}
 
+# supply correct constructor for Accessors.@set
+Accessors.constructorof(::Type{CTMRG{S}}) where {S} = CTMRG{S}
+
 """
     MPSKit.leading_boundary([envinit], state, alg::CTMRG)
 


### PR DESCRIPTION
This small PR will fix two small things:
1. The `miniter` condition didn't work anymore in `leading_boundary` runs
2. Using the `@set` macro from Accessors.jl for the CTMRG struct wouldn't work due to the type parameter