### PR TITLE
Add InfinitePEPS to InfiniteWeightPEPS conversion

### DIFF
--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -268,6 +268,20 @@ function InfinitePEPS(peps::InfiniteWeightPEPS)
 end
 
 """
+    InfiniteWeightPEPS(peps::InfinitePEPS)
+
+Create `InfiniteWeightPEPS` from `InfinitePEPS` by initializing the bond weights as identity matrices of element type `Float64`.
+"""
+function InfiniteWeightPEPS(peps::InfinitePEPS)
+    Nr, Nc = size(peps)
+    weights = map(Iterators.product(1:2, 1:Nr, 1:Nc)) do (d, r, c)
+        V = (d == 1 ? domain(peps[r, c])[2] : domain(peps[r, c])[1])
+        DiagonalTensorMap(ones(reduceddim(V)), V)
+    end
+    return InfiniteWeightPEPS(peps.A, SUWeight(weights))
+end
+
+"""
     mirror_antidiag(peps::InfiniteWeightPEPS)
 
 Mirror the unit cell of an iPEPS with weights by its anti-diagonal line.

--- a/src/states/infiniteweightpeps.jl
+++ b/src/states/infiniteweightpeps.jl
@@ -276,6 +276,7 @@ function InfiniteWeightPEPS(peps::InfinitePEPS)
     Nr, Nc = size(peps)
     weights = map(Iterators.product(1:2, 1:Nr, 1:Nc)) do (d, r, c)
         V = (d == 1 ? domain(peps[r, c])[2] : domain(peps[r, c])[1])
+        @assert !isdual(V)
         DiagonalTensorMap(ones(reduceddim(V)), V)
     end
     return InfiniteWeightPEPS(peps.A, SUWeight(weights))


### PR DESCRIPTION
Add function to convert an InfinitePEPS to an InfiniteWeightPEPS. This would be useful to have to be able to alternate AD-CTMRG with (trivial) SU for optimization. I'm open to suggestions if someone would want a more general conversion method.