### PR TITLE
Fix FixedSpaceTruncation for simple update

### DIFF
--- a/src/algorithms/time_evolution/evoltools.jl
+++ b/src/algorithms/time_evolution/evoltools.jl
@@ -141,11 +141,12 @@ function _apply_gate(
     trscheme::TruncationScheme,
 ) where {T<:Number,S<:ElementarySpace}
     @tensor a2b2[-1 -2; -3 -4] := gate[-2 -3; 1 2] * a[-1 1 3] * b[3 2 -4]
-    return tsvd!(
-        a2b2;
-        trunc=((trscheme isa FixedSpaceTruncation) ? truncspace(space(a, 3)) : trscheme),
-        alg=TensorKit.SVD(),
-    )
+    return tsvd!(a2b2; trunc=if trscheme isa FixedSpaceTruncation
+        V = space(b, 1)
+        truncspace(isdual(V) ? V' : V)
+    else
+        trscheme
+    end, alg=TensorKit.SVD())
 end
 
 """

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -239,7 +239,8 @@ function _get_allprojs(Ms, Rs, Ls, trunc::TensorKit.TruncationScheme, revs::Vect
     N = length(Ms)
     projs_errs = map(1:(N - 1)) do i
         trunc2 = if isa(trunc, FixedSpaceTruncation)
-            truncspace(space(Ms[i + 1], 1))
+            V = space(Ms[i + 1], 1)
+            truncspace(isdual(V) ? V' : V)
         else
             trunc
         end


### PR DESCRIPTION
This PR fixes the `FixedSpaceTruncation` for simple update. 

Suppose the (un-dualed) space on a bond in the PEPS was `V`. If the `trscheme` in the `SimpleUpdate` struct is set to `FixedSpaceTruncation`, the singular values are truncated using `truncspace(V)` after updating the bond. Previously `truncspace(V')` may be used, which can cause problems for symmetries with `V' != V` (e.g. `U1Irrep`). 