### PR TITLE
Implement TensorKit's `tsvd!` reverse-rule for `:fixed` differentiation mode

### DIFF
--- a/src/algorithms/ctmrg/projectors.jl
+++ b/src/algorithms/ctmrg/projectors.jl
@@ -77,7 +77,7 @@ function compute_projector(enlarged_corners, coordinate, alg::HalfInfiniteProjec
     end
 
     P_left, P_right = contract_projectors(U, S, V, enlarged_corners...)
-    return (P_left, P_right), info
+    return (P_left, P_right), (; U, S, V, info...)
 end
 function compute_projector(enlarged_corners, coordinate, alg::FullInfiniteProjector)
     halfinf_left = half_infinite_environment(enlarged_corners[1], enlarged_corners[2])
@@ -97,5 +97,5 @@ function compute_projector(enlarged_corners, coordinate, alg::FullInfiniteProjec
     end
 
     P_left, P_right = contract_projectors(U, S, V, halfinf_left, halfinf_right)
-    return (P_left, P_right), info
+    return (P_left, P_right), (; U, S, V, info...)
 end

--- a/src/algorithms/ctmrg/simultaneous.jl
+++ b/src/algorithms/ctmrg/simultaneous.jl
@@ -49,7 +49,10 @@ function _split_proj_and_info(proj_and_info)
     U = map(x -> x[2].U, proj_and_info)
     S = map(x -> x[2].S, proj_and_info)
     V = map(x -> x[2].V, proj_and_info)
-    info = (; truncation_error, condition_number, U, S, V)
+    U_full = map(x -> x[2].U_full, proj_and_info)
+    S_full = map(x -> x[2].S_full, proj_and_info)
+    V_full = map(x -> x[2].V_full, proj_and_info)
+    info = (; truncation_error, condition_number, U, S, V, U_full, S_full, V_full)
     return (P_left, P_right), info
 end
 

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -142,7 +142,6 @@ function _rrule(
     state,
     alg::SimultaneousCTMRG,
 )
-    @assert !isnothing(alg.projector_alg.svd_alg.rrule_alg)
     env, = leading_boundary(envinit, state, alg)
     env_conv, info = ctmrg_iteration(InfiniteSquareNetwork(state), env, alg)
     env_fixed, signs = gauge_fix(env, env_conv)
@@ -150,7 +149,7 @@ function _rrule(
     # Fix SVD
     U_fixed, V_fixed = fix_relative_phases(info.U, info.V, signs)
     svd_alg_fixed = SVDAdjoint(;
-        fwd_alg=FixedSVD(U_fixed, info.S, V_fixed),
+        fwd_alg=FixedSVD(U_fixed, info.S, V_fixed, info.U_full, info.S_full, info.V_full),
         rrule_alg=alg.projector_alg.svd_alg.rrule_alg,
     )
     alg_fixed = @set alg.projector_alg.svd_alg = svd_alg_fixed


### PR DESCRIPTION
Here we adapt `tsvd!` and `FixedSVD` such that the `:fixed` differentiation mode can also use TensorKit's SVD adjoint. For context, the `TensorKit.tsvd!` reverse-rule requires the full, untruncated SVD which is currently not passed along the CTMRG algorithm. To change this, `tsvd!` needs to return the untruncated decomposition as well. Hopefully, TensorKit's reverse-rule will eliminate some of the instabilities of KrylovKit's SVD reverse-rule.