### PR TITLE
Refactor `absorb_weight` and use `leftorth` in `_qr_bond`

### DIFF
--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -114,10 +114,10 @@ end
 
 """
     simpleupdate(peps::InfiniteWeightPEPS, ham::LocalOperator, alg::SimpleUpdate;
-                 bipartite::Bool=false, check_int::Int=500)
+                 bipartite::Bool=false, check_interval::Int=500)
 
 Perform simple update with nearest neighbor Hamiltonian `ham`, where the evolution
-information is printed every `check_int` steps. 
+information is printed every `check_interval` steps. 
 
 If `bipartite == true` (for square lattice), a unit cell size of `(2, 2)` is assumed, 
 as well as tensors and x/y weights which are the same across the diagonals, i.e. at
@@ -128,7 +128,7 @@ function simpleupdate(
     ham::LocalOperator,
     alg::SimpleUpdate;
     bipartite::Bool=false,
-    check_int::Int=500,
+    check_interval::Int=500,
 )
     time_start = time()
     Nr, Nc = size(peps)
@@ -147,7 +147,7 @@ function simpleupdate(
         cancel = (count == alg.maxiter)
         wts0 = deepcopy(peps.weights)
         time1 = time()
-        if ((count == 1) || (count % check_int == 0) || converge || cancel)
+        if ((count == 1) || (count % check_interval == 0) || converge || cancel)
             @info "Space of x-weight at [1, 1] = $(space(peps.weights[1, 1, 1], 1))"
             label = (converge ? "conv" : (cancel ? "cancel" : "iter"))
             message = @sprintf(

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -39,21 +39,16 @@ function _su_bondx!(
     A, B = peps.vertices[row, col], peps.vertices[row, cp1]
     sqrtsA = ntuple(dir -> (dir == EAST), 4)
     sqrtsB = ntuple(dir -> (dir == WEST), 4)
-    _allfalse, _alltrue = ntuple(Returns(false), 4), ntuple(Returns(true), 4)
-    A = _absorb_weights(A, peps.weights, row, col, Tuple(1:4), sqrtsA, _allfalse)
-    B = _absorb_weights(B, peps.weights, row, cp1, Tuple(1:4), sqrtsB, _allfalse)
+    A = _absorb_weights(A, peps.weights, row, col, Tuple(1:4), sqrtsA, false)
+    B = _absorb_weights(B, peps.weights, row, cp1, Tuple(1:4), sqrtsB, false)
     # apply gate
     X, a, b, Y = _qr_bond(A, B)
     a, s, b, ϵ = _apply_gate(a, b, gate, alg.trscheme)
     A, B = _qr_bond_undo(X, a, b, Y)
     # remove environment weights
-    _allfalse, _alltrue = _allfalse[1:3], _alltrue[1:3]
-    A = _absorb_weights(
-        A, peps.weights, row, col, (NORTH, SOUTH, WEST), _allfalse, _alltrue
-    )
-    B = _absorb_weights(
-        B, peps.weights, row, cp1, (NORTH, SOUTH, EAST), _allfalse, _alltrue
-    )
+    _allfalse = ntuple(Returns(false), 3)
+    A = _absorb_weights(A, peps.weights, row, col, (NORTH, SOUTH, WEST), _allfalse, true)
+    B = _absorb_weights(B, peps.weights, row, cp1, (NORTH, SOUTH, EAST), _allfalse, true)
     # update tensor dict and weight on current bond 
     # (max element of weight is normalized to 1)
     peps.vertices[row, col], peps.vertices[row, cp1] = A, B

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -39,7 +39,7 @@ function _su_bondx!(
     A, B = peps.vertices[row, col], peps.vertices[row, cp1]
     sqrtsA = ntuple(dir -> (dir == EAST), 4)
     sqrtsB = ntuple(dir -> (dir == WEST), 4)
-    _allfalse, _alltrue = ntuple(_ -> false, 4), ntuple(_ -> true, 4)
+    _allfalse, _alltrue = ntuple(Returns(false), 4), ntuple(Returns(true), 4)
     A = _absorb_weights(A, peps.weights, row, col, Tuple(1:4), sqrtsA, _allfalse)
     B = _absorb_weights(B, peps.weights, row, cp1, Tuple(1:4), sqrtsB, _allfalse)
     # apply gate

--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -190,7 +190,7 @@ end
     absorb_weight(t::PEPSTensor, row::Int, col::Int, ax::Int, weights::SUWeight;
                   sqrtwt::Bool=false, invwt::Bool=false)
 
-Absorb or remove environment weight on axis `ax` of vertex tensor `t` 
+Absorb or remove environment weight on an axis of vertex tensor `t` 
 known to be located at position (`row`, `col`) in the unit cell. 
 Weights around the tensor at `(row, col)` are
 ```
@@ -207,7 +207,7 @@ Weights around the tensor at `(row, col)` are
 - `t::T`: The vertex tensor to which the weight will be absorbed. The first axis of `t` should be the physical axis. 
 - `row::Int`: The row index specifying the position in the tensor network.
 - `col::Int`: The column index specifying the position in the tensor network.
-- `ax::Int`: The axis along which the weight is absorbed.
+- `ax::Int`: The axis into which the weight is absorbed, taking values from 1 to 4, standing for north, east, south, west respectively.
 - `weights::SUWeight`: The weight object to absorb into the tensor.
 - `sqrtwt::Bool=false` (optional): If `true`, the square root of the weight is absorbed.
 - `invwt::Bool=false` (optional): If `true`, the inverse of the weight is absorbed.
@@ -217,13 +217,13 @@ The optional kwargs `sqrtwt` and `invwt` allow taking the square root or the inv
 
 # Examples
 ```julia
-# Absorb the weight into the 2nd axis of tensor at position (2, 3)
-absorb_weight(t, 2, 3, 2, weights)
+# Absorb the weight into the north axis of tensor at position (2, 3)
+absorb_weight(t, 2, 3, 1, weights)
 
-# Absorb the square root of the weight into the tensor
-absorb_weight(t, 2, 3, 2, weights; sqrtwt=true)
+# Absorb the square root of the weight into the south axis
+absorb_weight(t, 2, 3, 3, weights; sqrtwt=true)
 
-# Absorb the inverse of (i.e. remove) the weight into the tensor
+# Absorb the inverse of (i.e. remove) the weight into the east axis
 absorb_weight(t, 2, 3, 2, weights; invwt=true)
 ```
 """
@@ -236,7 +236,7 @@ function absorb_weight(
     sqrtwt::Bool=false,
     invwt::Bool=false,
 )
-    return _absorb_weights(t, weights, row, col, (ax - 1,), (sqrtwt,), invwt)
+    return _absorb_weights(t, weights, row, col, (ax,), (sqrtwt,), invwt)
 end
 
 """

--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -138,9 +138,57 @@ function InfiniteWeightPEPS(
     )
 end
 
+function Base.size(peps::InfiniteWeightPEPS)
+    return size(peps.vertices)
+end
+
+function _absorb_weights(
+    t::PEPSTensor,
+    weights::SUWeight,
+    row::Int,
+    col::Int,
+    axs::NTuple{N,Int},
+    sqrts::NTuple{N,Bool},
+    invs::NTuple{N,Bool},
+) where {N}
+    Nr, Nc = size(weights)[2:end]
+    @assert 1 <= row <= Nr && 1 <= col <= Nc
+    @assert 1 <= N <= 4
+    tensors = Vector{AbstractTensorMap}()
+    indices = Vector{Vector{Int}}()
+    indices_t = collect(-1:-1:-5)
+    for (ax, sqrtwt, invwt) in zip(axs, sqrts, invs)
+        @assert 1 <= ax <= 4
+        axp1 = ax + 1
+        indices_t[axp1] *= -1
+        wt = if ax == NORTH
+            weights[2, row, col]
+        elseif ax == EAST
+            weights[1, row, col]
+        elseif ax == SOUTH
+            weights[2, _next(row, Nr), col]
+        else # WEST
+            weights[1, row, _prev(col, Nc)]
+        end
+        # TODO: remove the dual constraint
+        @assert !isdual(space(wt, 1)) && isdual(space(wt, 2))
+        if (!sqrtwt && !invwt)
+            push!(tensors, wt)
+        else
+            pow = (sqrtwt ? 1 / 2 : 1) * (invwt ? -1 : 1)
+            push!(tensors, sdiag_pow(wt, pow))
+        end
+        push!(indices, (ax in (NORTH, EAST) ? [axp1, -axp1] : [-axp1, axp1]))
+    end
+    push!(tensors, t)
+    push!(indices, indices_t)
+    t2 = permute(ncon(tensors, indices), ((1,), Tuple(2:5)))
+    return t2
+end
+
 """
-    absorb_weight(t::T, row::Int, col::Int, ax::Int, weights::SUWeight;
-                  sqrtwt::Bool=false, invwt::Bool=false) where {T<:PEPSTensor}
+    absorb_weight(t::PEPSTensor, row::Int, col::Int, ax::Int, weights::SUWeight;
+                  sqrtwt::Bool=false, invwt::Bool=false)
 
 Absorb or remove environment weight on axis `ax` of vertex tensor `t` 
 known to be located at position (`row`, `col`) in the unit cell. 
@@ -180,33 +228,15 @@ absorb_weight(t, 2, 3, 2, weights; invwt=true)
 ```
 """
 function absorb_weight(
-    t::T,
+    t::PEPSTensor,
     row::Int,
     col::Int,
     ax::Int,
     weights::SUWeight;
     sqrtwt::Bool=false,
     invwt::Bool=false,
-) where {T<:PEPSTensor}
-    Nr, Nc = size(weights)[2:end]
-    @assert 1 <= row <= Nr && 1 <= col <= Nc
-    @assert 2 <= ax <= 5
-    pow = (sqrtwt ? 1 / 2 : 1) * (invwt ? -1 : 1)
-    if ax == 2 # north
-        wt = weights[2, row, col]
-    elseif ax == 3 # east
-        wt = weights[1, row, col]
-    elseif ax == 4 # south
-        wt = weights[2, _next(row, Nr), col]
-    else # west
-        wt = weights[1, row, _prev(col, Nc)]
-    end
-    wt2 = sdiag_pow(wt, pow)
-    indices_t = collect(-1:-1:-5)
-    indices_t[ax] = 1
-    indices_wt = (ax in (2, 3) ? [1, -ax] : [-ax, 1])
-    t2 = permute(ncon((t, wt2), (indices_t, indices_wt)), ((1,), Tuple(2:5)))
-    return t2
+)
+    return _absorb_weights(t, weights, row, col, (ax - 1,), (sqrtwt,), (invwt,))
 end
 
 """
@@ -215,20 +245,17 @@ end
 Create `InfinitePEPS` from `InfiniteWeightPEPS` by absorbing bond weights into vertex tensors.
 """
 function InfinitePEPS(peps::InfiniteWeightPEPS)
-    vertices = deepcopy(peps.vertices)
-    Nr, Nc = size(vertices)
-    for (r, c) in Iterators.product(1:Nr, 1:Nc)
-        for ax in 2:5
-            vertices[r, c] = absorb_weight(
-                vertices[r, c], r, c, ax, peps.weights; sqrtwt=true
-            )
-        end
-    end
-    return InfinitePEPS(vertices)
-end
-
-function Base.size(peps::InfiniteWeightPEPS)
-    return size(peps.vertices)
+    Nr, Nc = size(peps)
+    axs = Tuple(1:4)
+    _allfalse = ntuple(_ -> false, 4)
+    _alltrue = ntuple(_ -> true, 4)
+    return InfinitePEPS(
+        collect(
+            _absorb_weights(
+                peps.vertices[r, c], peps.weights, r, c, axs, _alltrue, _allfalse
+            ) for r in 1:Nr, c in 1:Nc
+        ),
+    )
 end
 
 """

--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -148,8 +148,8 @@ function _absorb_weights(
     row::Int,
     col::Int,
     axs::NTuple{N,Int},
-    sqrts::NTuple{N,Bool},
-    invs::NTuple{N,Bool},
+    sqrtwts::NTuple{N,Bool},
+    invwt::Bool,
 ) where {N}
     Nr, Nc = size(weights)[2:end]
     @assert 1 <= row <= Nr && 1 <= col <= Nc
@@ -157,7 +157,7 @@ function _absorb_weights(
     tensors = Vector{AbstractTensorMap}()
     indices = Vector{Vector{Int}}()
     indices_t = collect(-1:-1:-5)
-    for (ax, sqrtwt, invwt) in zip(axs, sqrts, invs)
+    for (ax, sqrtwt) in zip(axs, sqrtwts)
         @assert 1 <= ax <= 4
         axp1 = ax + 1
         indices_t[axp1] *= -1
@@ -236,7 +236,7 @@ function absorb_weight(
     sqrtwt::Bool=false,
     invwt::Bool=false,
 )
-    return _absorb_weights(t, weights, row, col, (ax - 1,), (sqrtwt,), (invwt,))
+    return _absorb_weights(t, weights, row, col, (ax - 1,), (sqrtwt,), invwt)
 end
 
 """
@@ -247,13 +247,11 @@ Create `InfinitePEPS` from `InfiniteWeightPEPS` by absorbing bond weights into v
 function InfinitePEPS(peps::InfiniteWeightPEPS)
     Nr, Nc = size(peps)
     axs = Tuple(1:4)
-    _allfalse = ntuple(_ -> false, 4)
-    _alltrue = ntuple(_ -> true, 4)
+    _alltrue = ntuple(Returns(true), 4)
     return InfinitePEPS(
         collect(
-            _absorb_weights(
-                peps.vertices[r, c], peps.weights, r, c, axs, _alltrue, _allfalse
-            ) for r in 1:Nr, c in 1:Nc
+            _absorb_weights(peps.vertices[r, c], peps.weights, r, c, axs, _alltrue, false)
+            for r in 1:Nr, c in 1:Nc
         ),
     )
 end

--- a/test/heisenberg.jl
+++ b/test/heisenberg.jl
@@ -50,7 +50,7 @@ end
 
 @testset "Simple update into AD optimization" begin
     # random initialization of 2x2 iPEPS with weights and CTMRGEnv (using real numbers)
-    Random.seed!(234829)
+    Random.seed!(100)
     N1, N2 = 2, 2
     Pspace = ℂ^2
     Vspace = ℂ^Dbond
@@ -67,11 +67,11 @@ end
     ham = LocalOperator(ham.lattice, Tuple(ind => real(op) for (ind, op) in ham.terms)...)
 
     # simple update
-    dts = [1e-2, 1e-3, 4e-4, 1e-4]
+    dts = [1e-2, 1e-3, 1e-3, 4e-4]
     tols = [1e-7, 1e-8, 1e-8, 1e-8]
     maxiter = 5000
     for (n, (dt, tol)) in enumerate(zip(dts, tols))
-        Dbond2 = (n == 1) ? Dbond + 2 : Dbond
+        Dbond2 = (n == 2) ? Dbond + 2 : Dbond
         trscheme = truncerr(1e-10) & truncdim(Dbond2)
         alg = SimpleUpdate(dt, tol, maxiter, trscheme)
         result = simpleupdate(wpeps, ham, alg; bipartite=false)
@@ -80,6 +80,7 @@ end
 
     # absorb weight into site tensors and CTMRG
     peps = InfinitePEPS(wpeps)
+    Random.seed!(100)
     env₀ = CTMRGEnv(rand, Float64, peps, Espace)
     env, = leading_boundary(env₀, peps, SimultaneousCTMRG())
 


### PR DESCRIPTION
This PR refactors the function `absorb_weight` and replace the direction labels t, r, b, l (borrowed from YASTN) with the existing constants NORTH = 1, etc. 

In addition, in `_qr_bond` for time evolution, I found that using `leftorth` only appears to be more numerically stable for some reason. So I want to make this change as well. Another possible advantage is that using `leftorth` only can help produce a `bondenv` around `a`, `b` that is a linear map between "un-dualed" spaces, which can save some twists:
```
    ┌-----------------------┐
    |   ┌----┐              |
    └---|    |-← a === b →--┘
        |benv|   ↓     ↓
    ┌---|    |-→ a† == b† ←-┐
    |   └----┘              |
    └-----------------------┘
```