### PR TITLE
Fix `LocalOperator` constructor for indices of type `Tuple{Int,Int}`

### DIFF
--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -43,7 +43,7 @@ function select_algorithm(
 
     # adjust optimizer tol and verbosity
     if optimizer_alg isa NamedTuple
-        defaults = (; tol, verbosity=verbosity ≤ 1 ? -1 : 3)
+        defaults = (; tol, verbosity=verbosity < 1 ? -1 : 3)
         optimizer_alg = merge(defaults, optimizer_alg)
     end
 

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -45,7 +45,7 @@ function _elementwise_mult(a₁::AbstractTensorMap, a₂::AbstractTensorMap)
     return dst
 end
 
-_safe_pow(a::Real, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
+_safe_pow(a::Number, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
 
 """
     sdiag_pow(s, pow::Real; tol::Real=eps(scalartype(s))^(3 / 4))


### PR DESCRIPTION
Previously, tuple-typed indices would lead to an error since the inner constructor uses a `PeriodicArray` (which apparently can only be indexed using `CartesianIndices`). Now, I convert tuple indices to `CartesianIndices` such that internally always the same type is used but users can still use tuple indices (which we also do in the docstring).