### PR TITLE
Fix `Base.similar` for physical and contractible network types

### DIFF
--- a/src/networks/infinitesquarenetwork.jl
+++ b/src/networks/infinitesquarenetwork.jl
@@ -31,7 +31,7 @@ Base.eltype(::Type{InfiniteSquareNetwork{O}}) where {O} = O
 
 Base.copy(n::InfiniteSquareNetwork) = InfiniteSquareNetwork(copy(unitcell(n)))
 function Base.similar(n::InfiniteSquareNetwork, args...)
-    return InfiniteSquareNetwork(similar(unitcell(n), args...))
+    return InfiniteSquareNetwork(map(t -> similar(t, args...), unitcell(n)))
 end
 function Base.repeat(n::InfiniteSquareNetwork, counts...)
     return InfiniteSquareNetwork(repeat(unitcell(n), counts...))

--- a/src/networks/infinitesquarenetwork.jl
+++ b/src/networks/infinitesquarenetwork.jl
@@ -30,8 +30,8 @@ Base.eltype(n::InfiniteSquareNetwork) = eltype(typeof(n))
 Base.eltype(::Type{InfiniteSquareNetwork{O}}) where {O} = O
 
 Base.copy(n::InfiniteSquareNetwork) = InfiniteSquareNetwork(copy(unitcell(n)))
-function Base.similar(n::InfiniteSquareNetwork, args...)
-    return InfiniteSquareNetwork(map(t -> similar(t, args...), unitcell(n)))
+function Base.similar(n::InfiniteSquareNetwork, T::Type{TorA}=scalartype(n)) where {TorA}
+    return InfiniteSquareNetwork(map(t -> similar(t, T), unitcell(n)))
 end
 function Base.repeat(n::InfiniteSquareNetwork, counts...)
     return InfiniteSquareNetwork(repeat(unitcell(n), counts...))
@@ -53,6 +53,7 @@ end
 virtualspace(n::InfiniteSquareNetwork, r::Int, c::Int, dir) = virtualspace(n[r, c], dir)
 
 ## Vector interface
+
 function VectorInterface.scalartype(::Type{T}) where {T<:InfiniteSquareNetwork}
     return scalartype(eltype(T))
 end

--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -131,8 +131,8 @@ Base.eltype(::Type{InfinitePEPO{T}}) where {T} = T
 Base.eltype(A::InfinitePEPO) = eltype(typeof(A))
 
 Base.copy(A::InfinitePEPO) = InfinitePEPO(copy(unitcell(A)))
-function Base.similar(A::InfinitePEPO, args...)
-    return InfinitePEPO(map(t -> similar(t, args...), unitcell(A)))
+function Base.similar(A::InfinitePEPO, T::Type{TorA}=scalartype(A)) where {TorA}
+    return InfinitePEPO(map(t -> similar(t, T), unitcell(A)))
 end
 Base.repeat(A::InfinitePEPO, counts...) = InfinitePEPO(repeat(unitcell(A), counts...))
 
@@ -169,6 +169,15 @@ function InfiniteSquareNetwork(top::InfinitePEPS, mid::InfinitePEPO, bot::Infini
     return InfiniteSquareNetwork(
         map(tuple, unitcell(top), unitcell(bot), eachslice(unitcell(mid); dims=3)...)
     )
+end
+
+## Vector interface
+
+function VectorInterface.scalartype(::Type{NT}) where {NT<:InfinitePEPO}
+    return scalartype(eltype(NT))
+end
+function VectorInterface.zerovector(A::InfinitePEPO)
+    return InfinitePEPO(zerovector(unitcell(A)))
 end
 
 ## (Approximate) equality

--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -131,7 +131,9 @@ Base.eltype(::Type{InfinitePEPO{T}}) where {T} = T
 Base.eltype(A::InfinitePEPO) = eltype(typeof(A))
 
 Base.copy(A::InfinitePEPO) = InfinitePEPO(copy(unitcell(A)))
-Base.similar(A::InfinitePEPO, args...) = InfinitePEPO(similar(unitcell(A), args...))
+function Base.similar(A::InfinitePEPO, args...)
+    return InfinitePEPO(map(t -> similar(t, args...), unitcell(A)))
+end
 Base.repeat(A::InfinitePEPO, counts...) = InfinitePEPO(repeat(unitcell(A), counts...))
 
 Base.getindex(A::InfinitePEPO, args...) = Base.getindex(unitcell(A), args...)

--- a/src/states/infinitepartitionfunction.jl
+++ b/src/states/infinitepartitionfunction.jl
@@ -120,8 +120,10 @@ Base.eltype(::Type{InfinitePartitionFunction{T}}) where {T} = T
 Base.eltype(A::InfinitePartitionFunction) = eltype(typeof(A))
 
 Base.copy(A::InfinitePartitionFunction) = InfinitePartitionFunction(copy(unitcell(A)))
-function Base.similar(A::InfinitePartitionFunction, args...)
-    return InfinitePartitionFunction(map(t -> similar(t, args...), unitcell(A)))
+function Base.similar(
+    A::InfinitePartitionFunction, T::Type{TorA}=scalartype(A)
+) where {TorA}
+    return InfinitePartitionFunction(map(t -> similar(t, T), unitcell(A)))
 end
 function Base.repeat(A::InfinitePartitionFunction, counts...)
     return InfinitePartitionFunction(repeat(unitcell(A), counts...))
@@ -145,6 +147,15 @@ virtualspace(n::InfinitePartitionFunction, r::Int, c::Int, dir) = virtualspace(n
 
 function InfiniteSquareNetwork(state::InfinitePartitionFunction)
     return InfiniteSquareNetwork(unitcell(state))
+end
+
+## Vector interface
+
+function VectorInterface.scalartype(::Type{NT}) where {NT<:InfinitePartitionFunction}
+    return scalartype(eltype(NT))
+end
+function VectorInterface.zerovector(A::InfinitePartitionFunction)
+    return InfinitePartitionFunction(zerovector(unitcell(A)))
 end
 
 ## (Approximate) equality

--- a/src/states/infinitepartitionfunction.jl
+++ b/src/states/infinitepartitionfunction.jl
@@ -121,7 +121,7 @@ Base.eltype(A::InfinitePartitionFunction) = eltype(typeof(A))
 
 Base.copy(A::InfinitePartitionFunction) = InfinitePartitionFunction(copy(unitcell(A)))
 function Base.similar(A::InfinitePartitionFunction, args...)
-    return InfinitePartitionFunction(similar(unitcell(A), args...))
+    return InfinitePartitionFunction(map(t -> similar(t, args...), unitcell(A)))
 end
 function Base.repeat(A::InfinitePartitionFunction, counts...)
     return InfinitePartitionFunction(repeat(unitcell(A), counts...))

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -122,7 +122,9 @@ Base.eltype(::Type{InfinitePEPS{T}}) where {T} = T
 Base.eltype(A::InfinitePEPS) = eltype(typeof(A))
 
 Base.copy(A::InfinitePEPS) = InfinitePEPS(copy(unitcell(A)))
-Base.similar(A::InfinitePEPS, args...) = InfinitePEPS(similar(unitcell(A), args...))
+function Base.similar(A::InfinitePEPS, args...)
+    return InfinitePEPS(map(t -> similar(t, args...), unitcell(A)))
+end
 Base.repeat(A::InfinitePEPS, counts...) = InfinitePEPS(repeat(unitcell(A), counts...))
 
 Base.getindex(A::InfinitePEPS, args...) = Base.getindex(unitcell(A), args...)

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -122,8 +122,8 @@ Base.eltype(::Type{InfinitePEPS{T}}) where {T} = T
 Base.eltype(A::InfinitePEPS) = eltype(typeof(A))
 
 Base.copy(A::InfinitePEPS) = InfinitePEPS(copy(unitcell(A)))
-function Base.similar(A::InfinitePEPS, args...)
-    return InfinitePEPS(map(t -> similar(t, args...), unitcell(A)))
+function Base.similar(A::InfinitePEPS, T::Type{TorA}=scalartype(A)) where {TorA}
+    return InfinitePEPS(map(t -> similar(t, T), unitcell(A)))
 end
 Base.repeat(A::InfinitePEPS, counts...) = InfinitePEPS(repeat(unitcell(A), counts...))
 


### PR DESCRIPTION
The (untested) current implementations of `Base.similar` for our different network types was broken, leading to an `UndefRefError` in the checks on the virtual spaces in the inner constructor because all of the `unitcell` entries are `undef`. I patched it to really map `similar` over the unit cell entries, which I think is more in line with what we want here (e.g. to change the storage type of the entries in `similar(::TensorMap, ...)` style).

For context, I encountered this when calling `similar` on an `InfinitePEPS`, where I really expected the result to have the same virtual space structure. Alternatively, it's not clear that this is the proper way of implementing `Base.similar` and since this was never used or tested, I could also use `Base.copy` and just remove the broken `Base.similar` implementations.

Either way, I didn't want to leave in the broken implementations.