### PR TITLE
Fix 3-site SU `dt` and reduce artificial C4v breaking

### DIFF
--- a/src/algorithms/time_evolution/evoltools.jl
+++ b/src/algorithms/time_evolution/evoltools.jl
@@ -181,19 +181,20 @@ Obtain the 3-site gate MPO on the southeast cluster at position `[row, col]`
         c      c+1
 ```
 """
-function _get_gatempo_se(gate::LocalOperator, row::Int, col::Int)
-    Nr, Nc = size(gate.lattice)
+function _get_gatempo_se(ham::LocalOperator, dt::Number, row::Int, col::Int)
+    Nr, Nc = size(ham.lattice)
     @assert 1 <= row <= Nr && 1 <= col <= Nc
-    unit = id(space(gate.terms[1].second, 1))
+    unit = id(space(ham.terms[1].second, 1))
     sites = (
         CartesianIndex(row, col),
         CartesianIndex(row, col + 1),
         CartesianIndex(row - 1, col + 1),
     )
-    nb1x = get_gateterm(gate, (sites[1], sites[2]))
-    nb1y = get_gateterm(gate, (sites[2], sites[3]))
-    nb2 = get_gateterm(gate, (sites[1], sites[3]))
+    nb1x = get_gateterm(ham, (sites[1], sites[2]))
+    nb1y = get_gateterm(ham, (sites[2], sites[3]))
+    nb2 = get_gateterm(ham, (sites[1], sites[3]))
     op = (1 / 2) * (nb1x ⊗ unit + unit ⊗ nb1y) + permute(nb2 ⊗ unit, ((1, 3, 2), (4, 6, 5)))
+    op = exp(-dt * op)
     return gate_to_mpo3(op)
 end
 
@@ -201,7 +202,7 @@ end
 Construct the 3-site gate MPOs on the southeast cluster 
 for 3-site simple update on square lattice.
 """
-function _get_gatempos_se(gate::LocalOperator)
-    Nr, Nc = size(gate.lattice)
-    return collect(_get_gatempo_se(gate, r, c) for r in 1:Nr, c in 1:Nc)
+function _get_gatempos_se(ham::LocalOperator, dt::Number)
+    Nr, Nc = size(ham.lattice)
+    return collect(_get_gatempo_se(ham, dt, r, c) for r in 1:Nr, c in 1:Nc)
 end

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -414,13 +414,13 @@ function su3site_iter(
         ),
     )
     peps2 = deepcopy(peps)
-    for i in 1:2
+    for i in 1:4
         for site in CartesianIndices(peps2.vertices)
             r, c = site[1], site[2]
             gs = gatempos[i][r, c]
             _su3site_se!(r, c, gs, peps2, alg)
         end
-        peps2 = (i == 1) ? rotl90(peps2) : rotr90(peps2)
+        peps2 = rotl90(peps2)
     end
     return peps2
 end
@@ -432,9 +432,15 @@ function _simpleupdate3site(
     peps::InfiniteWeightPEPS, ham::LocalOperator, alg::SimpleUpdate; check_interval::Int=500
 )
     time_start = time()
-    gate = get_expham(alg.dt, ham)
-    # convert gates to 3-site MPOs
-    gatempos = [_get_gatempos_se(gate), _get_gatempos_se(rotl90(gate))]
+    # Convert Hamiltonian to 3-site exponentiated gate MPOs.
+    # Since each bond is updated 4 times, 
+    # `dt` for each MPO should be divided by 4
+    gatempos = [
+        _get_gatempos_se(ham, alg.dt / 4), 
+        _get_gatempos_se(rotl90(ham), alg.dt / 4),
+        _get_gatempos_se(rot180(ham), alg.dt / 4),
+        _get_gatempos_se(rotr90(ham), alg.dt / 4),
+    ]
     wtdiff = 1.0
     wts0 = deepcopy(peps.weights)
     for count in 1:(alg.maxiter)


### PR DESCRIPTION
This PR aims to solve issues of the 3-site simple update discovered in #215 (credit to @ogauthe). 

- Now each `su3site_iter` actually performs evolution over a period of `dt`. In particular, the exponentiation of the Hamiltonian is corrected. For each `⅃`-shaped cluster
```  
     r-1         M3 
                 | 
                 ↓ 
     r   M1 -←- M2 
         c      c+1 
 ``` 
the involved Hamiltonian terms are $H = (H_{12} + H_{23}) / 2 + H_{13}$ (the 1/2 factor is due to repeated counting from `L`-shaped clusters). Previously I mistakably exponentiated each H-term first and add them up:
```math
\exp({-\epsilon H_{12}})/2 + \exp({-\epsilon H_{23}})/2 + \exp({-\epsilon H_{13}})
\quad \text{(wrong)}
```
But this is approximately
```math
\begin{aligned}
& \frac{1}{2}(1 - \epsilon H_{12})
+ \frac{1}{2}(1 - \epsilon H_{23})
+ (1 - \epsilon H_{13}) + O(\epsilon^2)
\\
&= 2 - \epsilon \left[
\frac{1}{2}(H_{12} + H_{23}) + H_{13}
\right] + O(\epsilon^2)
= 2 \, \exp({-\epsilon H / 2})
\end{aligned}
```
with a useless extra factor of 2 in the front, and it reduced the time step to $\epsilon / 2$. Now I directly calculate $\exp({-\epsilon H})$ for each cluster. 

- The C4v symmetry is better preserved by more thorough rotation of the iPEPS during evolution. Previously, I only did `rotl90` -> `rotr90` in each iteration. Now I do `rotl90` four times. As a result now each NN bond is being updated 4 times in each iteration, so the exponentiation of the Hamiltonian is done with `alg.dt / 4`. 