### PR TITLE
Fix edge renormalization diagrams

### DIFF
--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1152,11 +1152,11 @@ environment tensors.
 
 ```
            |
-     [~P_bottom~]
-      |        |
-    E_east --  A -- 
-      |        |
      [~~P_top~~~]
+      |        |
+   -- A  --  E_east
+      |        |
+     [~P_bottom~]
            |
 ```
 """
@@ -1236,7 +1236,7 @@ environment tensors.
            |
      [~P_bottom~]
       |        |
-   -- A  --  E_west
+    E_west --  A -- 
       |        |
      [~~P_top~~~]
            |


### PR DESCRIPTION
Small PR to fix diagrams in the docstrings of `renormalize_east_edge` and `renormalize_west_edge`, as found in #193.