### PR TITLE
Fix optimizer verbosity in `fixedpoint` algorithm selector

### DIFF
--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -112,9 +112,10 @@ The optimization parameters can be supplied via the keyword arguments or directl
 * `tol::Real=$(Defaults.optimizer_tol)` : Overall tolerance for gradient norm convergence of the optimizer. Sets related tolerance such as the boundary and boundary-gradient tolerances to sensible defaults unless they are explictly specified.
 * `verbosity::Int=1` : Overall output information verbosity level, should be one of the following:
     0. Suppress all output
-    1. Optimizer output and warnings
-    2. Additionally print boundary information
-    3. All information including AD debug outputs
+    1. Only print warnings
+    2. Initialization and convergence info
+    3. Iteration info
+    4. Debug info including AD outputs
 * `reuse_env::Bool=$(Defaults.reuse_env)` : If `true`, the current optimization step is initialized on the previous environment, otherwise a random environment is used.
 * `symmetrization::Union{Nothing,SymmetrizationStyle}=nothing` : Accepts `nothing` or a `SymmetrizationStyle`, in which case the PEPS and PEPS gradient are symmetrized after each optimization iteration.
 * `(finalize!)=OptimKit._finalize!` : Inserts a `finalize!` function call after each optimization step by utilizing the `finalize!` kwarg of `OptimKit.optimize`. The function maps `(peps, env), f, g = finalize!((peps, env), f, g, numiter)`.

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -21,7 +21,7 @@ function select_algorithm(
     ::typeof(fixedpoint),
     env₀::CTMRGEnv;
     tol=Defaults.optimizer_tol, # top-level tolerance
-    verbosity=2, # top-level verbosity
+    verbosity=3, # top-level verbosity
     boundary_alg=(;),
     gradient_alg=(;),
     optimizer_alg=(;),
@@ -29,7 +29,7 @@ function select_algorithm(
 )
     # adjust CTMRG tols and verbosity
     if boundary_alg isa NamedTuple
-        defaults = (; verbosity=verbosity ≤ 1 ? -1 : verbosity, tol=1e-4tol)
+        defaults = (; verbosity=verbosity ≤ 3 ? -1 : 3, tol=1e-4tol)
         boundary_kwargs = merge(defaults, boundary_alg)
         boundary_alg = select_algorithm(leading_boundary, env₀; boundary_kwargs...)
     end
@@ -37,13 +37,13 @@ function select_algorithm(
     # adjust gradient verbosity
     if gradient_alg isa NamedTuple
         # TODO: check this:
-        defaults = (; verbosity=verbosity ≤ 2 ? -1 : 3, tol=1e-2tol)
+        defaults = (; verbosity=verbosity ≤ 3 ? -1 : 3, tol=1e-2tol)
         gradient_alg = merge(defaults, gradient_alg)
     end
 
     # adjust optimizer tol and verbosity
     if optimizer_alg isa NamedTuple
-        defaults = (; tol, verbosity=verbosity < 1 ? -1 : 3)
+        defaults = (; tol, verbosity)
         optimizer_alg = merge(defaults, optimizer_alg)
     end
 

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -43,7 +43,7 @@ function select_algorithm(
 
     # adjust optimizer tol and verbosity
     if optimizer_alg isa NamedTuple
-        defaults = (; tol, verbosity=verbosity ≤ 1 ? -1 : 3)
+        defaults = (; tol, verbosity=verbosity < 1 ? -1 : 3)
         optimizer_alg = merge(defaults, optimizer_alg)
     end
 

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -45,7 +45,7 @@ function _elementwise_mult(a₁::AbstractTensorMap, a₂::AbstractTensorMap)
     return dst
 end
 
-_safe_pow(a::Real, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
+_safe_pow(a::Number, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
 
 """
     sdiag_pow(s, pow::Real; tol::Real=eps(scalartype(s))^(3 / 4))


### PR DESCRIPTION
Small fix for wrong relative verbosity in `select_algorithm(fixedpoint, ...)`: we want to have optimizer output for each iteration if the global verbosity is 1.