### PR TITLE
Remove unnecessary type restriction on `_safe_pow`

### DIFF
--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -45,7 +45,7 @@ function _elementwise_mult(a₁::AbstractTensorMap, a₂::AbstractTensorMap)
     return dst
 end
 
-_safe_pow(a::Real, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
+_safe_pow(a::Number, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
 
 """
     sdiag_pow(s, pow::Real; tol::Real=eps(scalartype(s))^(3 / 4))

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -45,7 +45,7 @@ function _elementwise_mult(a₁::AbstractTensorMap, a₂::AbstractTensorMap)
     return dst
 end
 
-_safe_pow(a::Number, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
+_safe_pow(a::Real, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
 
 """
     sdiag_pow(s, pow::Real; tol::Real=eps(scalartype(s))^(3 / 4))


### PR DESCRIPTION
Here we loosen the restriction of the number type in `_safe_pow`. This makes sense since `sdiag_pow` should also work on complex diagonal tensor maps. (I need this for a niche application related to differentiating the SVD which has to do with extra phase freedom for complex SVDs.)