### PR TITLE
Add modified `tsvd!` reverse-rule with Lorentzian broadening

### DIFF
--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -97,6 +97,7 @@ const svd_rrule_tol = ctmrg_tol
 const svd_rrule_min_krylovdim = 48
 const svd_rrule_verbosity = -1
 const svd_rrule_alg = :tsvd # ∈ {:tsvd, :gmres, :bicgstab, :arnoldi}
+const svd_rrule_broadening = 1e-13
 const krylovdim_factor = 1.4
 
 # Projectors

--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -30,10 +30,11 @@ Module containing default algorithm parameter values and arguments.
 * `svd_rrule_min_krylovdim=$(Defaults.svd_rrule_min_krylovdim)` : Minimal Krylov dimension of the reverse-rule algorithm (if it is a Krylov algorithm).
 * `svd_rrule_verbosity=$(Defaults.svd_rrule_verbosity)` : SVD gradient output verbosity.
 * `svd_rrule_alg=:$(Defaults.svd_rrule_alg)` : Reverse-rule algorithm for the SVD gradient.
-    - `:tsvd`: Uses TensorKit's reverse-rule for `tsvd` which doesn't solve any linear problem and instead requires access to the full SVD, see [TensorKit](https://github.com/Jutho/TensorKit.jl/blob/f9cddcf97f8d001888a26f4dce7408d5c6e2228f/ext/TensorKitChainRulesCoreExt/factorizations.jl#L3)
+    - `:full`: Uses TensorKit's reverse-rule for `tsvd` which doesn't solve any linear problem and instead requires access to the full SVD, see [TensorKit](https://github.com/Jutho/TensorKit.jl/blob/f9cddcf97f8d001888a26f4dce7408d5c6e2228f/ext/TensorKitChainRulesCoreExt/factorizations.jl#L3)
     - `:gmres`: GMRES iterative linear solver, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.GMRES) for details
     - `:bicgstab`: BiCGStab iterative linear solver, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.BiCGStab) for details
     - `:arnoldi`: Arnoldi Krylov algorithm, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.Arnoldi) for details
+* `svd_rrule_broadening=$(Defaults.svd_rrule_broadening)` : Lorentzian broadening amplitude which smoothens the divergent term in the SVD adjoint in case of (pseudo) degenerate singular values
 
 ## Projectors
 
@@ -96,7 +97,7 @@ const svd_fwd_alg = :sdd # ∈ {:sdd, :svd, :iterative}
 const svd_rrule_tol = ctmrg_tol
 const svd_rrule_min_krylovdim = 48
 const svd_rrule_verbosity = -1
-const svd_rrule_alg = :tsvd # ∈ {:tsvd, :gmres, :bicgstab, :arnoldi}
+const svd_rrule_alg = :full # ∈ {:full, :gmres, :bicgstab, :arnoldi}
 const svd_rrule_broadening = 1e-13
 const krylovdim_factor = 1.4
 

--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -30,7 +30,7 @@ Module containing default algorithm parameter values and arguments.
 * `svd_rrule_min_krylovdim=$(Defaults.svd_rrule_min_krylovdim)` : Minimal Krylov dimension of the reverse-rule algorithm (if it is a Krylov algorithm).
 * `svd_rrule_verbosity=$(Defaults.svd_rrule_verbosity)` : SVD gradient output verbosity.
 * `svd_rrule_alg=:$(Defaults.svd_rrule_alg)` : Reverse-rule algorithm for the SVD gradient.
-    - `:full`: Uses TensorKit's reverse-rule for `tsvd` which doesn't solve any linear problem and instead requires access to the full SVD, see [TensorKit](https://github.com/Jutho/TensorKit.jl/blob/f9cddcf97f8d001888a26f4dce7408d5c6e2228f/ext/TensorKitChainRulesCoreExt/factorizations.jl#L3)
+    - `:full`: Uses a modified version of TensorKit's reverse-rule for `tsvd` which doesn't solve any linear problem and instead requires access to the full SVD, see [`FullSVDReverseRule`](@ref).
     - `:gmres`: GMRES iterative linear solver, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.GMRES) for details
     - `:bicgstab`: BiCGStab iterative linear solver, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.BiCGStab) for details
     - `:arnoldi`: Arnoldi Krylov algorithm, see the [KrylovKit docs](https://jutho.github.io/KrylovKit.jl/stable/man/algorithms/#KrylovKit.Arnoldi) for details

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -71,7 +71,7 @@ include("algorithms/select_algorithm.jl")
 
 using .Defaults: set_scheduler!
 export set_scheduler!
-export SVDAdjoint, FullReverse, IterSVD
+export SVDAdjoint, FullSVDReverseRule, IterSVD
 export CTMRGEnv, SequentialCTMRG, SimultaneousCTMRG
 export FixedSpaceTruncation, HalfInfiniteProjector, FullInfiniteProjector
 export LocalOperator

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -71,7 +71,7 @@ include("algorithms/select_algorithm.jl")
 
 using .Defaults: set_scheduler!
 export set_scheduler!
-export SVDAdjoint, IterSVD
+export SVDAdjoint, FullReverse, IterSVD
 export CTMRGEnv, SequentialCTMRG, SimultaneousCTMRG
 export FixedSpaceTruncation, HalfInfiniteProjector, FullInfiniteProjector
 export LocalOperator

--- a/src/algorithms/ctmrg/projectors.jl
+++ b/src/algorithms/ctmrg/projectors.jl
@@ -58,7 +58,6 @@ function svd_algorithm(alg::ProjectorAlgorithm, (dir, r, c))
         return SVDAdjoint(;
             fwd_alg=fix_svd,
             rrule_alg=alg.svd_alg.rrule_alg,
-            broadening=alg.svd_alg.broadening,
         )
     else
         return alg.svd_alg

--- a/src/algorithms/ctmrg/projectors.jl
+++ b/src/algorithms/ctmrg/projectors.jl
@@ -55,10 +55,7 @@ function svd_algorithm(alg::ProjectorAlgorithm, (dir, r, c))
                 nothing,
             )
         end
-        return SVDAdjoint(;
-            fwd_alg=fix_svd,
-            rrule_alg=alg.svd_alg.rrule_alg,
-        )
+        return SVDAdjoint(; fwd_alg=fix_svd, rrule_alg=alg.svd_alg.rrule_alg)
     else
         return alg.svd_alg
     end

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -263,7 +263,6 @@ function _fix_svd_algorithm(alg::SVDAdjoint, signs, info)
     return SVDAdjoint(;
         fwd_alg=FixedSVD(U_fixed, info.S, V_fixed, U_full_fixed, info.S_full, V_full_fixed),
         rrule_alg=alg.rrule_alg,
-        broadening=alg.broadening,
     )
 end
 function _fix_svd_algorithm(alg::SVDAdjoint{F}, signs, info) where {F<:IterSVD}
@@ -272,7 +271,6 @@ function _fix_svd_algorithm(alg::SVDAdjoint{F}, signs, info) where {F<:IterSVD}
     return SVDAdjoint(;
         fwd_alg=FixedSVD(U_fixed, info.S, V_fixed, nothing, nothing, nothing),
         rrule_alg=alg.rrule_alg,
-        broadening=alg.broadening,
     )
 end
 

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -522,7 +522,7 @@ function svd_pullback!(
         Δgauge = max(Δgauge, norm(view(aUΔU, rprange, rprange), Inf))
         Δgauge = max(Δgauge, norm(view(aVΔV, rprange, rprange), Inf))
     end
-    if verbosity == 1 && Δgauge < tol # warn if verbosity is 1
+    if verbosity == 1 && Δgauge > tol # warn if verbosity is 1
         @warn "`svd` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"
     elseif verbosity ≥ 2 # always info for debugging purposes
         @info "`svd` cotangents sensitive to gauge choice: (|Δgauge| = $Δgauge)"

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -83,8 +83,7 @@ function SVDAdjoint(; fwd_alg=(;), rrule_alg=(;), broadening=nothing)
         end
 
         if rrule_type <: Nothing
-            broadening =
-                isnothing(broadening) ? Defaults.svd_rrule_broadening : broadening
+            broadening = isnothing(broadening) ? Defaults.svd_rrule_broadening : broadening
             nothing
         else
             rrule_kwargs = Base.structdiff(rrule_kwargs, (; alg=nothing)) # remove `alg` keyword argument

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -83,9 +83,9 @@ function SVDAdjoint(; fwd_alg=(;), rrule_alg=(;), broadening=nothing)
         end
 
         if rrule_type <: Nothing
-            nothing
             broadening =
                 isnothing(broadening) ? Defaults.svd_rrule_broadening : broadening
+            nothing
         else
             rrule_kwargs = Base.structdiff(rrule_kwargs, (; alg=nothing)) # remove `alg` keyword argument
             rrule_type <: BiCGStab &&

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -423,7 +423,7 @@ end
 
 # Lorentzian broadening for divergent term in SVD rrule, see
 # https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.7.013237
-function _lorentz_broaden(x, ε=eps(real(scalartype(x)))^(3/4))
+function _lorentz_broaden(x, ε=eps(real(scalartype(x)))^(3 / 4))
     return x / (x^2 + ε)
 end
 

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -45,7 +45,7 @@ function _elementwise_mult(a₁::AbstractTensorMap, a₂::AbstractTensorMap)
     return dst
 end
 
-_safe_pow(a::Real, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
+_safe_pow(a::Number, pow::Real, tol::Real) = (pow < 0 && abs(a) < tol) ? zero(a) : a^pow
 
 """
     sdiag_pow(s, pow::Real; tol::Real=eps(scalartype(s))^(3 / 4))

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -93,7 +93,7 @@ end
         peps,
         env;
         optimizer_alg=(; tol=gradtol, maxiter=25),
-        boundary_alg=(; maxiter=150, svd_alg=(; rrule_alg=(; alg=:tsvd, tol=1e-5))),
+        boundary_alg=(; maxiter=150, svd_alg=(; rrule_alg=(; alg=:full, tol=1e-5))),
     )  # sensitivity warnings and degeneracies due to SU(2)?
     ξ_h, ξ_v, = correlation_length(peps_final, env_final)
     e_site2 = E_final / (N1 * N2)

--- a/test/gradients/ctmrg_gradients.jl
+++ b/test/gradients/ctmrg_gradients.jl
@@ -20,7 +20,7 @@ gradtol = 1e-4
 ctmrg_verbosity = 0
 ctmrg_algs = [[:sequential, :simultaneous], [:sequential, :simultaneous]]
 projector_algs = [[:halfinfinite, :fullinfinite], [:halfinfinite, :fullinfinite]]
-svd_rrule_algs = [[:tsvd, :arnoldi], [:tsvd, :arnoldi]]
+svd_rrule_algs = [[:full, :arnoldi], [:full, :arnoldi]]
 gradient_algs = [
     [nothing, :geomsum, :manualiter, :linsolver, :eigsolver],
     [:geomsum, :manualiter, :linsolver, :eigsolver],
@@ -29,9 +29,9 @@ gradient_iterschemes = [[:fixed, :diffgauge], [:fixed, :diffgauge]]
 steps = -0.01:0.005:0.01
 
 naive_gradient_combinations = [
-    (:simultaneous, :halfinfinite, :tsvd),
-    (:simultaneous, :fullinfinite, :tsvd),
-    (:sequential, :halfinfinite, :tsvd),
+    (:simultaneous, :halfinfinite, :full),
+    (:simultaneous, :fullinfinite, :full),
+    (:sequential, :halfinfinite, :full),
 ]
 naive_gradient_done = Set()
 

--- a/test/utility/svd_wrapper.jl
+++ b/test/utility/svd_wrapper.jl
@@ -23,7 +23,7 @@ r = randn(dtype, ℂ^m, ℂ^n)
 R = randn(space(r))
 broadenings = [10.0^k for k in -16:-4]
 
-full_alg = SVDAdjoint(; rrule_alg=(; alg=:tsvd), broadening=0)
+full_alg = SVDAdjoint(; rrule_alg=(; alg=:full, broadening=0))
 iter_alg = SVDAdjoint(; fwd_alg=(; alg=:iterative))
 
 @testset "Non-truncacted SVD" begin
@@ -43,7 +43,7 @@ end
 end
 
 @testset "Truncated SVD with χ=$χ and ε=$ε broadening" for ε in broadenings
-    broadened_alg = @set full_alg.broadening = ε
+    broadened_alg = @set full_alg.rrule_alg.broadening = ε
     l_unbroadened, g_unbroadened = withgradient(A -> lossfun(A, full_alg, R, trunc), r)
     l_broadened, g_broadened = withgradient(A -> lossfun(A, broadened_alg, R, trunc), r)
 
@@ -81,7 +81,7 @@ symm_R = randn(dtype, space(symm_r))
 end
 
 @testset "Truncated symmetric SVD with χ=$χ and ε=$ε broadening" for ε in broadenings
-    broadened_alg = @set full_alg.broadening = ε
+    broadened_alg = @set full_alg.rrule_alg.broadening = ε
     l_unbroadened, g_unbroadened = withgradient(
         A -> lossfun(A, full_alg, symm_R, symm_trspace), symm_r
     )

--- a/test/utility/svd_wrapper.jl
+++ b/test/utility/svd_wrapper.jl
@@ -2,7 +2,6 @@ using Test
 using Random
 using LinearAlgebra
 using TensorKit
-using KrylovKit
 using ChainRulesCore, Zygote
 using Accessors
 using PEPSKit
@@ -10,21 +9,21 @@ using PEPSKit
 
 # Gauge-invariant loss function
 function lossfun(A, alg, R=randn(space(A)), trunc=notrunc())
-    U, _, V, = PEPSKit.tsvd(A, alg; trunc)
-    return real(dot(R, U * V))  # Overlap with random tensor R is gauge-invariant and differentiable, also for m≠n
+    U, S, V, = PEPSKit.tsvd(A, alg; trunc)
+    return real(dot(R, U * V)) + dot(S, S)  # Overlap with random tensor R is gauge-invariant and differentiable, also for m≠n
 end
 
 m, n = 20, 30
 dtype = ComplexF64
 χ = 12
 trunc = truncspace(ℂ^χ)
-# lorentz_broadening = 1e-12
 rtol = 1e-9
 Random.seed!(123456789)
 r = randn(dtype, ℂ^m, ℂ^n)
 R = randn(space(r))
+broadenings = [10.0^k for k in -16:-4]
 
-full_alg = SVDAdjoint(; rrule_alg=(; alg=:tsvd))
+full_alg = SVDAdjoint(; rrule_alg=(; alg=:tsvd), broadening=0)
 iter_alg = SVDAdjoint(; fwd_alg=(; alg=:iterative))
 
 @testset "Non-truncacted SVD" begin
@@ -43,20 +42,14 @@ end
     @test g_fullsvd[1] ≈ g_itersvd[1] rtol = rtol
 end
 
-# TODO: Add when Lorentzian broadening is implemented
-# @testset "Truncated SVD with χ=$χ and ε=$lorentz_broadening broadening" begin
-#     l_fullsvd, g_fullsvd = withgradient(
-#         A -> lossfun(A, FullSVD(; lorentz_broadening, R; trunc), r
-#     )
-#     l_oldsvd, g_oldsvd = withgradient(A -> lossfun(A, OldSVD(; lorentz_broadening), R; trunc), r)
-#     l_itersvd, g_itersvd = withgradient(
-#         A -> lossfun(A, IterSVD(; howmany=χ, lorentz_broadening), R; trunc), r
-#     )
+@testset "Truncated SVD with χ=$χ and ε=$ε broadening" for ε in broadenings
+    broadened_alg = @set full_alg.broadening = ε
+    l_unbroadened, g_unbroadened = withgradient(A -> lossfun(A, full_alg, R, trunc), r)
+    l_broadened, g_broadened = withgradient(A -> lossfun(A, broadened_alg, R, trunc), r)
 
-#     @test l_oldsvd ≈ l_itersvd ≈ l_fullsvd 
-#     @test norm(g_fullsvd[1] - g_oldsvd[1]) / norm(g_fullsvd[1]) > rtol
-#     @test norm(g_fullsvd[1] - g_itersvd[1]) / norm(g_fullsvd[1]) < rtol
-# end
+    @test l_unbroadened ≈ l_broadened
+    @test 1e1 * norm(g_broadened[1]) * ε > norm(g_unbroadened[1] - g_broadened[1]) > ε
+end
 
 symm_m, symm_n = 18, 24
 symm_space = Z2Space(0 => symm_m, 1 => symm_n)
@@ -85,6 +78,19 @@ symm_R = randn(dtype, space(symm_r))
     )
     @test l_itersvd_fb ≈ l_fullsvd_tr
     @test g_fullsvd_tr[1] ≈ g_itersvd_fb[1] rtol = rtol
+end
+
+@testset "Truncated symmetric SVD with χ=$χ and ε=$ε broadening" for ε in broadenings
+    broadened_alg = @set full_alg.broadening = ε
+    l_unbroadened, g_unbroadened = withgradient(
+        A -> lossfun(A, full_alg, symm_R, symm_trspace), symm_r
+    )
+    l_broadened, g_broadened = withgradient(
+        A -> lossfun(A, broadened_alg, symm_R, symm_trspace), symm_r
+    )
+
+    @test l_unbroadened ≈ l_broadened
+    @test 1e1 * norm(g_broadened[1]) * ε > norm(g_unbroadened[1] - g_broadened[1]) > ε
 end
 
 # TODO: Add when IterSVD is implemented for HalfInfiniteEnv


### PR DESCRIPTION
In this PR we will add a rrule for `tsvd!` which supports Lorentzian broadening. To that end, I copy over TensorKit's [`svd_pullback!`](https://github.com/Jutho/TensorKit.jl/blob/fa1551472ac74d7f2a61bdb2135cf418c8c53378/ext/TensorKitChainRulesCoreExt/factorizations.jl#L150) and modify the `save_inv` function to support a broadened inverse.

Additionally, I will add a keyword argument to control the gauge-dependency warnings in that reverse-rule (which is currently not possible) since in some optimizations, the gauge-dependency warnings are really out of control even though they are non-problematic.