### PR TITLE
Add eigsolve-style rrule for CTMRG fixed-point gradient

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -190,7 +190,7 @@ export FixedSpaceTruncation, HalfInfiniteProjector, FullInfiniteProjector
 export LocalOperator
 export expectation_value, costfun, product_peps, correlation_length
 export leading_boundary
-export PEPSOptimize, GeomSum, ManualIter, LinSolver
+export PEPSOptimize, GeomSum, ManualIter, LinSolver, EigSolver
 export fixedpoint
 
 export absorb_weight

--- a/test/ctmrg/gradients.jl
+++ b/test/ctmrg/gradients.jl
@@ -33,12 +33,15 @@ gradmodes = [
         ManualIter(; tol=gradtol, iterscheme=:diffgauge),
         LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:fixed),
         LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:diffgauge),
+        EigSolver(; solver=KrylovKit.Arnoldi(; tol=gradtol), iterscheme=:fixed),
+        EigSolver(; solver=KrylovKit.Arnoldi(; tol=gradtol), iterscheme=:diffgauge),
     ],
     [  # Only use :diffgauge due to high gauge-sensitivity (perhaps due to small χenv?)
         nothing,
         GeomSum(; tol=gradtol, iterscheme=:diffgauge),
         ManualIter(; tol=gradtol, iterscheme=:diffgauge),
         LinSolver(; solver=KrylovKit.BiCGStab(; tol=gradtol), iterscheme=:diffgauge),
+        EigSolver(; solver=KrylovKit.Arnoldi(; tol=gradtol), iterscheme=:diffgauge),
     ],
 ]
 steps = -0.01:0.005:0.01


### PR DESCRIPTION
Solving the Sylvester problem as an eigenvalue equation, applied to the CTMRG fixed-point gradient linear problem.

Idea after:
https://github.com/Jutho/KrylovKit.jl/blob/fb56bbc7ee952bc8a6af6d278c42e78e553aa62e/ext/KrylovKitChainRulesCoreExt/eigsolve.jl#L167-L290

Actual implementation after:
https://github.com/tangwei94/VUMPSAutoDiff.jl/blob/57afc1cbcb2af9c596197c7d07adfb26ebabcd7a/src/vumps.jl#L161-L203