### PR TITLE
Warn in case of real environments in `:fixed` mode

### DIFF
--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -145,10 +145,10 @@ function fixedpoint(
     ψ₀::InfinitePEPS{F},
     H,
     alg::PEPSOptimize,
-    env₀::CTMRGEnv{C,T}=CTMRGEnv(ψ₀, field(F)^20);
+    env₀::CTMRGEnv=CTMRGEnv(ψ₀, field(F)^20);
     (finalize!)=OptimKit._finalize!,
     symmetrization=nothing,
-) where {F,C,T}
+) where {F}
     if isnothing(symmetrization)
         retract = peps_retract
     else
@@ -157,8 +157,8 @@ function fixedpoint(
         finalize! = (x, f, g, numiter) -> fin!(symm_finalize!(x, f, g, numiter)..., numiter)
     end
 
-    if scalartype(C) <: Real || scalartype(T) <: Real
-        env₀ = CTMRGEnv(complex.(env₀.corners), complex.(env₀.edges))
+    if scalartype(env₀) <: Real
+        env₀ = complex(env₀)
         @warn "the provided real environment was converted to a complex environment since\
         :fixed mode generally produces complex gauges; use :diffgauge mode instead to work\
         with purely real environments"

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -380,6 +380,9 @@ function eachcoordinate(x::CTMRGEnv, dirs)
     return collect(Iterators.product(dirs, axes(x, 2), axes(x, 3)))
 end
 
+Base.real(env::CTMRGEnv) = CTMRGEnv(real.(env.corners), real.(env.edges))
+Base.complex(env::CTMRGEnv) = CTMRGEnv(complex.(env.corners), complex.(env.edges))
+
 # In-place update of environment
 function update!(env::CTMRGEnv{C,T}, env´::CTMRGEnv{C,T}) where {C,T}
     env.corners .= env´.corners


### PR DESCRIPTION
Catches the issue with real-valued environments and the `fixed` optimization mode, detected in #100. Thanks to @Yue-Zhengyuan for finding this!