### PR TITLE
Rewrite svd to avoid empty blocks

### DIFF
--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -286,7 +286,9 @@ function TensorKit._compute_svddata!(
     I = sectortype(f)
     dims = SectorDict{I,Int}()
 
-    generator = Base.Iterators.map(blocks(f)) do (c, b)
+    sectors = trunc isa NoTruncation ? blocksectors(f) : blocksectors(trunc.space)
+    generator = Base.Iterators.map(sectors) do c
+        b = block(f, c)
         howmany = trunc isa NoTruncation ? minimum(size(b)) : blockdim(trunc.space, c)
 
         if howmany / minimum(size(b)) > alg.fallback_threshold  # Use dense SVD for small blocks


### PR DESCRIPTION
This avoids looping over blocks that will end up being truncated completely, ie that would get `howmany = 0`.

This probably fixes #185, although I don't have an explicit case to check this on.