### PR TITLE
Change default SVD algorithm to `SDD` and update tests

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -78,7 +78,7 @@ module Defaults
     const reuse_env = true
     const trscheme = FixedSpaceTruncation()
     const iterscheme = :fixed
-    const fwd_alg = TensorKit.SVD()
+    const fwd_alg = TensorKit.SDD()
     const rrule_alg = Arnoldi(; tol=1e-2fpgrad_tol, krylovdim=48, verbosity=-1)
     const svd_alg = SVDAdjoint(; fwd_alg, rrule_alg)
     const optimizer = LBFGS(32; maxiter=100, gradtol=1e-4, verbosity=2)

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -103,8 +103,8 @@ function MPSKit.leading_boundary(state, alg::CTMRG)
     return MPSKit.leading_boundary(CTMRGEnv(state, oneunit(spacetype(state))), state, alg)
 end
 function MPSKit.leading_boundary(envinit, state, alg::CTMRG)
-    CS = map(x -> tsvd(x; alg=TensorKit.SVD())[2], envinit.corners)
-    TS = map(x -> tsvd(x; alg=TensorKit.SVD())[2], envinit.edges)
+    CS = map(x -> tsvd(x)[2], envinit.corners)
+    TS = map(x -> tsvd(x)[2], envinit.edges)
 
     η = one(real(scalartype(state)))
     N = norm(state, envinit)

--- a/src/algorithms/ctmrg/gaugefix.jl
+++ b/src/algorithms/ctmrg/gaugefix.jl
@@ -160,10 +160,10 @@ function _singular_value_distance((S₁, S₂))
 end
 
 function calc_convergence(envs, CSold, TSold)
-    CSnew = map(x -> tsvd(x; alg=TensorKit.SVD())[2], envs.corners)
+    CSnew = map(x -> tsvd(x)[2], envs.corners)
     ΔCS = maximum(_singular_value_distance, zip(CSold, CSnew))
 
-    TSnew = map(x -> tsvd(x; alg=TensorKit.SVD())[2], envs.edges)
+    TSnew = map(x -> tsvd(x)[2], envs.edges)
     ΔTS = maximum(_singular_value_distance, zip(TSold, TSnew))
 
     @debug "maxᵢ|Cⁿ⁺¹ - Cⁿ|ᵢ = $ΔCS   maxᵢ|Tⁿ⁺¹ - Tⁿ|ᵢ = $ΔTS"

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -104,7 +104,7 @@ function TensorKit._compute_svddata!(
         howmany = trunc isa NoTruncation ? minimum(size(b)) : blockdim(trunc.space, c)
 
         if howmany / minimum(size(b)) > alg.fallback_threshold  # Use dense SVD for small blocks
-            U, S, V = TensorKit.MatrixAlgebra.svd!(b, TensorKit.SVD())
+            U, S, V = TensorKit.MatrixAlgebra.svd!(b, TensorKit.SDD())
             Udata[c] = U[:, 1:howmany]
             Vdata[c] = V[1:howmany, :]
         else
@@ -112,7 +112,7 @@ function TensorKit._compute_svddata!(
             S, lvecs, rvecs, info = KrylovKit.svdsolve(b, x₀, howmany, :LR, alg.alg)
             if info.converged < howmany  # Fall back to dense SVD if not properly converged
                 @warn "Iterative SVD did not converge for block $c, falling back to dense SVD"
-                U, S, V = TensorKit.MatrixAlgebra.svd!(b, TensorKit.SVD())
+                U, S, V = TensorKit.MatrixAlgebra.svd!(b, TensorKit.SDD())
                 Udata[c] = U[:, 1:howmany]
                 Vdata[c] = V[1:howmany, :]
             else  # Slice in case more values were converged than requested

--- a/test/ctmrg/ctmrgschemes.jl
+++ b/test/ctmrg/ctmrgschemes.jl
@@ -26,8 +26,8 @@ unitcells = [(1, 1), (3, 4)]
     @test abs(norm(psi, env_sequential)) ≈ abs(norm(psi, env_simultaneous)) rtol = 1e-6
 
     # compare singular values
-    CS_sequential = map(c -> tsvd(c; alg=TensorKit.SVD())[2], env_sequential.corners)
-    CS_simultaneous = map(c -> tsvd(c; alg=TensorKit.SVD())[2], env_simultaneous.corners)
+    CS_sequential = map(c -> tsvd(c)[2], env_sequential.corners)
+    CS_simultaneous = map(c -> tsvd(c)[2], env_simultaneous.corners)
     ΔCS = maximum(zip(CS_sequential, CS_simultaneous)) do (c_lm, c_as)
         smallest = infimum(MPSKit._firstspace(c_lm), MPSKit._firstspace(c_as))
         e_old = isometry(MPSKit._firstspace(c_lm), smallest)
@@ -36,8 +36,8 @@ unitcells = [(1, 1), (3, 4)]
     end
     @test ΔCS < 1e-2
 
-    TS_sequential = map(t -> tsvd(t; alg=TensorKit.SVD())[2], env_sequential.edges)
-    TS_simultaneous = map(t -> tsvd(t; alg=TensorKit.SVD())[2], env_simultaneous.edges)
+    TS_sequential = map(t -> tsvd(t)[2], env_sequential.edges)
+    TS_simultaneous = map(t -> tsvd(t)[2], env_simultaneous.edges)
     ΔTS = maximum(zip(TS_sequential, TS_simultaneous)) do (t_lm, t_as)
         MPSKit._firstspace(t_lm) == MPSKit._firstspace(t_as) || return scalartype(t_lm)(Inf)
         return norm(t_as - t_lm)

--- a/test/ctmrg/ctmrgschemes.jl
+++ b/test/ctmrg/ctmrgschemes.jl
@@ -7,8 +7,8 @@ using PEPSKit
 # initialize parameters
 χbond = 2
 χenv = 16
-ctm_alg_sequential = CTMRG(; tol=1e-10, verbosity=2, ctmrgscheme=:sequential)
-ctm_alg_simultaneous = CTMRG(; tol=1e-10, verbosity=2, ctmrgscheme=:simultaneous)
+ctm_alg_sequential = CTMRG(; ctmrgscheme=:sequential)
+ctm_alg_simultaneous = CTMRG(; ctmrgscheme=:simultaneous)
 unitcells = [(1, 1), (3, 4)]
 
 @testset "$(unitcell) unit cell" for unitcell in unitcells

--- a/test/ctmrg/fixed_iterscheme.jl
+++ b/test/ctmrg/fixed_iterscheme.jl
@@ -22,7 +22,7 @@ unitcells = [(1, 1), (3, 4)]
                                                                    Iterators.product(
     unitcells, svd_algs
 )
-    ctm_alg = CTMRG(; tol=1e-12, verbosity=2, ctmrgscheme=:simultaneous, svd_alg)
+    ctm_alg = CTMRG(; svd_alg)
 
     # initialize states
     Random.seed!(2394823842)
@@ -37,9 +37,7 @@ unitcells = [(1, 1), (3, 4)]
     # fix gauge of SVD
     U_fix, V_fix = fix_relative_phases(info.U, info.V, signs)
     svd_alg_fix = SVDAdjoint(; fwd_alg=FixedSVD(U_fix, info.S, V_fix))
-    ctm_alg_fix = CTMRG(;
-        svd_alg=svd_alg_fix, trscheme=notrunc(), ctmrgscheme=:simultaneous
-    )
+    ctm_alg_fix = CTMRG(; svd_alg=svd_alg_fix, trscheme=notrunc())
 
     # do iteration with FixedSVD
     env_fixedsvd, = ctmrg_iter(psi, env_conv1, ctm_alg_fix)
@@ -49,18 +47,10 @@ end
 
 @testset "Element-wise consistency of TensorKit.SDD and IterSVD" begin
     ctm_alg_iter = CTMRG(;
-        tol=1e-12,
         maxiter=200,
-        verbosity=2,
-        ctmrgscheme=:simultaneous,
         svd_alg=SVDAdjoint(; fwd_alg=IterSVD(; alg=GKL(; tol=1e-14, krylovdim=χenv + 10))),
     )
-    ctm_alg_full = CTMRG(;
-        tol=1e-12,
-        verbosity=2,
-        ctmrgscheme=:simultaneous,
-        svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SDD()),
-    )
+    ctm_alg_full = CTMRG(; svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SDD()))
 
     # initialize states
     Random.seed!(91283219347)
@@ -80,15 +70,11 @@ end
     # fix gauge of SVD
     U_fix_iter, V_fix_iter = fix_relative_phases(info_iter.U, info_iter.V, signs_iter)
     svd_alg_fix_iter = SVDAdjoint(; fwd_alg=FixedSVD(U_fix_iter, info_iter.S, V_fix_iter))
-    ctm_alg_fix_iter = CTMRG(;
-        svd_alg=svd_alg_fix_iter, trscheme=notrunc(), ctmrgscheme=:simultaneous
-    )
+    ctm_alg_fix_iter = CTMRG(; svd_alg=svd_alg_fix_iter, trscheme=notrunc())
 
     U_fix_full, V_fix_full = fix_relative_phases(info_full.U, info_full.V, signs_full)
     svd_alg_fix_full = SVDAdjoint(; fwd_alg=FixedSVD(U_fix_full, info_full.S, V_fix_full))
-    ctm_alg_fix_full = CTMRG(;
-        svd_alg=svd_alg_fix_full, trscheme=notrunc(), ctmrgscheme=:simultaneous
-    )
+    ctm_alg_fix_full = CTMRG(; svd_alg=svd_alg_fix_full, trscheme=notrunc())
 
     # do iteration with FixedSVD
     env_fixedsvd_iter, = ctmrg_iter(psi, env_conv1, ctm_alg_fix_iter)

--- a/test/ctmrg/fixed_iterscheme.jl
+++ b/test/ctmrg/fixed_iterscheme.jl
@@ -14,7 +14,7 @@ using PEPSKit:
 # initialize parameters
 χbond = 2
 χenv = 16
-svd_algs = [SVDAdjoint(; fwd_alg=TensorKit.SVD()), SVDAdjoint(; fwd_alg=IterSVD())]
+svd_algs = [SVDAdjoint(; fwd_alg=TensorKit.SDD()), SVDAdjoint(; fwd_alg=IterSVD())]
 unitcells = [(1, 1), (3, 4)]
 
 # test for element-wise convergence after application of fixed step
@@ -47,7 +47,7 @@ unitcells = [(1, 1), (3, 4)]
     @test calc_elementwise_convergence(env_conv1, env_fixedsvd) ≈ 0 atol = 1e-6
 end
 
-@testset "Element-wise consistency of TensorKit.SVD and IterSVD" begin
+@testset "Element-wise consistency of TensorKit.SDD and IterSVD" begin
     ctm_alg_iter = CTMRG(;
         tol=1e-12,
         maxiter=200,
@@ -59,7 +59,7 @@ end
         tol=1e-12,
         verbosity=2,
         ctmrgscheme=:simultaneous,
-        svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SVD()),
+        svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SDD()),
     )
 
     # initialize states

--- a/test/ctmrg/gaugefix.jl
+++ b/test/ctmrg/gaugefix.jl
@@ -7,10 +7,10 @@ using PEPSKit: ctmrg_iter, gauge_fix, calc_elementwise_convergence
 
 scalartypes = [Float64, ComplexF64]
 unitcells = [(1, 1), (2, 2), (3, 2)]
+maxiter = 200
 schemes = [:simultaneous, :sequential]
 χ = 6
 atol = 1e-4
-verbosity = 2
 
 function _make_symmetric!(psi)
     if ==(size(psi)...)
@@ -50,9 +50,7 @@ end
     Random.seed!(987654321)  # Seed RNG to make random environment consistent
     ctm = CTMRGEnv(psi, ctm_space)
 
-    alg = CTMRG(;
-        tol=1e-10, maxiter=200, verbosity, trscheme=FixedSpaceTruncation(), ctmrgscheme
-    )
+    alg = CTMRG(; maxiter, ctmrgscheme)
 
     ctm = leading_boundary(ctm, psi, alg)
     ctm2, = ctmrg_iter(psi, ctm, alg)
@@ -76,9 +74,7 @@ end
     psi = InfinitePEPS(physical_space, peps_space; unitcell)
     ctm = CTMRGEnv(psi, ctm_space)
 
-    alg = CTMRG(;
-        tol=1e-10, maxiter=200, verbosity, trscheme=FixedSpaceTruncation(), ctmrgscheme
-    )
+    alg = CTMRG(; maxiter, ctmrgscheme)
 
     ctm = leading_boundary(ctm, psi, alg)
     ctm2, = ctmrg_iter(psi, ctm, alg)

--- a/test/ctmrg/gradients.jl
+++ b/test/ctmrg/gradients.jl
@@ -18,8 +18,8 @@ names = ["Heisenberg", "p-wave superconductor"]
 
 gradtol = 1e-4
 boundary_algs = [
-    CTMRG(; tol=1e-10, verbosity=0, ctmrgscheme=:simultaneous),
-    CTMRG(; tol=1e-10, verbosity=0, ctmrgscheme=:sequential),
+    CTMRG(; verbosity=0, ctmrgscheme=:simultaneous),
+    CTMRG(; verbosity=0, ctmrgscheme=:sequential),
 ]
 gradmodes = [
     [
@@ -28,14 +28,14 @@ gradmodes = [
         GeomSum(; tol=gradtol, iterscheme=:diffgauge),
         ManualIter(; tol=gradtol, iterscheme=:fixed),
         ManualIter(; tol=gradtol, iterscheme=:diffgauge),
-        LinSolver(; solver=KrylovKit.GMRES(; tol=gradtol), iterscheme=:fixed),
-        LinSolver(; solver=KrylovKit.GMRES(; tol=gradtol), iterscheme=:diffgauge),
+        LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:fixed),
+        LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:diffgauge),
     ],
     [  # Only use :diffgauge due to high gauge-sensitivity (perhaps due to small χenv?)
         nothing,
         GeomSum(; tol=gradtol, iterscheme=:diffgauge),
         ManualIter(; tol=gradtol, iterscheme=:diffgauge),
-        LinSolver(; solver=KrylovKit.GMRES(; tol=gradtol), iterscheme=:diffgauge),
+        LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:diffgauge),
     ],
 ]
 steps = -0.01:0.005:0.01

--- a/test/ctmrg/svd_wrapper.jl
+++ b/test/ctmrg/svd_wrapper.jl
@@ -26,7 +26,7 @@ R = TensorMap(randn, space(r))
 
 full_alg = SVDAdjoint(; rrule_alg=nothing)
 old_alg = SVDAdjoint(; rrule_alg=NonTruncSVDAdjoint(), broadening=0.0)
-iter_alg = SVDAdjoint(; fwd_alg=IterSVD(), rrule_alg=GMRES(; tol=1e-13))  # Don't make adjoint tolerance too small, g_itersvd will be weird
+iter_alg = SVDAdjoint(; fwd_alg=IterSVD())
 
 @testset "Non-truncacted SVD" begin
     l_fullsvd, g_fullsvd = withgradient(A -> lossfun(A, full_alg, R), r)

--- a/test/ctmrg/svd_wrapper.jl
+++ b/test/ctmrg/svd_wrapper.jl
@@ -24,10 +24,8 @@ Random.seed!(123456789)
 r = TensorMap(randn, dtype, ℂ^m, ℂ^n)
 R = TensorMap(randn, space(r))
 
-full_alg = SVDAdjoint(; fwd_alg=TensorKit.SVD(), rrule_alg=nothing)
-old_alg = SVDAdjoint(;
-    fwd_alg=TensorKit.SVD(), rrule_alg=NonTruncSVDAdjoint(), broadening=0.0
-)
+full_alg = SVDAdjoint(; rrule_alg=nothing)
+old_alg = SVDAdjoint(; rrule_alg=NonTruncSVDAdjoint(), broadening=0.0)
 iter_alg = SVDAdjoint(; fwd_alg=IterSVD(), rrule_alg=GMRES(; tol=1e-13))  # Don't make adjoint tolerance too small, g_itersvd will be weird
 
 @testset "Non-truncacted SVD" begin

--- a/test/heisenberg.jl
+++ b/test/heisenberg.jl
@@ -8,25 +8,16 @@ using OptimKit
 # initialize parameters
 χbond = 2
 χenv = 16
-ctm_alg = CTMRG(;
-    tol=1e-10,
-    miniter=4,
-    maxiter=100,
-    verbosity=2,
-    ctmrgscheme=:simultaneous,
-)
+ctm_alg = CTMRG()
 opt_alg = PEPSOptimize(;
-    boundary_alg=ctm_alg,
-    optimizer=LBFGS(4; maxiter=100, gradtol=1e-3, verbosity=2),
-    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-6), iterscheme=:fixed),
-    reuse_env=true,
+    boundary_alg=ctm_alg, optimizer=LBFGS(4; gradtol=1e-3, verbosity=2)
 )
 
 # initialize states
 Random.seed!(91283219347)
 H = heisenberg_XYZ(InfiniteSquare())
 psi_init = InfinitePEPS(2, χbond)
-env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg);
+env_init = leading_boundary(CTMRGEnv(psi_init, ComplexSpace(χenv)), psi_init, ctm_alg)
 
 # find fixedpoint
 result = fixedpoint(psi_init, H, opt_alg, env_init)

--- a/test/heisenberg.jl
+++ b/test/heisenberg.jl
@@ -13,7 +13,6 @@ ctm_alg = CTMRG(;
     miniter=4,
     maxiter=100,
     verbosity=2,
-    svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SVD(), rrule_alg=GMRES(; tol=1e-10)),
     ctmrgscheme=:simultaneous,
 )
 opt_alg = PEPSOptimize(;

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -13,7 +13,6 @@ ctm_alg = CTMRG(;
     miniter=4,
     maxiter=100,
     verbosity=2,
-    svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SVD(), rrule_alg=GMRES(; tol=1e-10)),
     ctmrgscheme=:simultaneous,
 )
 opt_alg = PEPSOptimize(;

--- a/test/j1j2_model.jl
+++ b/test/j1j2_model.jl
@@ -7,19 +7,12 @@ using OptimKit
 
 # initialize parameters
 χbond = 2
-χenv = 16
-ctm_alg = CTMRG(;
-    tol=1e-10,
-    miniter=4,
-    maxiter=100,
-    verbosity=2,
-    ctmrgscheme=:simultaneous,
-)
+χenv = 12
+ctm_alg = CTMRG()
 opt_alg = PEPSOptimize(;
     boundary_alg=ctm_alg,
-    optimizer=LBFGS(4; maxiter=100, gradtol=1e-3, verbosity=2),
-    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-6), iterscheme=:diffgauge),
-    reuse_env=true,
+    optimizer=LBFGS(4; gradtol=1e-3, verbosity=2),
+    gradient_alg=LinSolver(; iterscheme=:diffgauge),
 )
 
 # initialize states

--- a/test/pwave.jl
+++ b/test/pwave.jl
@@ -10,18 +10,9 @@ unitcell = (2, 2)
 H = pwave_superconductor(InfiniteSquare(unitcell...))
 χbond = 2
 χenv = 16
-ctm_alg = CTMRG(;
-    tol=1e-8,
-    maxiter=150,
-    verbosity=2,
-    ctmrgscheme=:simultaneous,
-    svd_alg=SVDAdjoint(; rrule_alg=Arnoldi(; tol=1e-9, krylovdim=χenv + 30)),
-)
+ctm_alg = CTMRG(; maxiter=150)
 opt_alg = PEPSOptimize(;
-    boundary_alg=ctm_alg,
-    optimizer=LBFGS(4; maxiter=10, gradtol=1e-3, verbosity=2),
-    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-3, maxiter=2), iterscheme=:diffgauge),
-    reuse_env=true,
+    boundary_alg=ctm_alg, optimizer=LBFGS(4; maxiter=10, gradtol=1e-3, verbosity=2)
 )
 
 # initialize states

--- a/test/tf_ising.jl
+++ b/test/tf_ising.jl
@@ -19,17 +19,9 @@ mˣ = 0.91
 # initialize parameters
 χbond = 2
 χenv = 16
-ctm_alg = CTMRG(;
-    tol=1e-10,
-    miniter=4,
-    maxiter=100,
-    verbosity=2,
-)
+ctm_alg = CTMRG()
 opt_alg = PEPSOptimize(;
-    boundary_alg=ctm_alg,
-    optimizer=LBFGS(4; maxiter=100, gradtol=1e-3, verbosity=2),
-    gradient_alg=LinSolver(; solver=GMRES(; tol=1e-6)),
-    reuse_env=true,
+    boundary_alg=ctm_alg, optimizer=LBFGS(4; gradtol=1e-3, verbosity=2)
 )
 
 # initialize states

--- a/test/tf_ising.jl
+++ b/test/tf_ising.jl
@@ -24,7 +24,6 @@ ctm_alg = CTMRG(;
     miniter=4,
     maxiter=100,
     verbosity=2,
-    svd_alg=SVDAdjoint(; fwd_alg=TensorKit.SVD(), rrule_alg=GMRES(; tol=1e-10)),
 )
 opt_alg = PEPSOptimize(;
     boundary_alg=ctm_alg,


### PR DESCRIPTION
This PR will change the default SVD algorithm to `TensorKit.SDD` since this generally outperforms `TensorKit.SVD` and is used as the default algorithm in TensorKit (and Base uses `gesdd`). Since this anyways modifies many tests, I will update the tests such that they all use the updated `Defaults` to the fullest possible extent. 