### PR TITLE
Remove CTMRG redundant logging

### DIFF
--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -115,10 +115,8 @@ function MPSKit.leading_boundary(envinit, state, alg::CTMRG)
         ctmrg_loginit!(log, η, N)
         for iter in 1:(alg.maxiter)
             env, = ctmrg_iter(state, env, alg)  # Grow and renormalize in all 4 directions
-
             η, CS, TS = calc_convergence(env, CS, TS)
             N = norm(state, env)
-            ctmrg_logiter!(log, iter, η, N)
 
             if η ≤ alg.tol && iter ≥ alg.miniter
                 ctmrg_logfinish!(log, iter, η, N)


### PR DESCRIPTION
This PR removes a line of redundant logging in the `leading_boundary` function. 