### PR TITLE
Refactor `initializeMPS`

### DIFF
--- a/examples/boundary_mps.jl
+++ b/examples/boundary_mps.jl
@@ -23,7 +23,7 @@ T = InfiniteTransferPEPS(peps, 1, 1)
 # encodes the norm of the state
 
 # Fist we build an initial guess for the boundary MPS, choosing a bond dimension of 20
-mps = PEPSKit.initializeMPS(T, [ComplexSpace(20)])
+mps = initialize_mps(T, [ComplexSpace(20)])
 
 # We then find the leading boundary MPS fixed point using the VUMPS algorithm
 mps, env, ϵ = leading_boundary(mps, T, VUMPS())
@@ -51,7 +51,7 @@ N´ = abs(norm(peps, ctm))
 peps2 = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell=(2, 2))
 T2 = PEPSKit.MultilineTransferPEPS(peps2, 1)
 
-mps2 = PEPSKit.initializeMPS(T2, fill(ComplexSpace(20), 2, 2))
+mps2 = initialize_mps(T2, fill(ComplexSpace(20), 2, 2))
 mps2, env2, ϵ = leading_boundary(mps2, T2, VUMPS())
 N2 = abs(prod(expectation_value(mps2, T2)))
 
@@ -76,7 +76,7 @@ N2´ = abs(norm(peps2, ctm2))
 pepo = ising_pepo(1)
 T3 = InfiniteTransferPEPO(peps, pepo, 1, 1)
 
-mps3 = PEPSKit.initializeMPS(T3, [ComplexSpace(20)])
+mps3 = initialize_mps(T3, [ComplexSpace(20)])
 mps3, env3, ϵ = leading_boundary(mps3, T3, VUMPS())
 @show N3 = abs(prod(expectation_value(mps3, T3)))
 

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -89,7 +89,7 @@ export InfinitePartitionFunction
 export InfinitePEPS, InfiniteTransferPEPS
 export SUWeight, InfiniteWeightPEPS
 export InfinitePEPO, InfiniteTransferPEPO
-export initializeMPS, initializePEPS
+export initialize_mps, initializePEPS
 export ReflectDepth, ReflectWidth, Rotate, RotateReflect
 export symmetrize!, symmetrize_retract_and_finalize!
 export showtypeofgrad

--- a/test/boundarymps/vumps.jl
+++ b/test/boundarymps/vumps.jl
@@ -46,10 +46,10 @@ end
 
     psi = InfinitePEPS(D, d; unitcell=(1, 1))
     n = InfiniteSquareNetwork(psi)
-    T = PEPSKit.InfiniteTransferPEPS(psi, 1, 1)
+    T = InfiniteTransferPEPS(psi, 1, 1)
 
     # compare boundary MPS contraction to CTMRG contraction
-    mps = PEPSKit.initializeMPS(T, [χ])
+    mps = initialize_mps(T, [χ])
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     N_vumps = abs(prod(expectation_value(mps, T)))
 

--- a/test/boundarymps/vumps.jl
+++ b/test/boundarymps/vumps.jl
@@ -7,12 +7,14 @@ using LinearAlgebra
 
 Random.seed!(29384293742893)
 
-const vumps_alg = VUMPS(; alg_eigsolve=MPSKit.Defaults.alg_eigsolve(; ishermitian=false))
+const vumps_alg = VUMPS(;
+    tol=1e-6, alg_eigsolve=MPSKit.Defaults.alg_eigsolve(; ishermitian=false), verbosity=2
+)
 @testset "(1, 1) PEPS" begin
     psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(2))
 
     T = PEPSKit.InfiniteTransferPEPS(psi, 1, 1)
-    mps = PEPSKit.initializeMPS(T, [ComplexSpace(20)])
+    mps = initialize_mps(T, [ComplexSpace(20)])
 
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     N = abs(sum(expectation_value(mps, T)))
@@ -27,7 +29,7 @@ end
     psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell=(2, 2))
     T = PEPSKit.MultilineTransferPEPS(psi, 1)
 
-    mps = PEPSKit.initializeMPS(T, fill(ComplexSpace(20), 2, 2))
+    mps = initialize_mps(rand, scalartype(T), T, fill(ComplexSpace(20), 2, 2))
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     N = abs(prod(expectation_value(mps, T)))
 
@@ -64,7 +66,7 @@ end
     psi = PEPSKit.initializePEPS(O, ComplexSpace(2))
     T = InfiniteTransferPEPO(psi, O, 1, 1)
 
-    mps = PEPSKit.initializeMPS(T, [ComplexSpace(10)])
+    mps = initialize_mps(rand, scalartype(T), T, [ComplexSpace(10)])
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     f = abs(prod(expectation_value(mps, T)))
 
@@ -73,7 +75,7 @@ end
     psi2 = initializePEPS(O, ComplexSpace(2))
     T = InfiniteTransferPEPO(psi, O, 1, 1)
 
-    mps = PEPSKit.initializeMPS(T, [ComplexSpace(8)])
+    mps = initialize_mps(rand, T, [ComplexSpace(8)])
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     f = abs(prod(expectation_value(mps, T)))
 end

--- a/test/boundarymps/vumps.jl
+++ b/test/boundarymps/vumps.jl
@@ -75,7 +75,7 @@ end
     psi2 = initializePEPS(O, ComplexSpace(2))
     T = InfiniteTransferPEPO(psi, O, 1, 1)
 
-    mps = initialize_mps(rand, T, [ComplexSpace(8)])
+    mps = initialize_mps(rand, scalartype(T), T, [ComplexSpace(8)])
     mps, env, ϵ = leading_boundary(mps, T, vumps_alg)
     f = abs(prod(expectation_value(mps, T)))
 end


### PR DESCRIPTION
Here I rename the function to `initialize_mps` to make it consistent with our naming conventions and also add an optional function and type arguments such that it has the function signature

```julia
initialize_mps(f=randn, T=scalartype(O), O::Union{InfiniteTransferMatrix,MultilineTransferMatrix}, arg)
```
