### PR TITLE
Fix environment constructor scalar type

### DIFF
--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -242,7 +242,7 @@ function CTMRGEnv(
     Ds_east = _east_env_spaces(network)
     return CTMRGEnv(
         randn,
-        ComplexF64,
+        scalartype(network),
         Ds_north,
         Ds_east,
         _to_space.(chis_north),


### PR DESCRIPTION
This is a minor change that preserves the scalartype of the network for the `CTMRGEnv` constructor