### PR TITLE
Define `real`, `imag` for `LocalOperator`

### DIFF
--- a/examples/heisenberg_evol/simpleupdate.jl
+++ b/examples/heisenberg_evol/simpleupdate.jl
@@ -7,9 +7,7 @@ trscheme_env = truncerr(1e-10) & truncdim(χenv)
 Nr, Nc = 2, 2
 # Heisenberg model Hamiltonian
 # (already only includes nearest neighbor terms)
-ham = heisenberg_XYZ(ComplexF64, symm, InfiniteSquare(Nr, Nc); Jx=1.0, Jy=1.0, Jz=1.0)
-# convert to real tensors
-ham = LocalOperator(ham.lattice, Tuple(ind => real(op) for (ind, op) in ham.terms)...)
+ham = real(heisenberg_XYZ(ComplexF64, symm, InfiniteSquare(Nr, Nc); Jx=1.0, Jy=1.0, Jz=1.0))
 
 # random initialization of 2x2 iPEPS with weights and CTMRGEnv (using real numbers)
 if symm == Trivial

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -96,6 +96,15 @@ function Base.repeat(O::LocalOperator, m::Int, n::Int)
     return LocalOperator(lattice, terms...)
 end
 
+# Real and imaginary part
+# -----------------------
+function Base.real(O::LocalOperator)
+    return LocalOperator(O.lattice, Tuple(ind => real(op) for (ind, op) in O.terms)...)
+end
+function Base.imag(O::LocalOperator)
+    return LocalOperator(O.lattice, Tuple(ind => imag(op) for (ind, op) in O.terms)...)
+end
+
 # Linear Algebra
 # --------------
 function Base.:*(α::Number, O::LocalOperator)

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -99,10 +99,10 @@ end
 # Real and imaginary part
 # -----------------------
 function Base.real(O::LocalOperator)
-    return LocalOperator(O.lattice, Tuple(ind => real(op) for (ind, op) in O.terms)...)
+    return LocalOperator(O.lattice, (ind => real(op) for (ind, op) in O.terms)...)
 end
 function Base.imag(O::LocalOperator)
-    return LocalOperator(O.lattice, Tuple(ind => imag(op) for (ind, op) in O.terms)...)
+    return LocalOperator(O.lattice, (ind => imag(op) for (ind, op) in O.terms)...)
 end
 
 # Linear Algebra

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -59,8 +59,11 @@ end
     for ind in CartesianIndices(wpeps.vertices)
         wpeps.vertices[ind] /= norm(wpeps.vertices[ind], Inf)
     end
-    # Heisenberg model Hamiltonian (already only includes nearest neighbor terms)
-    ham = real(heisenberg_XYZ(InfiniteSquare(N1, N2); Jx=1.0, Jy=1.0, Jz=1.0))
+    # Heisenberg model Hamiltonian
+    ham = heisenberg_XYZ(InfiniteSquare(N1, N2); Jx=1.0, Jy=1.0, Jz=1.0)
+    # assert imaginary part is zero
+    @assert length(imag(ham).terms) == 0
+    ham = real(ham)
 
     # simple update
     dts = [1e-2, 1e-3, 1e-3, 1e-4]

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -60,9 +60,7 @@ end
         wpeps.vertices[ind] /= norm(wpeps.vertices[ind], Inf)
     end
     # Heisenberg model Hamiltonian (already only includes nearest neighbor terms)
-    ham = heisenberg_XYZ(InfiniteSquare(N1, N2); Jx=1.0, Jy=1.0, Jz=1.0)
-    # convert to real tensors
-    ham = LocalOperator(ham.lattice, Tuple(ind => real(op) for (ind, op) in ham.terms)...)
+    ham = real(heisenberg_XYZ(InfiniteSquare(N1, N2); Jx=1.0, Jy=1.0, Jz=1.0))
 
     # simple update
     dts = [1e-2, 1e-3, 1e-3, 1e-4]


### PR DESCRIPTION
This PR defines `Base.real` and `Base.imag` for a `LocalOperator` to extract its real and imaginary parts, respectively. Relevant test/example code is updated. 