### PR TITLE
Enforce `FixedSpaceTruncation` during differentiation

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -3,7 +3,7 @@ module PEPSKit
 using LinearAlgebra, Statistics, Base.Threads, Base.Iterators, Printf
 using Base: @kwdef
 using Compat
-using Accessors: @set
+using Accessors: @set, @reset
 using VectorInterface
 using TensorKit, KrylovKit, MPSKit, OptimKit, TensorOperations
 using ChainRulesCore, Zygote

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -111,13 +111,15 @@ function _rrule(
     alg::CTMRGAlgorithm,
 )
     env, info = leading_boundary(envinit, state, alg)
-    @reset alg.projector_alg.trscheme = FixedSpaceTruncation() # fix spaces during differentiation
+    alg_fixed = @set alg.projector_alg.trscheme = FixedSpaceTruncation() # fix spaces during differentiation
 
     function leading_boundary_diffgauge_pullback((Δenv′, Δinfo))
         Δenv = unthunk(Δenv′)
 
         # find partial gradients of gauge_fixed single CTMRG iteration
-        f(A, x) = gauge_fix(x, ctmrg_iteration(InfiniteSquareNetwork(A), x, alg)[1])[1]
+        function f(A, x)
+            return gauge_fix(x, ctmrg_iteration(InfiniteSquareNetwork(A), x, alg_fixed)[1])[1]
+        end
         _, env_vjp = rrule_via_ad(config, f, state, env)
 
         # evaluate the geometric sum

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -111,6 +111,7 @@ function _rrule(
     alg::CTMRGAlgorithm,
 )
     env, info = leading_boundary(envinit, state, alg)
+    @reset alg.projector_alg.trscheme = FixedSpaceTruncation() # fix spaces during differentiation
 
     function leading_boundary_diffgauge_pullback((Δenv′, Δinfo))
         Δenv = unthunk(Δenv′)


### PR DESCRIPTION
This fixes #138 by overwriting the `trscheme` to `FixedSpaceTruncation` in the CTMRG algorithm during differentiation. This is only necessary for `:diffgauge` since for the `:fixed` mode the SVD is anyway fixed and only accepts `NoTruncation`.