### PR TITLE
[Perf] Another round of performance improvements

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -15,7 +15,7 @@ import MPSKit: leading_boundary, loginit!, logiter!, logfinish!, logcancel!, phy
 
 using MPSKitModels
 using FiniteDifferences
-using OhMyThreads: tmap
+using OhMyThreads: tmap, tmap!
 using DocStringExtensions
 
 include("Defaults.jl")  # Include first to allow for docstring interpolation with Defaults values

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1310,12 +1310,19 @@ end
 function renormalize_west_edge(
     E_west::CTMRG_PEPS_EdgeTensor, P_bottom, P_top, A::PEPSSandwich
 )
-    return @autoopt @tensor edge[χ_S D_Eab D_Ebe; χ_N] :=
-        E_west[χ1 D1 D2; χ2] *
-        ket(A)[d; D3 D_Eab D5 D1] *
-        conj(bra(A)[d; D4 D_Ebe D6 D2]) *
-        P_bottom[χ2 D3 D4; χ_N] *
-        P_top[χ_S; χ1 D5 D6]
+    # starting with P_top to save one permute in the end
+    return @tensor begin
+        # already putting χE in front here to make next permute cheaper
+        PE[χS χNW DSb DWb; DSt DWt] := P_top[χS; χSW DSt DSb] * E_west[χSW DWt DWb; χNW]
+
+        PEket[χS χNW DNt DEt; DSb DWb d] :=
+            PE[χS χNW DSb DWb; DSt DWt] * ket(A)[d; DNt DEt DSt DWt]
+
+        corner[χS DEt DEb; χNW DNt DNb] :=
+            PEket[χS χNW DNt DEt; DSb DWb d] * conj(bra(A)[d; DNb DEb DSb DWb])
+        
+        edge[χS DEt DEb; χN] := corner[χS DEt DEb; χNW DNt DNb] * P_bottom[χNW DNt DNb; χN]
+    end
 end
 function renormalize_west_edge(E_west::CTMRG_PF_EdgeTensor, P_bottom, P_top, A::PFTensor)
     return @autoopt @tensor edge[χ_S D_E; χ_N] :=

--- a/src/algorithms/ctmrg/sequential.jl
+++ b/src/algorithms/ctmrg/sequential.jl
@@ -24,12 +24,12 @@ For a full description, see [`leading_boundary`](@ref). The supported keywords a
 * `svd_alg::Union{<:SVDAdjoint,NamedTuple}`
 * `projector_alg::Symbol=:$(Defaults.projector_alg)`
 """
-struct SequentialCTMRG <: CTMRGAlgorithm
+struct SequentialCTMRG{P<:ProjectorAlgorithm} <: CTMRGAlgorithm
     tol::Float64
     maxiter::Int
     miniter::Int
     verbosity::Int
-    projector_alg::ProjectorAlgorithm
+    projector_alg::P
 end
 function SequentialCTMRG(; kwargs...)
     return CTMRGAlgorithm(; alg=:sequential, kwargs...)
@@ -81,14 +81,16 @@ for a specific `coordinate` (where `dir=WEST` is already implied in the `:sequen
 """
 function sequential_projectors(col::Int, network, env::CTMRGEnv, alg::ProjectorAlgorithm)
     coordinates = eachcoordinate(env)[:, col]
-    proj_and_info = dtmap(coordinates) do (r, c)
+    T_dst = Base.promote_op(sequential_projectors, NTuple{3,Int}, typeof(network), typeof(env), typeof(alg))
+    proj_and_info = similar(coordinates, T_dst)
+    proj_and_info′::typeof(proj_and_info) = dtmap!!(proj_and_info, coordinates) do (r, c)
         trscheme = truncation_scheme(alg, env.edges[WEST, _prev(r, size(env, 2)), c])
         proj, info = sequential_projectors(
             (WEST, r, c), network, env, @set(alg.trscheme = trscheme)
         )
         return proj, info
     end
-    return _split_proj_and_info(proj_and_info)
+    return _split_proj_and_info(proj_and_info′)
 end
 function sequential_projectors(
     coordinate::NTuple{3,Int}, network, env::CTMRGEnv, alg::HalfInfiniteProjector

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -56,6 +56,8 @@ function EnlargedCorner(network::InfiniteSquareNetwork, env, coordinates)
             network[r, c],
             dir,
         )
+    else
+        throw(ArgumentError(lazy"Invalid direction $dir"))
     end
 end
 
@@ -73,6 +75,8 @@ function TensorKit.TensorMap(Q::EnlargedCorner)
         return enlarge_southeast_corner(Q.E_1, Q.C, Q.E_2, Q.A)
     elseif Q.dir == SOUTHWEST
         return enlarge_southwest_corner(Q.E_1, Q.C, Q.E_2, Q.A)
+    else
+        throw(ArgumentError(lazy"Invalid direction $dir"))
     end
 end
 

--- a/src/utility/diffable_threads.jl
+++ b/src/utility/diffable_threads.jl
@@ -8,6 +8,8 @@ All calls of `dtmap` inside of PEPSKit use the threading scheduler stored inside
 """
 dtmap(args...; scheduler=Defaults.scheduler[]) = tmap(args...; scheduler)
 
+dtmap!!(args...; scheduler=Defaults.scheduler[]) = tmap!(args...; scheduler)
+
 # Follows the `map` rrule from ChainRules.jl but specified for the case of one AbstractArray that is being mapped
 # https://github.com/JuliaDiff/ChainRules.jl/blob/e245d50a1ae56ce46fc8c1f0fe9b925964f1146e/src/rulesets/Base/base.jl#L243
 function ChainRulesCore.rrule(
@@ -31,6 +33,17 @@ function ChainRulesCore.rrule(
     end
 
     return y, dtmap_pullback
+end
+
+function ChainRulesCore.rrule(
+    config::RuleConfig{>:HasReverseMode},
+    ::typeof(dtmap!!),
+    f,
+    C::AbstractArray,
+    A::AbstractArray;
+    kwargs...,
+)
+    return rrule(config, dtmap(f, A; kwargs...))
 end
 
 """

--- a/src/utility/diffable_threads.jl
+++ b/src/utility/diffable_threads.jl
@@ -39,11 +39,16 @@ function ChainRulesCore.rrule(
     config::RuleConfig{>:HasReverseMode},
     ::typeof(dtmap!!),
     f,
-    C::AbstractArray,
+    C′::AbstractArray,
     A::AbstractArray;
     kwargs...,
 )
-    return rrule(config, dtmap(f, A; kwargs...))
+    C, dtmap_pullback = rrule(config, dtmap, f, A; kwargs...)
+    function dtmap!!_pullback(dy)
+        dtmap, df, dA = dtmap_pullback(dy)
+        return dtmap, df, NoTangent, dA
+    end
+    return C, dtmap!!_pullback
 end
 
 """


### PR DESCRIPTION
This is another round of improvements for generic performances.

In particular, the `renormalize_west_edge` function now got the same treatment with optimizing intermediate permutations, and I altered some implementations with `dtmap` as these were completely type-unstable.
At least now, from what I can test, `ctmrg_iteration` is actually type-stable, and while I don't think this would lead to massive speedups, I do believe this might help with compilation times.