### PR TITLE
Fix row and column mismatch in `correlation_length` with unit cells

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PEPSKit"
 uuid = "52969e89-939e-4361-9b68-9bc7cde4bdeb"
 authors = ["Paul Brehmer", "Lander Burgelman", "Lukas Devos <ldevos98@gmail.com>"]
-version = "0.6.1"
+version = "0.6.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PEPSKit"
 uuid = "52969e89-939e-4361-9b68-9bc7cde4bdeb"
 authors = ["Paul Brehmer", "Lander Burgelman", "Lukas Devos <ldevos98@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -281,7 +281,7 @@ function _correlation_length(env::CTMRGEnv; num_vals=2, kwargs...)
     # Horizontal
     λ_h = map(1:n_rows) do r
         above = InfiniteMPS(env.edges[NORTH, r, :])
-        below = InfiniteMPS(_dag.(env.edges[SOUTH, mod1(r + 1, n_rows), :]))
+        below = InfiniteMPS(_dag.(env.edges[SOUTH, _next(r, n_rows), :]))
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end
@@ -290,7 +290,7 @@ function _correlation_length(env::CTMRGEnv; num_vals=2, kwargs...)
     # Vertical
     λ_v = map(1:n_cols) do c
         above = InfiniteMPS(env.edges[EAST, :, c])
-        below = InfiniteMPS(_dag.(env.edges[WEST, :, mod1(c + 1, n_cols)]))
+        below = InfiniteMPS(_dag.(env.edges[WEST, :, _next(c, n_cols)]))
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -276,29 +276,25 @@ MPSKit.correlation_length(state, env::CTMRGEnv; num_vals=2, kwargs...) =
     _correlation_length(env; num_vals, kwargs...)
 
 function _correlation_length(env::CTMRGEnv; num_vals=2, kwargs...)
-    T = scalartype(env)
-    ξ_h = Vector{real(T)}(undef, size(env, 2))
-    ξ_v = Vector{real(T)}(undef, size(env, 3))
-    λ_h = Vector{Vector{T}}(undef, size(env, 2))
-    λ_v = Vector{Vector{T}}(undef, size(env, 3))
+    _, n_rows, n_cols = size(env)
 
     # Horizontal
-    λ_h = map(1:size(env, 2)) do r
+    λ_h = map(1:n_rows) do r
         above = InfiniteMPS(env.edges[NORTH, r, :])
-        below = InfiniteMPS(_dag.(env.edges[SOUTH, r, :]))
+        below = InfiniteMPS(_dag.(env.edges[SOUTH, mod1(r + 1, n_rows), :]))
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end
-    ξ_h = map(λ_row -> -1 / log(abs(λ_row[2])), λ_h)
+    ξ_h = map(λ_row -> -n_rows / log(abs(λ_row[2])), λ_h)
 
     # Vertical
-    λ_v = map(1:size(env, 3)) do c
+    λ_v = map(1:n_cols) do c
         above = InfiniteMPS(env.edges[EAST, :, c])
-        below = InfiniteMPS(_dag.(env.edges[WEST, :, c]))
+        below = InfiniteMPS(_dag.(env.edges[WEST, :, mod1(c + 1, n_cols)]))
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end
-    ξ_v = map(λ_row -> -1 / log(abs(λ_row[2])), λ_v)
+    ξ_v = map(λ_col -> -n_cols / log(abs(λ_col[2])), λ_v)
 
     return ξ_h, ξ_v, λ_h, λ_v
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -285,7 +285,7 @@ function _correlation_length(env::CTMRGEnv; num_vals=2, kwargs...)
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end
-    ξ_h = map(λ_row -> -n_rows / log(abs(λ_row[2])), λ_h)
+    ξ_h = map(λ -> -1 / log(abs(λ[2])), λ_h)
 
     # Vertical
     λ_v = map(1:n_cols) do c
@@ -294,7 +294,7 @@ function _correlation_length(env::CTMRGEnv; num_vals=2, kwargs...)
         vals = MPSKit.transfer_spectrum(above; below, num_vals, kwargs...)
         return vals ./ abs(vals[1]) # normalize largest eigenvalue
     end
-    ξ_v = map(λ_col -> -n_cols / log(abs(λ_col[2])), λ_v)
+    ξ_v = map(λ -> -1 / log(abs(λ[2])), λ_v)
 
     return ξ_h, ξ_v, λ_h, λ_v
 end

--- a/test/ctmrg/correlation_length.jl
+++ b/test/ctmrg/correlation_length.jl
@@ -1,0 +1,29 @@
+using Test: @test, @testset
+using TensorKit: ←, ⊗, SU2Irrep, Vect, permute, truncdim, truncbelow
+using MPSKit: correlation_length, leading_boundary
+using PEPSKit: CTMRGEnv, InfinitePEPS
+
+@testset "Correlation length" begin
+    # regression test for https://github.com/QuantumKitHub/PEPSKit.jl/issues/197
+    vD = Vect[SU2Irrep](1//2 => 1)
+    vd = Vect[SU2Irrep](2 => 1)
+    tAKLT_A = ones(vd ← vD ⊗ vD ⊗ vD ⊗ vD)
+    tAKLT_B = permute(adjoint(tAKLT_A), (5,), (1, 2, 3, 4))
+
+    ψ = InfinitePEPS([tAKLT_A tAKLT_B; tAKLT_B tAKLT_A])
+    trscheme = truncdim(20) & truncbelow(1e-12)
+    boundary_alg = (; tol=1e-10, trscheme=trscheme, maxiter=1, verbosity=0)
+    env0 = CTMRGEnv(randn, Float64, ψ, oneunit(vD))
+    env, info_ctmrg = leading_boundary(env0, ψ; boundary_alg...)
+
+    ξ_h, ξ_v, λ_h, λ_v = correlation_length(ψ, env)
+    @test ξ_h isa Vector{Float64}
+    @test size(ξ_h) == (2,)
+    @test all(isfinite.(ξ_h))
+    @test all(ξ_h .> 0)
+
+    @test ξ_v isa Vector{Float64}
+    @test size(ξ_v) == (2,)
+    @test all(isfinite.(ξ_v))
+    @test all(ξ_v .> 0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,9 @@ end
         @time @safetestset "PEPO" begin
             include("ctmrg/pepo.jl")
         end
+        @time @safetestset "correlation length" begin
+            include("ctmrg/correlation_length.jl")
+        end
     end
     if GROUP == "ALL" || GROUP == "GRADIENTS"
         @time @safetestset "CTMRG gradients" begin


### PR DESCRIPTION
Fix #197 

The current fix also changes the definition of the correlation length: it includes the size of the unit cell inside. I am not sure about this change, I can discard it if it breaks MPSKit conventions.

I still think there is something wrong: in the AKLT case, this fix gives a correlation length around 1 when I believe it is around 2 (as published in https://link.aps.org/doi/10.1103/PhysRevB.96.121115), but I am less sure where the factor 2 is wrong.

I can add the AKLT case as a test, regardless of the factor 2 just to check if it executes.