### PR TITLE
Define `Base.show` for `SUWeight`

### DIFF
--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -49,7 +49,7 @@ function compare_weights(wts1::SUWeight, wts2::SUWeight)
     return sum(_singular_value_distance, zip(wts1.data, wts2.data)) / length(wts1)
 end
 
-function Base.show(io::IO, wts::SUWeight)
+function Base.show(io::IO, ::MIME"text/plain", wts::SUWeight)
     println(io, typeof(wts))
     for idx in CartesianIndices(wts.data)
         println(io, Tuple(idx), ":")

--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -49,6 +49,17 @@ function compare_weights(wts1::SUWeight, wts2::SUWeight)
     return sum(_singular_value_distance, zip(wts1.data, wts2.data)) / length(wts1)
 end
 
+function Base.show(io::IO, wts::SUWeight)
+    println(io, typeof(wts))
+    for idx in CartesianIndices(wts.data)
+        println(io, Tuple(idx), ":")
+        for (k, b) in blocks(wts.data[idx])
+            println(io, k, " = ", diag(b))
+        end
+    end
+    return nothing
+end
+
 """
     struct InfiniteWeightPEPS{T<:PEPSTensor,E<:PEPSWeight}
 


### PR DESCRIPTION
This PR defines `Base.show` for `SUWeight`, so we can use `display(peps.weights)` to see the diagonal elements in the weight matrices in an `InfiniteWeightPEPS`. It's a simple IO function so I don't have tests for it. A possible future improvement is to define a more compact output for `println` and `print`. 

Example output for `peps` with `U1Irrep` symmetry: 
```
SUWeight{TensorMap{Float64, GradedSpace{U1Irrep, TensorKit.SortedVectorDict{U1Irrep, Int64}}, 1, 1, Vector{Float64}}}
(1, 1, 1):
Irrep[U₁](0) = [1.0, 0.013284183529494106, 0.01025508746347934]
Irrep[U₁](-1) = [0.155297993782553]
(2, 1, 1):
Irrep[U₁](1/2) = [1.0, 0.013284183529494106]
Irrep[U₁](-1/2) = [0.155297993782553]
Irrep[U₁](3/2) = [0.01025508746347934]
(1, 2, 1):
Irrep[U₁](0) = [1.0, 0.013284183529494106]
Irrep[U₁](1) = [0.155297993782553]
Irrep[U₁](-1) = [0.01025508746347934]
(2, 2, 1):
Irrep[U₁](0) = [1.0, 0.013284183529494106, 0.01025508746347934]
Irrep[U₁](1) = [0.155297993782553]
(1, 1, 2):
Irrep[U₁](0) = [1.0, 0.013284183529494106]
Irrep[U₁](1) = [0.155297993782553]
Irrep[U₁](-1) = [0.01025508746347934]
(2, 1, 2):
Irrep[U₁](0) = [1.0, 0.013284183529494106, 0.01025508746347934]
Irrep[U₁](1) = [0.155297993782553]
(1, 2, 2):
Irrep[U₁](0) = [1.0, 0.013284183529494106, 0.01025508746347934]
Irrep[U₁](-1) = [0.155297993782553]
(2, 2, 2):
Irrep[U₁](1/2) = [1.0, 0.013284183529494106]
Irrep[U₁](-1/2) = [0.155297993782553]
Irrep[U₁](3/2) = [0.01025508746347934]
```