### PR TITLE
Add unit cell size check for simple update

### DIFF
--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -70,6 +70,11 @@ function su_iter(
     if bipartite
         @assert Nr == Nc == 2
     end
+    (Nr >= 2 && Nc >= 2) || throw(
+        ArgumentError(
+            "iPEPS unit cell size for simple update should be no smaller than (2, 2)."
+        ),
+    )
     # TODO: make algorithm independent on the choice of dual in the network
     for (r, c) in Iterators.product(1:Nr, 1:Nc)
         @assert [isdual(space(peps.vertices[r, c], ax)) for ax in 1:5] == [0, 1, 1, 0, 0]
@@ -132,10 +137,6 @@ function simpleupdate(
     check_interval::Int=500,
 )
     time_start = time()
-    Nr, Nc = size(peps)
-    if bipartite
-        @assert Nr == Nc == 2
-    end
     # exponentiating the 2-site Hamiltonian gate
     gate = get_gate(alg.dt, ham)
     wtdiff = 1.0


### PR DESCRIPTION
This PR addresses issue #169 by adding a iPEPS unit cell size check for simple update. It ensure that the unit cell size should be no smaller than (2, 2), because when updating a nearest neighbor bond, SU generally produces two different tensors connected by this bond. 