### PR TITLE
Improve default SVD `rrule_alg`

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -62,6 +62,7 @@ Module containing default values that represent typical algorithm parameters.
 - `ctmrg_tol = 1e-12`: Tolerance checking singular value and norm convergence
 - `fpgrad_maxiter = 100`: Maximal number of iterations for computing the CTMRG fixed-point gradient
 - `fpgrad_tol = 1e-6`: Convergence tolerance for the fixed-point gradient iteration
+- `rrule_alg = Arnoldi(; tol=1e1ctmrg_tol, krylovdim=48, verbosity=-1)`: Default cotangent linear problem algorithm
 """
 module Defaults
     using TensorKit, KrylovKit, OptimKit
@@ -76,7 +77,7 @@ module Defaults
     const trscheme = FixedSpaceTruncation()
     const iterscheme = :fixed
     const fwd_alg = TensorKit.SVD()
-    const rrule_alg = GMRES(; tol=1e1ctmrg_tol)
+    const rrule_alg = Arnoldi(; tol=1e-2fpgrad_tol, krylovdim=48, verbosity=-1)
     const svd_alg = SVDAdjoint(; fwd_alg, rrule_alg)
     const optimizer = LBFGS(32; maxiter=100, gradtol=1e-4, verbosity=2)
     const gradient_linsolver = KrylovKit.BiCGStab(;


### PR DESCRIPTION
This PR will change the default SVD cotangent problem `rrule_alg` to `Arnoldi`.

After some benchmarking, `Arnoldi` has turned out to be the fastest algorithm in many cases (as compared to `GMRES` and `BiCGStab`). The Krylov dimension has to be chosen according to the chosen environment dimension, so this has to be adapted to the specific problems anyway; but choosing a reasonably large dimension will ensure less warnings and better convergence, usually. To really get rid of the warnings by default (since they turn out to be non-crucial in most cases), I set `verbosity=-1`.