### PR TITLE
`CTMRG` support for PEPS-PEPO-PEPS networks

### DIFF
--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -310,14 +310,28 @@ Alternatively, contract the environment with a vector `x` acting on it
 
 or contract the adjoint environment with `x`, e.g. as needed for iterative solvers.
 """
-function half_infinite_environment(
-    quadrant1::AbstractTensorMap{T,S,3,3}, quadrant2::AbstractTensorMap{T,S,3,3}
-) where {T,S}
-    return @autoopt @tensor env[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
-        quadrant1[χ_in D_inabove D_inbelow; χ D1 D2] *
-        quadrant2[χ D1 D2; χ_out D_outabove D_outbelow]
+@generated function half_infinite_environment(
+    quadrant1::AbstractTensorMap{T,S,N,N}, quadrant2::AbstractTensorMap{T,S,N,N}
+) where {T,S,N}
+    env_e = tensorexpr(
+        :env,
+        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
+        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
+    )
+    quadrant1_e = tensorexpr(
+        :quadrant1,
+        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
+        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
+    )
+    quadrant2_e = tensorexpr(
+        :quadrant2,
+        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
+        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
+    )
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $env_e := $quadrant1_e * $quadrant2_e)
+    )
 end
-
 function half_infinite_environment(
     C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
 ) where {P<:PEPSSandwich}
@@ -364,12 +378,6 @@ function half_infinite_environment(
         conj(E_3[χ4 D7 D8; χ5]) *
         conj(C_2[χ5; χ6]) *
         conj(E_4[χ6 D9 D10; χ_in])
-end
-function half_infinite_environment(
-    quadrant1::AbstractTensorMap{T,S,2,2}, quadrant2::AbstractTensorMap{T,S,2,2}
-) where {T,S}
-    return @autoopt @tensor env[χ_in D_in; χ_out D_out] :=
-        quadrant1[χ_in D_in; χ D1] * quadrant2[χ D1; χ_out D_out]
 end
 function half_infinite_environment(
     C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
@@ -487,18 +495,48 @@ Alternatively, contract the environment with a vector `x` acting on it
 
 or contract the adjoint environment with `x`, e.g. as needed for iterative solvers.
 """
-function full_infinite_environment(
-    quadrant1::T, quadrant2::T, quadrant3::T, quadrant4::T
-) where {T<:AbstractTensorMap{<:Number,<:ElementarySpace,3,3}}
-    return @autoopt @tensor env[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
-        quadrant1[χ_in D_inabove D_inbelow; χ1 D1 D2] *
-        quadrant2[χ1 D1 D2; χ2 D3 D4] *
-        quadrant3[χ2 D3 D4; χ3 D5 D6] *
-        quadrant4[χ3 D5 D6; χ_out D_outabove D_outbelow]
+@generated function full_infinite_environment(
+    quadrant1::AbstractTensorMap{T,S,N,N},
+    quadrant2::AbstractTensorMap{T,S,N,N},
+    quadrant3::AbstractTensorMap{T,S,N,N},
+    quadrant4::AbstractTensorMap{T,S,N,N},
+) where {T,S,N}
+    env_e = tensorexpr(
+        :env,
+        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
+        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
+    )
+    quadrant1_e = tensorexpr(
+        :quadrant1,
+        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
+        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
+    )
+    quadrant2_e = tensorexpr(
+        :quadrant2,
+        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
+        (envlabel(:EC), ntuple(i -> virtuallabel(:EC, i), N - 1)...),
+    )
+    quadrant3_e = tensorexpr(
+        :quadrant3,
+        (envlabel(:EC), ntuple(i -> virtuallabel(:EC, i), N - 1)...),
+        (envlabel(:SC), ntuple(i -> virtuallabel(:SC, i), N - 1)...),
+    )
+    quadrant4_e = tensorexpr(
+        :quadrant4,
+        (envlabel(:SC), ntuple(i -> virtuallabel(:SC, i), N - 1)...),
+        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
+    )
+    return macroexpand(
+        @__MODULE__,
+        :(
+            return @autoopt @tensor $env_e :=
+                $quadrant1_e * $quadrant2_e * $quadrant3_e * $quadrant4_e
+        ),
+    )
 end
 function full_infinite_environment(
-    half1::T, half2::T
-) where {T<:AbstractTensorMap{<:Number,<:ElementarySpace,3,3}}
+    half1::AbstractTensorMap{T,S,N}, half2::AbstractTensorMap{T,S,N}
+) where {T,S,N}
     return half_infinite_environment(half1, half2)
 end
 function full_infinite_environment(
@@ -514,33 +552,29 @@ function full_infinite_environment(
     E_6,
     E_7,
     E_8,
-    ket_1::P,
-    bra_1::P,
-    ket_2::P,
-    bra_2::P,
-    ket_3::P,
-    bra_3::P,
-    ket_4::P,
-    bra_4::P,
-) where {P<:PEPSTensor}
+    A_1::P,
+    A_2::P,
+    A_3::P,
+    A_4::P,
+) where {P<:PEPSSandwich}
     return @autoopt @tensor env[χ_in D_inabove D_inbelow; χ_out D_outabove D_outbelow] :=
         E_1[χ_in D1 D2; χ1] *
         C_1[χ1; χ2] *
         E_2[χ2 D3 D4; χ3] *
-        ket_1[d1; D3 D11 D_inabove D1] *
-        conj(bra_1[d1; D4 D12 D_inbelow D2]) *
-        ket_2[d2; D5 D7 D9 D11] *
-        conj(bra_2[d2; D6 D8 D10 D12]) *
+        ket(A_1)[d1; D3 D11 D_inabove D1] *
+        conj(bra(A_1)[d1; D4 D12 D_inbelow D2]) *
+        ket(A_2)[d2; D5 D7 D9 D11] *
+        conj(bra(A_2)[d2; D6 D8 D10 D12]) *
         E_3[χ3 D5 D6; χ4] *
         C_2[χ4; χ5] *
         E_4[χ5 D7 D8; χ6] *
         E_5[χ6 D13 D14; χ7] *
         C_3[χ7; χ8] *
         E_6[χ8 D15 D16; χ9] *
-        ket_3[d3; D9 D13 D15 D17] *
-        conj(bra_3[d3; D10 D14 D16 D18]) *
-        ket_4[d4; D_outabove D17 D19 D21] *
-        conj(bra_4[d4; D_outbelow D18 D20 D22]) *
+        ket(A_3)[d3; D9 D13 D15 D17] *
+        conj(bra(A_3)[d3; D10 D14 D16 D18]) *
+        ket(A_4)[d4; D_outabove D17 D19 D21] *
+        conj(bra(A_4)[d4; D_outbelow D18 D20 D22]) *
         E_7[χ9 D19 D20; χ10] *
         C_4[χ10; χ11] *
         E_8[χ11 D21 D22; χ_out]
@@ -628,20 +662,6 @@ function full_infinite_environment(
         E_7[χ9 D19 D20; χ10] *
         C_4[χ10; χ11] *
         E_8[χ11 D21 D22; χ_in]
-end
-function full_infinite_environment(
-    quadrant1::T, quadrant2::T, quadrant3::T, quadrant4::T
-) where {T<:AbstractTensorMap{<:Number,<:ElementarySpace,2,2}}
-    return @autoopt @tensor env[χ_in D_inabove; χ_out D_outabove] :=
-        quadrant1[χ_in D_inabove; χ1 D1] *
-        quadrant2[χ1 D1; χ2 D2] *
-        quadrant3[χ2 D2; χ3 D3] *
-        quadrant4[χ3 D3; χ_out D_outabove]
-end
-function full_infinite_environment(
-    half1::T, half2::T
-) where {T<:AbstractTensorMap{<:Number,<:ElementarySpace,2,2}}
-    return half_infinite_environment(half1, half2)
 end
 function full_infinite_environment(
     C_1,
@@ -776,17 +796,29 @@ Apply projectors to each side of a quadrant.
         |
 ```
 """
-function renormalize_corner(
-    quadrant::AbstractTensorMap{T,S,3,3}, P_left, P_right
-) where {T,S}
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        P_right[χ_in; χ1 D1 D2] * quadrant[χ1 D1 D2; χ2 D3 D4] * P_left[χ2 D3 D4; χ_out]
-end
-function renormalize_corner(
-    quadrant::AbstractTensorMap{T,S,2,2}, P_left, P_right
-) where {T,S}
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        P_right[χ_in; χ1 D1] * quadrant[χ1 D1; χ2 D3] * P_left[χ2 D3; χ_out]
+@generated function renormalize_corner(
+    quadrant::AbstractTensorMap{T,S,N,N}, P_left, P_right
+) where {T,S,N}
+    corner_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
+    P_right_e = tensorexpr(
+        :P_right,
+        (envlabel(:out),),
+        (envlabel(:L), ntuple(i -> virtuallabel(:L, i), N - 1)...),
+    )
+    P_left_e = tensorexpr(
+        :P_left,
+        (envlabel(:R), ntuple(i -> virtuallabel(:R, i), N - 1)...),
+        (envlabel(:in),),
+    )
+    quadrant_e = tensorexpr(
+        :quadrant,
+        (envlabel(:L), ntuple(i -> virtuallabel(:L, i), N - 1)...),
+        (envlabel(:R), ntuple(i -> virtuallabel(:R, i), N - 1)...),
+    )
+    return macroexpand(
+        @__MODULE__,
+        :(return @autoopt @tensor $corner_e := $P_right_e * $quadrant_e * $P_left_e),
+    )
 end
 
 """
@@ -844,7 +876,7 @@ end
 
 """
     renormalize_northeast_corner((row, col), enlarged_env::CTMRGEnv, P_left, P_right)
-    renormalize_northwest_corner(quadrant::AbstractTensorMap{T,S,N,N}, P_left, P_right) where {T,S,N}
+    renormalize_northeast_corner(quadrant::AbstractTensorMap{T,S,N,N}, P_left, P_right) where {T,S,N}
     renormalize_northeast_corner(E_north, C_northeast, E_east, P_left, P_right, A::O)
 
 Apply `renormalize_corner` to the enlarged northeast corner.
@@ -927,7 +959,7 @@ function renormalize_southeast_corner(
     return renormalize_corner(quadrant, P_left, P_right)
 end
 function renormalize_southeast_corner(
-    E_east, C_southeast, E_south, P_left, P_right, A::PEPOSandwich
+    E_east, C_southeast, E_south, P_left, P_right, A::PEPSSandwich
 )
     return @autoopt @tensor corner[χ_in; χ_out] :=
         P_right[χ_in; χ1 D1 D2] *
@@ -1014,23 +1046,31 @@ Apply bottom projector to southwest corner and south edge.
      C --  E -- in
 ```
 """
-function renormalize_bottom_corner(
-    (row, col), env::CTMRGEnv{C,<:CTMRG_PEPS_EdgeTensor}, projectors
-) where {C}
+function renormalize_bottom_corner((row, col), env::CTMRGEnv, projectors)
     C_southwest = env.corners[SOUTHWEST, row, _prev(col, end)]
     E_south = env.edges[SOUTH, row, col]
     P_bottom = projectors[1][row]
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        E_south[χ_in D1 D2; χ1] * C_southwest[χ1; χ2] * P_bottom[χ2 D1 D2; χ_out]
+    return renormalize_bottom_corner(C_southwest, E_south, P_bottom)
 end
-function renormalize_bottom_corner(
-    (row, col), env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor}, projectors
-) where {C}
-    C_southwest = env.corners[SOUTHWEST, row, _prev(col, end)]
-    E_south = env.edges[SOUTH, row, col]
-    P_bottom = projectors[1][row]
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        E_south[χ_in D1; χ1] * C_southwest[χ1; χ2] * P_bottom[χ2 D1; χ_out]
+@generated function renormalize_bottom_corner(
+    C_southwest, E_south::CTMRGEdgeTensor{T,S,N}, P_bottom
+) where {T,S,N}
+    C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
+    C_southwest_e = tensorexpr(:C_southwest, (envlabel(:SSW),), (envlabel(:WSW),))
+    E_south_e = tensorexpr(
+        :E_south,
+        (envlabel(:out), ntuple(i -> virtuallabel(i), N - 1)...),
+        (envlabel(:SSW),),
+    )
+    P_bottom_e = tensorexpr(
+        :P_bottom,
+        (envlabel(:WSW), ntuple(i -> virtuallabel(i), N - 1)...),
+        (envlabel(:in),),
+    )
+    return macroexpand(
+        @__MODULE__,
+        :(return @autoopt @tensor $C_out_e := $E_south_e * $C_southwest_e * $P_bottom_e),
+    )
 end
 
 """
@@ -1050,13 +1090,21 @@ function renormalize_top_corner((row, col), env::CTMRGEnv, projectors)
     P_top = projectors[2][_next(row, end)]
     return renormalize_top_corner(C_northwest, E_north, P_top)
 end
-function renormalize_top_corner(C_northwest, E_north::CTMRG_PEPS_EdgeTensor, P_top)
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        P_top[χ_in; χ1 D1 D2] * C_northwest[χ1; χ2] * E_north[χ2 D1 D2; χ_out]
-end
-function renormalize_top_corner(C_northwest, E_north::CTMRG_PF_EdgeTensor, P_top)
-    return @autoopt @tensor corner[χ_in; χ_out] :=
-        P_top[χ_in; χ1 D1] * C_northwest[χ1; χ2] * E_north[χ2 D1; χ_out]
+@generated function renormalize_top_corner(
+    C_northwest, E_north::CTMRGEdgeTensor{T,S,N}, P_top
+) where {T,S,N}
+    C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
+    C_northwest_e = tensorexpr(:C_northwest, (envlabel(:WNW),), (envlabel(:NNW),))
+    E_north_e = tensorexpr(
+        :E_north, (envlabel(:NNW), ntuple(i -> virtuallabel(i), N - 1)...), (envlabel(:in),)
+    )
+    P_top_e = tensorexpr(
+        :P_top, (envlabel(:out),), (envlabel(:WNW), ntuple(i -> virtuallabel(i), N - 1)...)
+    )
+    return macroexpand(
+        @__MODULE__,
+        :(return @autoopt @tensor $C_out_e := $E_north_e * $C_northwest_e * $P_top_e),
+    )
 end
 
 # edges
@@ -1464,4 +1512,841 @@ Multiply west right singular vectors with gauge signs from the left.
 """
 function fix_gauge_west_right_vecs((row, col), V, signs)
     return signs[WEST, _prev(row, end), col] * V[WEST, row, col]
+end
+
+## WIP: PEPO contractions...
+
+#
+# Expressions
+#
+
+## PEPS tensor expressions
+
+function _virtual_labels(dir, layer, args...; contract=nothing)
+    return isnothing(contract) ? (dir, layer, args...) : (contract, layer)
+end
+_north_labels(args...; kwargs...) = _virtual_labels(:N, args...; kwargs...)
+_east_labels(args...; kwargs...) = _virtual_labels(:E, args...; kwargs...)
+_south_labels(args...; kwargs...) = _virtual_labels(:S, args...; kwargs...)
+_west_labels(args...; kwargs...) = _virtual_labels(:W, args...; kwargs...)
+
+# layer=:top for ket PEPS, layer=:bot for bra PEPS, connects to PEPO slice h
+function _pepo_pepstensor_expr(
+    tensorname,
+    layer::Symbol,
+    h::Int,
+    args...;
+    contract_north=nothing,
+    contract_east=nothing,
+    contract_south=nothing,
+    contract_west=nothing,
+)
+    return tensorexpr(
+        tensorname,
+        (physicallabel(h, args...),),
+        (
+            virtuallabel(_north_labels(layer, args...; contract=contract_north)...),
+            virtuallabel(_east_labels(layer, args...; contract=contract_east)...),
+            virtuallabel(_south_labels(layer, args...; contract=contract_south)...),
+            virtuallabel(_west_labels(layer, args...; contract=contract_west)...),
+        ),
+    )
+end
+
+# PEPO slice h
+function _pepo_pepotensor_expr(
+    tensorname,
+    h::Int,
+    args...;
+    contract_north=nothing,
+    contract_east=nothing,
+    contract_south=nothing,
+    contract_west=nothing,
+)
+    layer = Symbol(:mid, :_, h)
+    return tensorexpr(
+        tensorname,
+        (physicallabel(h + 1, args...), physicallabel(h, args...)),
+        (
+            virtuallabel(_north_labels(layer, args...; contract=contract_north)...),
+            virtuallabel(_east_labels(layer, args...; contract=contract_east)...),
+            virtuallabel(_south_labels(layer, args...; contract=contract_south)...),
+            virtuallabel(_west_labels(layer, args...; contract=contract_west)...),
+        ),
+    )
+end
+
+# PEPOSandwich
+function _pepo_sandwich_expr(sandwichname, H::Int, args...; kwargs...)
+    ket_e = _pepo_pepstensor_expr(:(ket($sandwichname)), :top, 1, args...; kwargs...)
+    bra_e = _pepo_pepstensor_expr(:(bra($sandwichname)), :bot, H + 1, args...; kwargs...)
+    pepo_es = map(1:H) do h
+        return _pepo_pepotensor_expr(:(pepo($sandwichname)[$h]), h, args...; kwargs...)
+    end
+
+    return ket_e, bra_e, pepo_es
+end
+
+## Corner expressions
+
+function _corner_expr(cornername, codom_label, dom_label, args...)
+    return tensorexpr(
+        cornername, (envlabel(codom_label, args...),), (envlabel(dom_label, args...),)
+    )
+end
+
+## Edge expressions
+
+function _pepo_edge_expr(edgename, codom_label, dom_label, dir, H::Int, args...)
+    return tensorexpr(
+        edgename,
+        (
+            envlabel(codom_label, args...),
+            virtuallabel(dir, :top, args...),
+            ntuple(i -> virtuallabel(dir, :mid, i, args...), H)...,
+            virtuallabel(dir, :bot, args...),
+        ),
+        (envlabel(dom_label, args...),),
+    )
+end
+
+## Enlarged corner (quadrant) expressions
+
+function _pepo_enlarged_corner_expr(
+    cornername, codom_label, dom_label, codom_dir, dom_dir, H::Int, args...
+)
+    return tensorexpr(
+        cornername,
+        (
+            envlabel(codom_label, args...),
+            virtuallabel(codom_dir, :top, args...),
+            ntuple(i -> virtuallabel(codom_dir, :mid, i, args...), H)...,
+            virtuallabel(codom_dir, :bot, args...),
+        ),
+        (
+            envlabel(dom_label, args...),
+            virtuallabel(dom_dir, :top, args...),
+            ntuple(i -> virtuallabel(dom_dir, :mid, i, args...), H)...,
+            virtuallabel(dom_dir, :bot, args...),
+        ),
+    )
+end
+
+## Environment expressions
+
+function _pepo_env_expr(
+    envname,
+    codom_label,
+    dom_label,
+    codom_dir,
+    dom_dir,
+    codom_site,
+    dom_site,
+    H::Int,
+    args...,
+)
+    return tensorexpr(
+        envname,
+        (
+            envlabel(codom_label, args...),
+            virtuallabel(codom_dir, :top, codom_site, args...),
+            ntuple(i -> virtuallabel(codom_dir, :mid, i, codom_site, args...), H)...,
+            virtuallabel(codom_dir, :bot, codom_site, args...),
+        ),
+        (
+            envlabel(dom_label, args...),
+            virtuallabel(dom_dir, :top, dom_site, args...),
+            ntuple(i -> virtuallabel(dom_dir, :mid, i, dom_site, args...), H)...,
+            virtuallabel(dom_dir, :bot, dom_site, args...),
+        ),
+    )
+end
+
+function _pepo_env_arg_expr(argname, codom_label, codom_dir, codom_site, H::Int, args...)
+    return tensorexpr(
+        argname,
+        (
+            envlabel(codom_label, args...),
+            virtuallabel(codom_dir, :top, codom_site, args...),
+            ntuple(i -> virtuallabel(codom_dir, :mid, i, codom_site, args...), H)...,
+            virtuallabel(codom_dir, :bot, codom_site, args...),
+        ),
+    )
+end
+
+## Projector expressions
+
+function _pepo_codomain_projector_expr(
+    projname, codom_label, dom_label, dom_dir, H::Int, args...
+)
+    return tensorexpr(
+        projname,
+        (envlabel(codom_label, args...),),
+        (
+            envlabel(dom_label, args...),
+            virtuallabel(dom_dir, :top, args...),
+            ntuple(i -> virtuallabel(dom_dir, :mid, i, args...), H)...,
+            virtuallabel(dom_dir, :bot, args...),
+        ),
+    )
+end
+
+function _pepo_domain_projector_expr(
+    projname, codom_label, codom_dir, dom_label, H::Int, args...
+)
+    return tensorexpr(
+        projname,
+        (
+            envlabel(codom_label, args...),
+            virtuallabel(codom_dir, :top, args...),
+            ntuple(i -> virtuallabel(codom_dir, :mid, i, args...), H)...,
+            virtuallabel(codom_dir, :bot, args...),
+        ),
+        (envlabel(dom_label, args...),),
+    )
+end
+
+#
+# Contractions
+#
+
+## Site contraction
+@generated function _contract_site(
+    C_northwest,
+    C_northeast,
+    C_southeast,
+    C_southwest,
+    E_north::CTMRGEdgeTensor{T,S,N},
+    E_east::CTMRGEdgeTensor{T,S,N},
+    E_south::CTMRGEdgeTensor{T,S,N},
+    E_west::CTMRGEdgeTensor{T,S,N},
+    O::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    C_northwest_e = _corner_expr(:C_northwest, :WNW, :NNW)
+    C_northeast_e = _corner_expr(:C_northeast, :NNE, :ENE)
+    C_southeast_e = _corner_expr(:C_southeast, :ESE, :SSE)
+    C_southwest_e = _corner_expr(:C_southwest, :SSW, :WSW)
+
+    E_north_e = _pepo_edge_expr(:E_north, :NNW, :NNE, :N, H)
+    E_east_e = _pepo_edge_expr(:E_east, :ENE, :ESE, :E, H)
+    E_south_e = _pepo_edge_expr(:E_south, :SSE, :SSW, :S, H)
+    E_west_e = _pepo_edge_expr(:E_west, :WSW, :WNW, :W, H)
+
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        C_northwest_e,
+        C_northeast_e,
+        C_southeast_e,
+        C_southwest_e,
+        E_north_e,
+        E_east_e,
+        E_south_e,
+        E_west_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $rhs))
+end
+
+## Enlarged corner contractions
+
+@generated function enlarge_northwest_corner(
+    E_west::CTMRGEdgeTensor{T,S,N},
+    C_northwest::CTMRGCornerTensor,
+    E_north::CTMRGEdgeTensor{T,S,N},
+    O::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_west_e = _pepo_edge_expr(:E_west, :SW, :WNW, :W, H)
+    C_northwest_e = _corner_expr(:C_northwest, :WNW, :NNW)
+    E_north_e = _pepo_edge_expr(:E_north, :NNW, :NE, :N, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
+
+    C_out_e = _pepo_enlarged_corner_expr(:C_northwest´, :SW, :NE, :S, :E, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        E_west_e,
+        C_northwest_e,
+        E_north_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function enlarge_northeast_corner(
+    E_north::CTMRGEdgeTensor{T,S,N},
+    C_northeast::CTMRGCornerTensor,
+    E_east::CTMRGEdgeTensor{T,S,N},
+    O::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_north_e = _pepo_edge_expr(:E_north, :NW, :NNE, :N, H)
+    C_northeast = _corner_expr(:C_northeast, :NNE, :ENE)
+    E_east_e = _pepo_edge_expr(:E_east, :ENE, :SE, :E, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
+
+    C_out_e = _pepo_enlarged_corner_expr(:C_northeast´, :NW, :SE, :W, :S, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        E_north_e,
+        C_northeast,
+        E_east_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function enlarge_southeast_corner(
+    E_east::CTMRGEdgeTensor{T,S,N},
+    C_southeast::CTMRGCornerTensor,
+    E_south::CTMRGEdgeTensor{T,S,N},
+    O::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_east_e = _pepo_edge_expr(:E_east, :NE, :ESE, :E, H)
+    C_southeast_e = _corner_expr(:C_southeast, :ESE, :SSE)
+    E_south_e = _pepo_edge_expr(:E_south, :SSE, :SW, :S, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
+
+    C_out_e = _pepo_enlarged_corner_expr(:C_southeast´, :NE, :SW, :N, :W, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        E_east_e,
+        C_southeast_e,
+        E_south_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function enlarge_southwest_corner(
+    E_south::CTMRGEdgeTensor{T,S,N},
+    C_southwest::CTMRGCornerTensor,
+    E_west::CTMRGEdgeTensor{T,S,N},
+    O::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_south_e = _pepo_edge_expr(:E_south, :SE, :SSW, :S, H)
+    C_southwest_e = _corner_expr(:C_southwest, :SSW, :WSW)
+    E_west_e = _pepo_edge_expr(:E_west, :WSW, :NW, :W, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
+
+    C_out_e = _pepo_enlarged_corner_expr(:C_southwest´, :SE, :NW, :E, :N, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        E_south_e,
+        C_southwest_e,
+        E_west_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+## Projector contractions: skip, since these are somehow never used
+
+## HalfInfiniteEnvironment contractions
+
+# reuse partial multiplication expression; TODO: return quadrants separately?
+function _half_infinite_environnment_expr(H)
+    # site 1 (codomain)
+    C1_e = _corner_expr(:C_1, :WNW, :NNW)
+    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
+    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
+    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east=:NC)
+
+    # site 2 (domain)
+    C2_e = _corner_expr(:C_2, :NNE, :ENE)
+    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
+    E4_e = _pepo_edge_expr(:E_4, :ENE, :SE, :E, H, 2)
+    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(:A_2, H, 2; contract_west=:NC)
+
+    partial_expr = Expr(
+        :call,
+        :*,
+        E1_e,
+        C1_e,
+        E2_e,
+        ket1_e,
+        Expr(:call, :conj, bra1_e),
+        pepo1_es...,
+        E3_e,
+        C2_e,
+        E4_e,
+        ket2_e,
+        Expr(:call, :conj, bra2_e),
+        pepo2_es...,
+    )
+
+    return partial_expr
+end
+
+@generated function half_infinite_environment(
+    C_1, C_2, E_1, E_2, E_3, E_4, A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}
+) where {H}
+    # return projector expression
+    env_e = _pepo_env_expr(:env, :SW, :SE, :S, :S, 1, 2, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _half_infinite_environnment_expr(H)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $rhs))
+end
+@generated function half_infinite_environment(
+    C_1,
+    C_2,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    x::AbstractTensor{T,S,N},
+    A_1::PEPOSandwich{H},
+    A_2::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    # codomain vector (output)
+    env_x_e = _pepo_env_arg_expr(:env_x, :SW, :S, 1, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _half_infinite_environnment_expr(H)
+
+    # domain vector (input)
+    x_e = _pepo_env_arg_expr(:x, :SE, :S, 2, H)
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * $x_e)
+    )
+end
+@generated function half_infinite_environment(
+    x::AbstractTensor{T,S,N},
+    C_1,
+    C_2,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    A_1::PEPOSandwich{H},
+    A_2::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+    # codomain vector (input)
+    x_e = _pepo_env_arg_expr(:x, :SW, :S, 1, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _half_infinite_environnment_expr(H)
+
+    # domain vector (output)
+    x_env_e = _pepo_env_arg_expr(:env_x, :SE, :S, 2, H)
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $x_env_e := $x_e * $proj_expr)
+    )
+end
+
+## FullInfiniteEnvironment contractions
+
+# reuse partial multiplication expression; TODO: return quadrants separately?
+function _full_infinite_environment_expr(H)
+    # site 1 (codomain)
+    C1_e = _corner_expr(:C_1, :WNW, :NNW)
+    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
+    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
+    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east=:NC)
+
+    # site 2
+    C2_e = _corner_expr(:C_2, :NNE, :ENE)
+    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
+    E4_e = _pepo_edge_expr(:E_4, :ENE, :EC, :E, H, 2)
+    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(
+        :A_2, H, 2; contract_west=:NC, contract_south=:EC
+    )
+
+    # site 3
+    C3_e = _corner_expr(:C_3, :WSW, :SSW)
+    E5_e = _pepo_edge_expr(:E_5, :EC, :WSW, :E, H, 3)
+    E6_e = _pepo_edge_expr(:E_6, :SSW, :SC, :S, H, 3)
+    ket3_e, bra3_e, pepo3_es = _pepo_sandwich_expr(
+        :A_3, H, 3; contract_north=:EC, contract_west=:SC
+    )
+
+    # site 4 (domain)
+    C4_e = _corner_expr(:C_4, :SSW, :WSW)
+    E7_e = _pepo_edge_expr(:E_7, :SC, :SSW, :S, H, 4)
+    E8_e = _pepo_edge_expr(:E_8, :WSW, :NW, :W, H, 4)
+    ket4_e, bra4_e, pepo4_es = _pepo_sandwich_expr(:A_4, H, 4; contract_east=:SC)
+
+    partial_expr = Expr(
+        :call,
+        :*,
+        E1_e,
+        C1_e,
+        E2_e,
+        ket1_e,
+        Expr(:call, :conj, bra1_e),
+        pepo1_es...,
+        E3_e,
+        C2_e,
+        E4_e,
+        ket2_e,
+        Expr(:call, :conj, bra2_e),
+        pepo2_es...,
+        E5_e,
+        C3_e,
+        E6_e,
+        ket3_e,
+        Expr(:call, :conj, bra3_e),
+        pepo3_es...,
+        E7_e,
+        C4_e,
+        E8_e,
+        ket4_e,
+        Expr(:call, :conj, bra4_e),
+        pepo4_es...,
+    )
+
+    return partial_expr
+end
+
+@generated function full_infinite_environment(
+    C_1,
+    C_2,
+    C_3,
+    C_4,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    E_5,
+    E_6,
+    E_7,
+    E_8,
+    A_1::PEPOSandwich{H},
+    A_2::PEPOSandwich{H},
+    A_3::PEPOSandwich{H},
+    A_4::PEPOSandwich{H},
+) where {H}
+    # return projector expression
+    env_e = _pepo_env_expr(:env, :SW, :NW, :S, :N, 1, 4, N - 1)
+
+    # reuse partial multiplication expression
+    proj_expr = _full_infinite_environment_expr(H)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
+end
+@generated function full_infinite_environment(
+    C_1,
+    C_2,
+    C_3,
+    C_4,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    E_5,
+    E_6,
+    E_7,
+    E_8,
+    x::AbstractTensor{T,S,N},
+    A_1::PEPOSandwich{H},
+    A_2::PEPOSandwich{H},
+    A_3::PEPOSandwich{H},
+    A_4::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    # codomain vecor (output)
+    env_x_e = _pepo_env_arg_expr(:env, :SW, :S, 1, N - 1)
+
+    # reuse partial multiplication expression
+    proj_expr = _full_infinite_environment_expr(H)
+
+    # domain vector (input)
+    x_e = _pepo_env_arg_expr(:env, :NW, :N, 4, N - 1)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * x_e))
+end
+@generated function full_infinite_environment(
+    x::AbstractTensor{T,S,N},
+    C_1,
+    C_2,
+    C_3,
+    C_4,
+    E_1,
+    E_2,
+    E_3,
+    E_4,
+    E_5,
+    E_6,
+    E_7,
+    E_8,
+    A_1::PEPOSandwich{H},
+    A_2::PEPOSandwich{H},
+    A_3::PEPOSandwich{H},
+    A_4::PEPOSandwich{H},
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    # codomain vecor (input)
+    x_e = _pepo_env_arg_expr(:env, :SW, :S, 1, N - 1)
+
+    # reuse partial multiplication expression
+    proj_expr = _full_infinite_environment_expr(H)
+
+    # domain vector (output)
+    x_env_e = _pepo_env_arg_expr(:env, :NW, :N, 4, N - 1)
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $x_env_e := $x_e * $proj_expr)
+    )
+end
+
+## Corner renormalization contractions
+
+@generated function renormalize_northwest_corner(
+    E_west, C_northwest, E_north, P_left, P_right, A::PEPOSandwich{H}
+) where {H}
+    C_out_e = _corner_expr(:corner, :out, :in)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :S, :S, H)
+    E_west_e = _pepo_edge_expr(:E_west, :S, :WNW, :W, H)
+    C_northwest_e = _corner_expr(:C_northwest, :WNW, :NNW)
+    E_north_e = _pepo_edge_expr(:E_north, :NNW, :E, :N, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :E, :E, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_west_e,
+        C_northwest_e,
+        E_north_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function renormalize_northeast_corner(
+    E_north, C_northeast, E_east, P_left, P_right, A::PEPOSandwich{H}
+) where {H}
+    C_out_e = _corner_expr(:corner, :out, :in)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :W, :W, H)
+    E_north_e = _pepo_edge_expr(:E_north, :W, :NNE, :N, H)
+    C_northeast_e = _corner_expr(:C_northeast, :NNE, :ENE)
+    E_east_e = _pepo_edge_expr(:E_east, :ENE, :S, :E, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :S, :S, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_north_e,
+        C_northeast_e,
+        E_east_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function renormalize_southeast_corner(
+    E_east, C_southeast, E_south, P_left, P_right, A::PEPOSandwich{H}
+) where {H}
+    C_out_e = _corner_expr(:corner, :out, :in)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :N, :N, H)
+    E_east_e = _pepo_edge_expr(:E_east, :N, :EWE, :E, H)
+    C_southeast_e = _corner_expr(:C_southeast, :ESE, :SSE)
+    E_south_e = _pepo_edge_expr(:E_south, :SSE, :W, :S, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :W, :W, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_east_e,
+        C_southeast_e,
+        E_south_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+@generated function renormalize_southwest_corner(
+    E_south, C_southwest, E_west, P_left, P_right, A::PEPOSandwich{H}
+) where {H}
+    C_out_e = _corner_expr(:corner, :out, :in)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :E, :E, H)
+    E_south_e = _pepo_edge_expr(:E_south, :E, :SSW, :S, H)
+    C_southwest_e = _corner_expr(:C_southwest, :SSW, :WSW)
+    E_west_e = _pepo_edge_expr(:E_west, :WSW, :N, :W, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :N, :N, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_south_e,
+        C_southwest_e,
+        E_west_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $C_out_e := $rhs))
+end
+
+## Edge renormalization contractions
+
+@generated function renormalize_north_edge(
+    E_north::CTMRGEdgeTensor{T,S,N}, P_left, P_right, A::PEPOSandwich{H}
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_out_e = _pepo_edge_expr(:edge, :out, :in, :S, H)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :W, :W, H)
+    E_north_e = _pepo_edge_expr(:E_north, :W, :E, :N, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :E, :E, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_north_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $E_out_e := $rhs))
+end
+
+@generated function renormalize_east_edge(
+    E_east::CTMRGEdgeTensor{T,S,N}, P_bottom, P_top, A::PEPOSandwich{H}
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_out_e = _pepo_edge_expr(:edge, :out, :in, :W, H)
+
+    P_top_e = _pepo_codomain_projector_expr(:P_top, :out, :N, :N, H)
+    E_east_e = _pepo_edge_expr(:E_east, :N, :S, :E, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_bottom_e = _pepo_domain_projector_expr(:P_bottom, :S, :S, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_top_e,
+        E_east_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_bottom_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $E_out_e := $rhs))
+end
+
+@generated function renormalize_south_edge(
+    E_south::CTMRGEdgeTensor{T,S,N}, P_left, P_right, A::PEPOSandwich{H}
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_out_e = _pepo_edge_expr(:edge, :out, :in, :N, H)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :E, :E, H)
+    E_south_e = _pepo_edge_expr(:E_south, :E, :W, :S, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :W, :W, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_right_e,
+        E_south_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_left_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $E_out_e := $rhs))
+end
+
+@generated function renormalize_west_edge(
+    E_west::CTMRGEdgeTensor{T,S,N}, P_bottom, P_top, A::PEPOSandwich{H}
+) where {T,S,N,H}
+    @assert N == H + 3
+
+    E_out_e = _pepo_edge_expr(:edge, :out, :in, :E, H)
+
+    P_top_e = _pepo_codomain_projector_expr(:P_top, :out, :S, :S, H)
+    E_west_e = _pepo_edge_expr(:E_west, :S, :N, :W, H)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+    P_bottom_e = _pepo_domain_projector_expr(:P_bottom, :N, :N, :in, H)
+
+    rhs = Expr(
+        :call,
+        :*,
+        P_top_e,
+        E_west_e,
+        ket_e,
+        Expr(:call, :conj, bra_e),
+        pepo_es...,
+        P_bottom_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $E_out_e := $rhs))
 end

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -757,7 +757,9 @@ Apply projectors to each side of a quadrant.
 ```
 """
 @generated function renormalize_corner(
-    quadrant::AbstractTensorMap{<:Any,S,N,N}, P_left::AbstractTensorMap{<:Any,S,N,1}, P_right::AbstractTensorMap{<:Any,S,1,N}
+    quadrant::AbstractTensorMap{<:Any,S,N,N},
+    P_left::AbstractTensorMap{<:Any,S,N,1},
+    P_right::AbstractTensorMap{<:Any,S,1,N},
 ) where {T,S,N}
     corner_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     P_right_e = tensorexpr(
@@ -1013,7 +1015,9 @@ function renormalize_bottom_corner((row, col), env::CTMRGEnv, projectors)
     return renormalize_bottom_corner(C_southwest, E_south, P_bottom)
 end
 @generated function renormalize_bottom_corner(
-    C_southwest, E_south::CTMRGEdgeTensor{T,S,N}, P_bottom
+    C_southwest::CTMRGCornerTensor{<:Any,S},
+    E_south::CTMRGEdgeTensor{<:Any,S,N},
+    P_bottom::AbstractTensorMap{<:Any,S,N,1},
 ) where {T,S,N}
     C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     C_southwest_e = tensorexpr(:C_southwest, (envlabel(:SSW),), (envlabel(:WSW),))
@@ -1051,7 +1055,9 @@ function renormalize_top_corner((row, col), env::CTMRGEnv, projectors)
     return renormalize_top_corner(C_northwest, E_north, P_top)
 end
 @generated function renormalize_top_corner(
-    C_northwest, E_north::CTMRGEdgeTensor{T,S,N}, P_top
+    C_northwest::CTMRGCornerTensor{<:Any,S},
+    E_north::CTMRGEdgeTensor{<:Any,S,N},
+    P_top::AbstractTensorMap{<:Any,S,1,N},
 ) where {T,S,N}
     C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     C_northwest_e = tensorexpr(:C_northwest, (envlabel(:WNW),), (envlabel(:NNW),))
@@ -1479,8 +1485,6 @@ Multiply west right singular vectors with gauge signs from the left.
 function fix_gauge_west_right_vecs((row, col), V, signs)
     return signs[WEST, _prev(row, end), col] * V[WEST, row, col]
 end
-
-## WIP: PEPO contractions...
 
 #
 # Expressions

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -284,27 +284,13 @@ Alternatively, contract the environment with a vector `x` acting on it
 
 or contract the adjoint environment with `x`, e.g. as needed for iterative solvers.
 """
-@generated function half_infinite_environment(
+function half_infinite_environment(
     quadrant1::AbstractTensorMap{T,S,N,N}, quadrant2::AbstractTensorMap{T,S,N,N}
 ) where {T,S,N}
-    env_e = tensorexpr(
-        :env,
-        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
-        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
-    )
-    quadrant1_e = tensorexpr(
-        :quadrant1,
-        (envlabel(:out), ntuple(i -> virtuallabel(:out, i), N - 1)...),
-        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
-    )
-    quadrant2_e = tensorexpr(
-        :quadrant2,
-        (envlabel(:NC), ntuple(i -> virtuallabel(:NC, i), N - 1)...),
-        (envlabel(:in), ntuple(i -> virtuallabel(:in, i), N - 1)...),
-    )
-    return macroexpand(
-        @__MODULE__, :(return @autoopt @tensor $env_e := $quadrant1_e * $quadrant2_e)
-    )
+    p1 = (codomainind(quadrant1), domainind(quadrant1) .+ numout(quadrant1))
+    p2 = (codomainind(quadrant2), domainind(quadrant2) .+ numout(quadrant2))
+    p3 = (codomainind(quadrant1), domainind(quadrant2) .+ numout(quadrant1))
+    return tensorcontract(quadrant1, p1, false, quadrant2, p2, false, p3)
 end
 function half_infinite_environment(
     C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1555,7 +1555,7 @@ function _pepo_sandwich_expr(sandwichname, H::Int, args...; kwargs...)
     ket_e = _pepo_pepstensor_expr(:(ket($sandwichname)), :top, 1, args...; kwargs...)
     bra_e = _pepo_pepstensor_expr(:(bra($sandwichname)), :bot, H + 1, args...; kwargs...)
     pepo_es = map(1:H) do h
-        return _pepo_pepotensor_expr(:(pepo($sandwichname)[$h]), h, args...; kwargs...)
+        return _pepo_pepotensor_expr(:(pepo($sandwichname, $h)), h, args...; kwargs...)
     end
 
     return ket_e, bra_e, pepo_es

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -287,10 +287,8 @@ or contract the adjoint environment with `x`, e.g. as needed for iterative solve
 function half_infinite_environment(
     quadrant1::AbstractTensorMap{T,S,N,N}, quadrant2::AbstractTensorMap{T,S,N,N}
 ) where {T,S,N}
-    p1 = (codomainind(quadrant1), domainind(quadrant1) .+ numout(quadrant1))
-    p2 = (codomainind(quadrant2), domainind(quadrant2) .+ numout(quadrant2))
-    p3 = (codomainind(quadrant1), domainind(quadrant2) .+ numout(quadrant1))
-    return tensorcontract(quadrant1, p1, false, quadrant2, p2, false, p3)
+    p = (codomainind(quadrant1), domainind(quadrant1))
+    return tensorcontract(quadrant1, p, false, quadrant2, p, false, p)
 end
 function half_infinite_environment(
     C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -757,7 +757,7 @@ Apply projectors to each side of a quadrant.
 ```
 """
 @generated function renormalize_corner(
-    quadrant::AbstractTensorMap{T,S,N,N}, P_left, P_right
+    quadrant::AbstractTensorMap{<:Any,S,N,N}, P_left::AbstractTensorMap{<:Any,S,N,1}, P_right::AbstractTensorMap{<:Any,S,1,N}
 ) where {T,S,N}
     corner_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     P_right_e = tensorexpr(

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -20,12 +20,6 @@ coordinates, environments and network, or by directly providing the tensors.
          |            |
 ```
 """
-function enlarge_northwest_corner((row, col), env::CTMRGEnv, network::InfiniteSquareNetwork)
-    E_west = env.edges[WEST, row, _prev(col, end)]
-    C_northwest = env.corners[NORTHWEST, _prev(row, end), _prev(col, end)]
-    E_north = env.edges[NORTH, _prev(row, end), col]
-    return enlarge_northwest_corner(E_west, C_northwest, E_north, network[row, col])
-end
 function enlarge_northwest_corner(
     E_west::CTMRG_PEPS_EdgeTensor,
     C_northwest::CTMRGCornerTensor,
@@ -63,12 +57,6 @@ coordinates, environments and network, or by directly providing the tensors.
           |             |
 ```
 """
-function enlarge_northeast_corner((row, col), env::CTMRGEnv, network::InfiniteSquareNetwork)
-    E_north = env.edges[NORTH, _prev(row, end), col]
-    C_northeast = env.corners[NORTHEAST, _prev(row, end), _next(col, end)]
-    E_east = env.edges[EAST, row, _next(col, end)]
-    return enlarge_northeast_corner(E_north, C_northeast, E_east, network[row, col])
-end
 function enlarge_northeast_corner(
     E_north::CTMRG_PEPS_EdgeTensor,
     C_northeast::CTMRGCornerTensor,
@@ -106,12 +94,6 @@ coordinates, environments and network, or by directly providing the tensors.
     -- E_south -- C_southeast
 ```
 """
-function enlarge_southeast_corner((row, col), env::CTMRGEnv, network::InfiniteSquareNetwork)
-    E_east = env.edges[EAST, row, _next(col, end)]
-    C_southeast = env.corners[SOUTHEAST, _next(row, end), _next(col, end)]
-    E_south = env.edges[SOUTH, _next(row, end), col]
-    return enlarge_southeast_corner(E_east, C_southeast, E_south, network[row, col])
-end
 function enlarge_southeast_corner(
     E_east::CTMRG_PEPS_EdgeTensor,
     C_southeast::CTMRGCornerTensor,
@@ -149,14 +131,6 @@ coordinates, environments and network, or by directly providing the tensors.
     C_southwest -- E_south -- 
 ```
 """
-function enlarge_southwest_corner((row, col), env::CTMRGEnv, network::InfiniteSquareNetwork)
-    E_south = env.edges[SOUTH, _next(row, end), col]
-    C_southwest = env.corners[SOUTHWEST, _next(row, end), _prev(col, end)]
-    E_west = env.edges[WEST, row, _prev(col, end)]
-    return enlarge_southwest_corner(
-        E_south, C_southwest, E_west, ket[row, col], bra[row, col]
-    )
-end
 function enlarge_southwest_corner(
     E_south::CTMRG_PEPS_EdgeTensor,
     C_southwest::CTMRGCornerTensor,

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -758,7 +758,7 @@ Apply projectors to each side of a quadrant.
     quadrant::AbstractTensorMap{<:Any,S,N,N},
     P_left::AbstractTensorMap{<:Any,S,N,1},
     P_right::AbstractTensorMap{<:Any,S,1,N},
-) where {T,S,N}
+) where {S,N}
     corner_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     P_right_e = tensorexpr(
         :P_right,
@@ -1016,7 +1016,7 @@ end
     C_southwest::CTMRGCornerTensor{<:Any,S},
     E_south::CTMRGEdgeTensor{<:Any,S,N},
     P_bottom::AbstractTensorMap{<:Any,S,N,1},
-) where {T,S,N}
+) where {S,N}
     C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     C_southwest_e = tensorexpr(:C_southwest, (envlabel(:SSW),), (envlabel(:WSW),))
     E_south_e = tensorexpr(
@@ -1056,7 +1056,7 @@ end
     C_northwest::CTMRGCornerTensor{<:Any,S},
     E_north::CTMRGEdgeTensor{<:Any,S,N},
     P_top::AbstractTensorMap{<:Any,S,1,N},
-) where {T,S,N}
+) where {S,N}
     C_out_e = tensorexpr(:corner, (envlabel(:out),), (envlabel(:in),))
     C_northwest_e = tensorexpr(:C_northwest, (envlabel(:WNW),), (envlabel(:NNW),))
     E_north_e = tensorexpr(

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -262,38 +262,3 @@ end
     end
     return macroexpand(@__MODULE__, returnex)
 end
-
-# Partition function contractions
-
-"""
-    contract_local_tensor(inds, O, env)
-
-Contract a local tensor `O` inserted into a partition function `pf` at position `inds`,
-using the environment `env`.
-"""
-function contract_local_tensor(
-    inds::Tuple{Int,Int},
-    O::AbstractTensorMap{T,S,2,2},
-    env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor},
-) where {T,S,C}
-    r, c = inds
-    return @autoopt @tensor env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][
-            χ_WNW
-            χ_NNW
-        ] *
-        env.edges[NORTH, _prev(r, end), c][χ_NNW D_N; χ_NNE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NNE; χ_ENE] *
-        env.edges[EAST, r, _next(c, end)][χ_ENE D_E; χ_ESE] *
-        env.corners[SOUTHEAST, _next(r, end), _next(c, end)][χ_ESE; χ_SSE] *
-        env.edges[SOUTH, _next(r, end), c][χ_SSE D_S; χ_SSW] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_SSW; χ_WSW] *
-        env.edges[WEST, r, _prev(c, end)][χ_WSW D_W; χ_WNW] *
-        O[D_W D_S; D_N D_E]
-end
-function contract_local_tensor(
-    inds::CartesianIndex{2},
-    O::AbstractTensorMap{T,S,2,2},
-    env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor},
-) where {T,S,C}
-    return contract_local_tensor(Tuple(inds), O, env)
-end

--- a/src/algorithms/contractions/vumps_contractions.jl
+++ b/src/algorithms/contractions/vumps_contractions.jl
@@ -201,22 +201,11 @@ pepo(p::∂PEPOSandwich, i::Int) = p[1 + i]
     @assert H == N - 3
 
     ∂p_e = _pepo_pepstensor_expr(:∂p, :bot, H + 1)
-<<<<<<< HEAD
-    AC_e = _pepo_mpstensor_expr(:AC, :N, H)
-    ĀC_e = _pepo_mpstensor_expr(:ĀC, :S, H)
-    GL_e = _pepo_leftenv_expr(:GL, :W, H)
-    GR_e = _pepo_rightenv_expr(:GR, :E, H)
-    ket_e = _pepo_pepstensor_expr(:(ket(O)), :top, 1)
-    pepo_es = map(1:H) do h
-        return _pepo_pepotensor_expr(:(pepo(O, $h)), h)
-    end
-=======
     AC_e = _pepo_edge_expr(:AC, :NW, :NE, :N, H)
     ĀC_e = _pepo_edge_expr(:ĀC, :SW, :SE, :S, H)
     GL_e = _pepo_edge_expr(:GL, :SW, :NW, :W, H)
     GR_e = _pepo_edge_expr(:GR, :NE, :SE, :E, H)
     ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)
->>>>>>> Rough attempt at CTMRG for PEPO stacks
 
     rhs = Expr(:call, :*, AC_e, Expr(:call, :conj, ĀC_e), GL_e, GR_e, ket_e, pepo_es...)
 

--- a/src/algorithms/contractions/vumps_contractions.jl
+++ b/src/algorithms/contractions/vumps_contractions.jl
@@ -46,7 +46,7 @@ end
     @assert H == N - 3
 
     GL´_e = _pepo_edge_expr(:GL´, :SE, :NE, :E, H)
-    GL_e = _pepo_edge_expr(:GL, :SW, NW, :W, H)
+    GL_e = _pepo_edge_expr(:GL, :SW, :NW, :W, H)
     A_e = _pepo_edge_expr(:A, :NW, :NE, :N, H)
     Ā_e = _pepo_edge_expr(:Ā, :SW, :SE, :S, H)
     ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:O, H)

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -349,18 +349,17 @@ function contract_local_tensor(
     inds::Tuple{Int,Int}, O::PFTensor, env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor}
 ) where {C}
     r, c = inds
-    return @autoopt @tensor env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][
-            χ_WNW
-            χ_NNW
-        ] *
-        env.edges[NORTH, _prev(r, end), c][χ_NNW D_N; χ_NNE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NNE; χ_ENE] *
-        env.edges[EAST, r, _next(c, end)][χ_ENE D_E; χ_ESE] *
-        env.corners[SOUTHEAST, _next(r, end), _next(c, end)][χ_ESE; χ_SSE] *
-        env.edges[SOUTH, _next(r, end), c][χ_SSE D_S; χ_SSW] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_SSW; χ_WSW] *
-        env.edges[WEST, r, _prev(c, end)][χ_WSW D_W; χ_WNW] *
-        O[D_W D_S; D_N D_E]
+    return _contract_site(
+        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+        env.corners[NORTHEAST, _prev(r, end), _next(c, end)],
+        env.corners[SOUTHEAST, _next(r, end), _next(c, end)],
+        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
+        env.edges[NORTH, _prev(r, end), c],
+        env.edges[EAST, r, _next(c, end)],
+        env.edges[SOUTH, _next(r, end), c],
+        env.edges[WEST, r, _prev(c, end)],
+        O,
+    )
 end
 
 """
@@ -377,7 +376,7 @@ function contract_local_tensor(
 )
     r, c, h = ind
     sandwich´ = Base.setindex(network[r, c], O, h + 2)
-    return PEPSKit._contract_site(
+    return _contract_site(
         env.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
         env.corners[NORTHEAST, _prev(r, end), _next(c, end)],
         env.corners[SOUTHEAST, _next(r, end), _next(c, end)],

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -76,37 +76,62 @@ network_value(state, env::CTMRGEnv) = network_value(InfiniteSquareNetwork(state)
 
 Contract around a single site `ind` of a square network using a given CTMRG environment.
 """
-function _contract_site(
-    ind::Tuple{Int,Int}, network::InfiniteSquareNetwork{<:PEPSSandwich}, env::CTMRGEnv
-)
+function _contract_site(ind::Tuple{Int,Int}, network, env::CTMRGEnv)
     r, c = ind
-    return @autoopt @tensor env.edges[WEST, r, _prev(c, end)][
-            χ_WSW D_W_above D_W_below
-            χ_WNW
-        ] *
-        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][χ_WNW; χ_NNW] *
-        env.edges[NORTH, _prev(r, end), c][χ_NNW D_N_above D_N_below; χ_NNE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NNE; χ_ENE] *
-        env.edges[EAST, r, _next(c, end)][χ_ENE D_E_above D_E_below; χ_ESE] *
-        env.corners[SOUTHEAST, _next(r, end), _next(c, end)][χ_ESE; χ_SSE] *
-        env.edges[SOUTH, _next(r, end), c][χ_SSE D_S_above D_S_below; χ_SSW] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_SSW; χ_WSW] *
-        ket(network[r, c])[d; D_N_above D_E_above D_S_above D_W_above] *
-        conj(bra(network[r, c])[d; D_N_below D_E_below D_S_below D_W_below])
+    return _contract_site(
+        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+        env.corners[NORTHEAST, _prev(r, end), _next(c, end)],
+        env.corners[SOUTHEAST, _next(r, end), _next(c, end)],
+        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
+        env.edges[NORTH, _prev(r, end), c],
+        env.edges[EAST, r, _next(c, end)],
+        env.edges[SOUTH, _next(r, end), c],
+        env.edges[WEST, r, _prev(c, end)],
+        network[r, c],
+    )
 end
 function _contract_site(
-    ind::Tuple{Int,Int}, network::InfiniteSquareNetwork{<:PFTensor}, env::CTMRGEnv
+    C_northwest,
+    C_northeast,
+    C_southeast,
+    C_southwest,
+    E_north::CTMRG_PEPS_EdgeTensor,
+    E_east::CTMRG_PEPS_EdgeTensor,
+    E_south::CTMRG_PEPS_EdgeTensor,
+    E_west::CTMRG_PEPS_EdgeTensor,
+    O::PEPSSandwich,
 )
-    r, c = ind
-    return @autoopt @tensor env.edges[WEST, r, _prev(c, end)][χ_WSW D_W; χ_WNW] *
-        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][χ_WNW; χ_NNW] *
-        env.edges[NORTH, _prev(r, end), c][χ_NNW D_N; χ_NNE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NNE; χ_ENE] *
-        env.edges[EAST, r, _next(c, end)][χ_ENE D_E; χ_ESE] *
-        env.corners[SOUTHEAST, _next(r, end), _next(c, end)][χ_ESE; χ_SSE] *
-        env.edges[SOUTH, _next(r, end), c][χ_SSE D_S; χ_SSW] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_SSW; χ_WSW] *
-        network[r, c][D_W D_S; D_N D_E]
+    return @autoopt @tensor E_west[χ_WSW D_W_above D_W_below; χ_WNW] *
+        C_northwest[χ_WNW; χ_NNW] *
+        E_north[χ_NNW D_N_above D_N_below; χ_NNE] *
+        C_northeast[χ_NNE; χ_ENE] *
+        E_east[χ_ENE D_E_above D_E_below; χ_ESE] *
+        C_southeast[χ_ESE; χ_SSE] *
+        E_south[χ_SSE D_S_above D_S_below; χ_SSW] *
+        C_southwest[χ_SSW; χ_WSW] *
+        ket(O)[d; D_N_above D_E_above D_S_above D_W_above] *
+        conj(bra(O)[d; D_N_below D_E_below D_S_below D_W_below])
+end
+function _contract_site(
+    C_northwest,
+    C_northeast,
+    C_southeast,
+    C_southwest,
+    E_north::CTMRG_PF_EdgeTensor,
+    E_east::CTMRG_PF_EdgeTensor,
+    E_south::CTMRG_PF_EdgeTensor,
+    E_west::CTMRG_PF_EdgeTensor,
+    O::PFTensor,
+)
+    return @autoopt @tensor E_west[χ_WSW D_W; χ_WNW] *
+        C_northwest[χ_WNW; χ_NNW] *
+        E_north[χ_NNW D_N; χ_NNE] *
+        C_northeast[χ_NNE; χ_ENE] *
+        E_east[χ_ENE D_E; χ_ESE] *
+        C_southeast[χ_ESE; χ_SSE] *
+        E_south[χ_SSE D_S; χ_SSW] *
+        C_southwest[χ_SSW; χ_WSW] *
+        O[D_W D_S; D_N D_E]
 end
 
 """
@@ -131,27 +156,49 @@ end
 Contract the vertical edges and corners around the east edge at position `ind` of the
 CTMRG environment `env`.
 """
-function _contract_vertical_edges(
-    ind::Tuple{Int,Int}, env::CTMRGEnv{<:Any,<:CTMRG_PEPS_EdgeTensor}
-)
+function _contract_vertical_edges(ind::Tuple{Int,Int}, env::CTMRGEnv)
     r, c = ind
-    return @autoopt @tensor env.edges[WEST, r, _prev(c, end)][χ_SW D_above D_below; χ_NW] *
-        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][χ_NW; χ_N] *
-        env.corners[NORTHEAST, _prev(r, end), c][χ_N; χ_NE] *
-        env.edges[EAST, r, c][χ_NE D_above D_below; χ_SE] *
-        env.corners[SOUTHEAST, _next(r, end), c][χ_SE; χ_S] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_S; χ_SW]
+    return _contract_vertical_edges(
+        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+        env.corners[NORTHEAST, _prev(r, end), c],
+        env.corners[SOUTHEAST, _next(r, end), c],
+        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)],
+        env.edges[EAST, r, c],
+        env.edges[WEST, r, _prev(c, end)],
+    )
 end
-function _contract_vertical_edges(
-    ind::Tuple{Int,Int}, env::CTMRGEnv{<:Any,<:CTMRG_PF_EdgeTensor}
-)
-    r, c = ind
-    return @autoopt @tensor env.edges[WEST, r, _prev(c, end)][χ_SW D; χ_NW] *
-        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][χ_NW; χ_N] *
-        env.corners[NORTHEAST, _prev(r, end), c][χ_N; χ_NE] *
-        env.edges[EAST, r, c][χ_NE D; χ_SE] *
-        env.corners[SOUTHEAST, _next(r, end), c][χ_SE; χ_S] *
-        env.corners[SOUTHWEST, _next(r, end), _prev(c, end)][χ_S; χ_SW]
+@generated function _contract_vertical_edges(
+    C_northwest::CTMRGCornerTensor,
+    C_northeast::CTMRGCornerTensor,
+    C_southeast::CTMRGCornerTensor,
+    C_southwest::CTMRGCornerTensor,
+    E_east::CTMRGEdgeTensor{T,S,N},
+    E_west::CTMRGEdgeTensor{T,S,N},
+) where {T,S,N}
+    C_northwest_e = tensorexpr(:C_northwest, (envlabel(:NW),), (envlabel(:N),))
+    C_northeast_e = tensorexpr(:C_northeast, (envlabel(:N),), (envlabel(:NE),))
+    C_southeast_e = tensorexpr(:C_southeast, (envlabel(:SE),), (envlabel(:S),))
+    C_southwest_e = tensorexpr(:C_southwest, (envlabel(:S),), (envlabel(:SW),))
+
+    E_east_e = tensorexpr(
+        :E_east, (envlabel(:NE), ntuple(i -> virtuallabel(i), N - 1)...), (envlabel(:SE),)
+    )
+    E_west_e = tensorexpr(
+        :E_west, (envlabel(:SW), ntuple(i -> virtuallabel(i), N - 1)...), (envlabel(:NW),)
+    )
+
+    rhs = Expr(
+        :call,
+        :*,
+        E_west_e,
+        C_northwest_e,
+        C_northeast_e,
+        E_east_e,
+        C_southeast_e,
+        C_southwest_e,
+    )
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $rhs))
 end
 
 """
@@ -160,59 +207,49 @@ end
 Contract the horizontal edges and corners around the south edge at position `ind` of the
 CTMRG environment `env`.
 """
-function _contract_horizontal_edges(
-    ind::Tuple{Int,Int}, env::CTMRGEnv{<:Any,<:CTMRG_PEPS_EdgeTensor}
-)
+function _contract_horizontal_edges(ind::Tuple{Int,Int}, env::CTMRGEnv)
     r, c = ind
-    return @autoopt @tensor env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][
-            χ_W
-            χ_NW
-        ] *
-        env.edges[NORTH, _prev(r, end), c][χ_NW D_above D_below; χ_NE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NE; χ_E] *
-        env.corners[SOUTHEAST, r, _next(c, end)][χ_E; χ_SE] *
-        env.edges[SOUTH, r, c][χ_SE D_above D_below; χ_SW] *
-        env.corners[SOUTHWEST, r, _prev(c, end)][χ_SW; χ_W]
+    return _contract_horizontal_edges(
+        env.corners[NORTHWEST, _prev(r, end), _prev(c, end)],
+        env.corners[NORTHEAST, _prev(r, end), _next(c, end)],
+        env.corners[SOUTHEAST, r, _next(c, end)],
+        env.corners[SOUTHWEST, r, _prev(c, end)],
+        env.edges[NORTH, _prev(r, end), c],
+        env.edges[SOUTH, r, c],
+    )
 end
-function _contract_horizontal_edges(
-    ind::Tuple{Int,Int}, env::CTMRGEnv{<:Any,<:CTMRG_PF_EdgeTensor}
-)
-    r, c = ind
-    return @autoopt @tensor env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][
-            χ_W
-            χ_NW
-        ] *
-        env.edges[NORTH, _prev(r, end), c][χ_NW D; χ_NE] *
-        env.corners[NORTHEAST, _prev(r, end), _next(c, end)][χ_NE; χ_E] *
-        env.corners[SOUTHEAST, r, _next(c, end)][χ_E; χ_SE] *
-        env.edges[SOUTH, r, c][χ_SE D; χ_SW] *
-        env.corners[SOUTHWEST, r, _prev(c, end)][χ_SW; χ_W]
-end
+@generated function _contract_horizontal_edges(
+    C_northwest::CTMRGCornerTensor,
+    C_northeast::CTMRGCornerTensor,
+    C_southeast::CTMRGCornerTensor,
+    C_southwest::CTMRGCornerTensor,
+    E_north::CTMRGEdgeTensor{T,S,N},
+    E_south::CTMRGEdgeTensor{T,S,N},
+) where {T,S,N}
+    C_northwest_e = tensorexpr(:C_northwest, (envlabel(:W),), (envlabel(:NW),))
+    C_northeast_e = tensorexpr(:C_northeast, (envlabel(:NE),), (envlabel(:E),))
+    C_southeast_e = tensorexpr(:C_southeast, (envlabel(:E),), (envlabel(:SE),))
+    C_southwest_e = tensorexpr(:C_southwest, (envlabel(:SW),), (envlabel(:W),))
 
-function MPSKit.transfer_spectrum(
-    above::MultilineMPS,
-    O::MultilineTransferMatrix,
-    below::MultilineMPS;
-    num_vals=2,
-    solver=MPSKit.Defaults.eigsolver,
-)
-    @assert size(above) == size(O)
-    @assert size(below) == size(O)
+    E_north_e = tensorexpr(
+        :E_north, (envlabel(:NW), ntuple(i -> virtuallabel(i), N - 1)...), (envlabel(:NE),)
+    )
+    E_south_e = tensorexpr(
+        :E_south, (envlabel(:SE), ntuple(i -> virtuallabel(i), N - 1)...), (envlabel(:SW),)
+    )
 
-    numrows = size(above, 1)
-    eigenvals = Vector{Vector{scalartype(above)}}(undef, numrows)
+    rhs = Expr(
+        :call,
+        :*,
+        C_northwest_e,
+        E_north_e,
+        C_northeast_e,
+        C_southeast_e,
+        E_south_e,
+        C_southwest_e,
+    )
 
-    @threads for cr in 1:numrows
-        L0 = MPSKit.randomize!(MPSKit.allocate_GL(above[cr - 1], O[cr], below[cr + 1], 1))
-
-        E_LL = MPSKit.TransferMatrix(above[cr - 1].AL, O[cr], below[cr + 1].AL)  # Note that this index convention is different from above!
-        λ, _, convhist = eigsolve(flip(E_LL), L0, num_vals, :LM, solver)
-        convhist.converged < num_vals &&
-            @warn "correlation length failed to converge: normres = $(convhist.normres)"
-        eigenvals[cr] = λ
-    end
-
-    return eigenvals
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $rhs))
 end
 
 """

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -346,9 +346,7 @@ Contract a local tensor `O` inserted into a partition function `pf` at position 
 using the environment `env`.
 """
 function contract_local_tensor(
-    inds::Tuple{Int,Int},
-    O::PFTensor,
-    env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor},
+    inds::Tuple{Int,Int}, O::PFTensor, env::CTMRGEnv{C,<:CTMRG_PF_EdgeTensor}
 ) where {C}
     r, c = inds
     return @autoopt @tensor env.corners[NORTHWEST, _prev(r, end), _prev(c, end)][

--- a/src/networks/infinitesquarenetwork.jl
+++ b/src/networks/infinitesquarenetwork.jl
@@ -20,6 +20,7 @@ struct InfiniteSquareNetwork{O}
         return InfiniteSquareNetwork{eltype(A)}(A)
     end
 end
+InfiniteSquareNetwork(n::InfiniteSquareNetwork) = n
 
 ## Unit cell interface
 

--- a/test/ctmrg/partition_function.jl
+++ b/test/ctmrg/partition_function.jl
@@ -1,10 +1,9 @@
 using Test
 using Random
+using LinearAlgebra
 using PEPSKit
 using TensorKit
-using LinearAlgebra
 using QuadGK
-using MPSKit
 
 ## Setup
 
@@ -44,8 +43,9 @@ Implements the 2D classical Ising model with partition function
 \\mathcal{Z}(\\beta) = \\sum_{\\{s\\}} \\exp(-\\beta H(s)) \\text{ with } H(s) = -J \\sum_{\\langle i, j \\rangle} s_i s_j
 ```
 """
-function classical_ising(; beta=log(1 + sqrt(2)) / 2, J=1.0)
+function classical_ising(beta=log(1 + sqrt(2)) / 2, J=1.0)
     K = beta * J
+
     # Boltzmann weights
     t = ComplexF64[exp(K) exp(-K); exp(-K) exp(K)]
     r = eigen(t)
@@ -80,7 +80,7 @@ end
 
 # initialize
 beta = 0.6
-O, M, E = classical_ising(; beta)
+O, M, E = classical_ising(beta)
 Z = InfinitePartitionFunction(O)
 Random.seed!(81812781143)
 

--- a/test/ctmrg/partition_function.jl
+++ b/test/ctmrg/partition_function.jl
@@ -8,7 +8,7 @@ using QuadGK
 ## Setup
 
 """
-    ising_exact(beta, J)
+    classical_ising_exact(beta, J)
 
 [Exact Onsager solution](https://en.wikipedia.org/wiki/Square_lattice_Ising_model#Exact_solution)
 for the 2D classical Ising Model with partition function
@@ -43,7 +43,7 @@ Implements the 2D classical Ising model with partition function
 \\mathcal{Z}(\\beta) = \\sum_{\\{s\\}} \\exp(-\\beta H(s)) \\text{ with } H(s) = -J \\sum_{\\langle i, j \\rangle} s_i s_j
 ```
 """
-function classical_ising(beta=log(1 + sqrt(2)) / 2, J=1.0)
+function classical_ising(; beta=log(1 + sqrt(2)) / 2, J=1.0)
     K = beta * J
 
     # Boltzmann weights
@@ -80,7 +80,7 @@ end
 
 # initialize
 beta = 0.6
-O, M, E = classical_ising(beta)
+O, M, E = classical_ising(; beta)
 Z = InfinitePartitionFunction(O)
 Random.seed!(81812781143)
 

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -56,8 +56,8 @@ O, M, E = three_dimensional_classical_ising(beta)
 χenv = ℂ^12
 
 # cover all different flavors
-ctm_styles = [SequentialCTMRG, SimultaneousCTMRG]
-projector_algs = [HalfInfiniteProjector, FullInfiniteProjector]
+ctm_styles = [:sequential, :simultaneous]
+projector_algs = [:halfinfinite, :fullinfinite]
 
 @testset "PEPO CTMRG runthroughs for unitcell=$(unitcell)" for unitcell in
                                                                [(1, 1, 1), (1, 1, 2)]
@@ -70,12 +70,11 @@ projector_algs = [HalfInfiniteProjector, FullInfiniteProjector]
     env0 = CTMRGEnv(n, χenv)
 
     @testset "PEPO CTMRG contraction using $ctm_style with $projector_alg" for (
-        ctm_style, projector_alg
+        alg, projector_alg
     ) in Iterators.product(
         ctm_styles, projector_algs
     )
-        ctm_alg = ctm_style(; maxiter=150, projector_alg)
-        env, = leading_boundary(env0, n, ctm_alg)
+        env, = leading_boundary(env0, n; alg, maxiter=150, projector_alg)
     end
 end
 

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -50,7 +50,7 @@ end
 ## Test
 
 # initialize
-beta = 0.224 # slightly lower temperature than βc ≈ 0.2216544
+beta = 0.2391 # slightly lower temperature than βc ≈ 0.2216544
 O, M, E = three_dimensional_classical_ising(beta)
 χpeps = ℂ^2
 χenv = ℂ^12

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -133,7 +133,7 @@ end
     nrm3 = PEPSKit._contract_site((1, 1), n3_final, env3_final)
 
     # compare to Monte-Carlo result from https://www.worldscientific.com/doi/abs/10.1142/S0129183101002383
-    @test abs(m / nrm3) ≈ 0.0 rtol = 1e-2
+    @test abs(m / nrm3) ≈ 0.667162 rtol = 1e-2
 
     # TODO: figure out issue with energy conventions...
 end

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -89,7 +89,9 @@ end
     )
     opt_alg = LBFGS(32; maxiter=50, gradtol=1e-5, verbosity=3)
     function pepo_retract(x, η, α)
-        return (PEPSKit.peps_retract(x[1:2], η, α)..., deepcopy(x[3])), η
+        x´_partial, ξ = PEPSKit.peps_retract(x[1:2], η, α)
+        x´ = (x´_partial..., deepcopy(x[3]))
+        return x´, ξ
     end
     function pepo_transport!(ξ, x, η, α, x´)
         return PEPSKit.peps_transport!(ξ, x[1:2], η, α, x´[1:2])

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -87,7 +87,7 @@ end
     alg_rrule = EigSolver(;
         solver=KrylovKit.Arnoldi(; maxiter=30, tol=1e-6, eager=true), iterscheme=:diffgauge
     )
-    opt_alg = LBFGS(32; maxiter=20, gradtol=1e-4, verbosity=3)
+    opt_alg = LBFGS(32; maxiter=20, gradtol=1e-5, verbosity=3)
     function pepo_retract(x, η, α)
         peps = deepcopy(x[1])
         peps.A .+= η.A .* α
@@ -129,14 +129,11 @@ end
 
     # check energy
     n3_final = InfiniteSquareNetwork(psi_final, T)
-    e = PEPSKit.contract_local_tensor((1, 1, 1), E, n3_final, env3_final)
+    m = PEPSKit.contract_local_tensor((1, 1, 1), M, n3_final, env3_final)
     nrm3 = PEPSKit._contract_site((1, 1), n3_final, env3_final)
 
-    e_per_link = e / nrm3 / 3
+    # compare to Monte-Carlo result from https://www.worldscientific.com/doi/abs/10.1142/S0129183101002383
+    @test abs(m / nrm3) ≈ 0.0 rtol = 1e-2
 
-    @test e_per_link ≈ -0.53 atol = 1e-2
-
-    # TODO: figure out what we should actually get
-    # result does not seem to match the one from https://iopscience.iop.org/article/10.1088/0305-4470/31/29/007/pdf
-    # beta = 0.2240, E ≈ 0.378615(26)
+    # TODO: figure out issue with energy conventions...
 end

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -1,0 +1,54 @@
+
+using Test
+using Random
+using PEPSKit
+using TensorKit
+using LinearAlgebra
+using QuadGK
+using MPSKit
+
+## Setup
+
+function ising_pepo(beta; unitcell=(1, 1, 1))
+    t = ComplexF64[exp(beta) exp(-beta); exp(-beta) exp(beta)]
+    q = sqrt(t)
+
+    O = zeros(2, 2, 2, 2, 2, 2)
+    O[1, 1, 1, 1, 1, 1] = 1
+    O[2, 2, 2, 2, 2, 2] = 1
+    @tensor o[-1 -2; -3 -4 -5 -6] :=
+        O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
+
+    O = TensorMap(o, ℂ^2 ⊗ (ℂ^2)' ← ℂ^2 ⊗ ℂ^2 ⊗ (ℂ^2)' ⊗ (ℂ^2)')
+
+    return InfinitePEPO(O; unitcell)
+end
+
+## Test
+
+# initialize
+beta = 1
+O = ising_pepo(1)
+O2 = repeat(O, 1, 1, 2)
+Random.seed!(81812781143)
+
+# contract
+psi = initializePEPS(O, ComplexSpace(2))
+n1 = InfiniteSquareNetwork(psi, O)
+n2 = InfiniteSquareNetwork(psi, O2)
+χenv = ℂ^12
+env1_0 = CTMRGEnv(n1, χenv)
+env2_0 = CTMRGEnv(n2, χenv)
+
+# cover all different flavors
+ctm_styles = [SequentialCTMRG, SimultaneousCTMRG]
+projector_algs = [HalfInfiniteProjector, FullInfiniteProjector]
+
+@testset "PEPO-trial using $ctm_style with $projector_alg" for (ctm_style, projector_alg) in
+                                                               Iterators.product(
+    ctm_styles, projector_algs
+)
+    ctm_alg = ctm_style(; maxiter=150, projector_alg)
+    env1, = leading_boundary(env1_0, n1, ctm_alg)
+    env2, = leading_boundary(env2_0, n2, ctm_alg)
+end

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -84,7 +84,8 @@ end
     # prep
     ctm_alg = SimultaneousCTMRG(; maxiter=150, tol=1e-8, verbosity=2)
     alg_rrule = EigSolver(;
-        solver=KrylovKit.Arnoldi(; maxiter=30, tol=1e-6, eager=true), iterscheme=:diffgauge
+        solver_alg=KrylovKit.Arnoldi(; maxiter=30, tol=1e-6, eager=true),
+        iterscheme=:diffgauge,
     )
     opt_alg = LBFGS(32; maxiter=50, gradtol=1e-5, verbosity=3)
     function pepo_retract(x, η, α)

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -69,7 +69,7 @@ projector_algs = [:halfinfinite, :fullinfinite]
     n = InfiniteSquareNetwork(psi0, T)
     env0 = CTMRGEnv(n, χenv)
 
-    @testset "PEPO CTMRG contraction using $ctm_style with $projector_alg" for (
+    @testset "PEPO CTMRG contraction using $alg with $projector_alg" for (
         alg, projector_alg
     ) in Iterators.product(
         ctm_styles, projector_algs

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -94,7 +94,7 @@ end
         env3 = deepcopy(x[3])
         return (peps, env2, env3), η
     end
-    
+
     # contract
     T = InfinitePEPO(O; unitcell=(1, 1, 1))
     psi0 = initializePEPS(T, ComplexSpace(2))
@@ -125,11 +125,11 @@ end
     n3_final = InfiniteSquareNetwork(psi_final, T)
     e = PEPSKit.contract_local_tensor((1, 1, 1), E, n3_final, env3_final)
     nrm3 = PEPSKit._contract_site((1, 1), n3_final, env3_final)
-    
+
     e_per_link = e / nrm3 / 3
 
-    @test e_per_link ≈ -0.53, atol=1e-2
-            
+    @test e_per_link ≈ -0.53, atol = 1e-2
+
     # TODO: figure out what we should actually get
     # result does not seem to match the one from https://iopscience.iop.org/article/10.1088/0305-4470/31/29/007/pdf
     # beta = 0.2240, E ≈ 0.378615(26)

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -3,52 +3,134 @@ using Test
 using Random
 using PEPSKit
 using TensorKit
-using LinearAlgebra
-using QuadGK
-using MPSKit
+using KrylovKit
+using OptimKit
+using Zygote
+using ChainrulesCore
 
 ## Setup
 
-function ising_pepo(beta; unitcell=(1, 1, 1))
-    t = ComplexF64[exp(beta) exp(-beta); exp(-beta) exp(beta)]
-    q = sqrt(t)
+function three_dimensional_classical_ising(beta, J=1.0)
+    K = beta * J
 
+    # Boltzmann weights
+    t = ComplexF64[exp(K) exp(-K); exp(-K) exp(K)]
+    r = eigen(t)
+    q = r.vectors * sqrt(LinearAlgebra.Diagonal(r.values)) * r.vectors
+
+    # local partition function tensor
     O = zeros(2, 2, 2, 2, 2, 2)
     O[1, 1, 1, 1, 1, 1] = 1
     O[2, 2, 2, 2, 2, 2] = 1
     @tensor o[-1 -2; -3 -4 -5 -6] :=
         O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
 
-    O = TensorMap(o, ℂ^2 ⊗ (ℂ^2)' ← ℂ^2 ⊗ ℂ^2 ⊗ (ℂ^2)' ⊗ (ℂ^2)')
+    # magnetization tensor
+    M = copy(O)
+    M[2, 2, 2, 2, 2, 2] *= -1
+    @tensor m[-1 -2; -3 -4 -5 -6] :=
+        M[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
 
-    return InfinitePEPO(O; unitcell)
+    # bond interaction tensor and energy-per-site tensor
+    e = ComplexF64[-J J; J -J] .* q
+    @tensor e_x[-1 -2; -3 -4 -5 -6] :=
+        O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * q[-3; 3] * e[-4; 4] * q[-5; 5] * q[-6; 6]
+    @tensor e_y[-1 -2; -3 -4 -5 -6] :=
+        O[1 2; 3 4 5 6] * q[-1; 1] * q[-2; 2] * e[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
+    @tensor e_z[-1 -2; -3 -4 -5 -6] :=
+        O[1 2; 3 4 5 6] * e[-1; 1] * q[-2; 2] * q[-3; 3] * q[-4; 4] * q[-5; 5] * q[-6; 6]
+    e = e_x + e_y + e_z
+
+    # fixed tensor map space for all three
+    TMS = ℂ^2 ⊗ ℂ^2 ← ℂ^2 ⊗ ℂ^2 ⊗ ℂ^2 ⊗ ℂ^2
+
+    return TensorMap(o, TMS), TensorMap(m, TMS), TensorMap(e, TMS)
 end
 
 ## Test
 
 # initialize
-beta = 1
-O = ising_pepo(1)
-O2 = repeat(O, 1, 1, 2)
-Random.seed!(81812781143)
-
-# contract
-psi = initializePEPS(O, ComplexSpace(2))
-n1 = InfiniteSquareNetwork(psi, O)
-n2 = InfiniteSquareNetwork(psi, O2)
+beta = 0.224 # slightly lower temperature than βc ≈ 0.2216544
+O, M, E = three_dimensional_classical_ising(beta)
 χenv = ℂ^12
-env1_0 = CTMRGEnv(n1, χenv)
-env2_0 = CTMRGEnv(n2, χenv)
 
 # cover all different flavors
 ctm_styles = [SequentialCTMRG, SimultaneousCTMRG]
 projector_algs = [HalfInfiniteProjector, FullInfiniteProjector]
 
-@testset "PEPO-trial using $ctm_style with $projector_alg" for (ctm_style, projector_alg) in
-                                                               Iterators.product(
-    ctm_styles, projector_algs
-)
-    ctm_alg = ctm_style(; maxiter=150, projector_alg)
-    env1, = leading_boundary(env1_0, n1, ctm_alg)
-    env2, = leading_boundary(env2_0, n2, ctm_alg)
+@testset "PEPO CTMRG runthroughs for unitcell=$(unitcell)" for unitcell in
+                                                               [(1, 1, 1), (1, 1, 2)]
+    Random.seed!(81812781143)
+
+    # contract
+    T = InfinitePEPO(O; unitcell=unitcell)
+    psi0 = initializePEPS(T, ComplexSpace(2))
+    n = InfiniteSquareNetwork(psi, T)
+    env0 = CTMRGEnv(n, χenv)
+
+    @testset "PEPO CTMRG contraction using $ctm_style with $projector_alg" for (
+        ctm_style, projector_alg
+    ) in Iterators.product(
+        ctm_styles, projector_algs
+    )
+        ctm_alg = ctm_style(; maxiter=150, projector_alg)
+        env, = leading_boundary(env0, n, ctm_alg)
+    end
+end
+
+@testset "Fixed-point computation for 3D classical ising model" begin
+    Random.seed!(81812781143)
+
+    # prep
+    ctm_alg = SimultaneousCTMRG(; maxiter=150, tol=1e-8, verbosity=2)
+    alg_rrule = LinSolver(;
+        solver=KrylovKit.GMRES(; maxiter=30, tol=1e-6), iterscheme=:fixed
+    )
+    opt_alg = LBFGS(32; maxiter=20, gradtol=1e-4, verbosity=3)
+    function pepo_retract(x, η, α)
+        peps = deepcopy(x[1])
+        peps.A .+= η.A .* α
+        env2 = deepcopy(x[2])
+        env3 = deepcopy(x[3])
+        return (peps, env2, env3), η
+    end
+    
+    # contract
+    T = InfinitePEPO(O; unitcell=(1, 1, 1))
+    psi0 = initializePEPS(T, ComplexSpace(2))
+    env2_0 = CTMRGEnv(InfiniteSquareNetwork(psi0), χenv)
+    env3_0 = CTMRGEnv(InfiniteSquareNetwork(psi0, T), χenv)
+
+    # optimize free energy per site
+    (psi_final, env2_final, env3_final), E, = optimize(
+        (psi0, env2_0, env3_0), opt_alg; retract=pepo_retract, inner=PEPSKit.real_inner
+    ) do (psi, env2, env3)
+        E, gs = withgradient(psi) do ψ
+            env2′, info = hook_pullback(leading_boundary, env2, n2, ctm_alg; alg_rrule)
+            n3 = InfiniteSquareNetwork(ψ, T)
+            env3′, info = hook_pullback(leading_boundary, env3, n3, ctm_alg; alg_rrule)
+            ignore_derivatives() do
+                update!(env2, env2′)
+                update!(env3, env3′)
+            end
+            λ3 = network_value(n3, env3)
+            λ2 = network_value(n2, env2)
+            return -log(real(λ3 / λ2))
+        end
+        g = only(gs)
+        return E, g
+    end
+
+    # check energy
+    n3_final = InfiniteSquareNetwork(psi_final, T)
+    e = PEPSKit.contract_local_tensor((1, 1, 1), E, n3_final, env3_final)
+    nrm3 = PEPSKit._contract_site((1, 1), n3_final, env3_final)
+    
+    e_per_link = e / nrm3 / 3
+
+    @test e_per_link ≈ -0.53, atol=1e-2
+            
+    # TODO: figure out what we should actually get
+    # result does not seem to match the one from https://iopscience.iop.org/article/10.1088/0305-4470/31/29/007/pdf
+    # beta = 0.2240, E ≈ 0.378615(26)
 end

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -134,6 +134,4 @@ end
 
     # compare to Monte-Carlo result from https://www.worldscientific.com/doi/abs/10.1142/S0129183101002383
     @test abs(m / nrm3) ≈ 0.667162 rtol = 1e-2
-
-    # TODO: figure out issue with energy conventions...
 end

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -87,7 +87,7 @@ end
     alg_rrule = EigSolver(;
         solver=KrylovKit.Arnoldi(; maxiter=30, tol=1e-6, eager=true), iterscheme=:diffgauge
     )
-    opt_alg = LBFGS(32; maxiter=20, gradtol=1e-5, verbosity=3)
+    opt_alg = LBFGS(32; maxiter=50, gradtol=1e-5, verbosity=3)
     function pepo_retract(x, η, α)
         peps = deepcopy(x[1])
         peps.A .+= η.A .* α

--- a/test/ctmrg/pepo.jl
+++ b/test/ctmrg/pepo.jl
@@ -10,7 +10,7 @@ using Zygote
 
 ## Setup
 
-function three_dimensional_classical_ising(beta, J=1.0)
+function three_dimensional_classical_ising(; beta, J=1.0)
     K = beta * J
 
     # Boltzmann weights
@@ -51,7 +51,7 @@ end
 
 # initialize
 beta = 0.2391 # slightly lower temperature than βc ≈ 0.2216544
-O, M, E = three_dimensional_classical_ising(beta)
+O, M, E = three_dimensional_classical_ising(; beta)
 χpeps = ℂ^2
 χenv = ℂ^12
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,6 @@ end
         @time @safetestset ":fixed CTMRG iteration scheme" begin
             include("ctmrg/fixed_iterscheme.jl")
         end
-        @time @safetestset "Unit cells" begin
-            include("ctmrg/unitcell.jl")
-        end
         @time @safetestset "Flavors" begin
             include("ctmrg/flavors.jl")
         end
@@ -34,6 +31,9 @@ end
         end
         @time @safetestset "Partition function" begin
             include("ctmrg/partition_function.jl")
+        end
+        @time @safetestset "PEPO" begin
+            include("ctmrg/pepo.jl")
         end
     end
     if GROUP == "ALL" || GROUP == "BOUNDARYMPS"


### PR DESCRIPTION
Implements all the contractions required to run CTMRG for PEPO sandwiches with an arbitrary number of layers.

TODO:
- [x] Add a test with a proper numerical check on the outcome