### PR TITLE
Reduced density matrices

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -90,8 +90,9 @@ export CTMRGEnv, SequentialCTMRG, SimultaneousCTMRG
 export FixedSpaceTruncation, SiteDependentTruncation
 export HalfInfiniteProjector, FullInfiniteProjector
 export LocalOperator, physicalspace
-export expectation_value, cost_function, product_peps, correlation_length, network_value
-export correlator
+export product_peps
+export reduced_densitymatrix, expectation_value, network_value, cost_function
+export correlator, correlation_length
 export leading_boundary
 export PEPSOptimize, GeomSum, ManualIter, LinSolver, EigSolver
 export fixedpoint

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -290,6 +290,9 @@ function reduced_densitymatrix(
 ) where {N}
     return reduced_densitymatrix(CartesianIndex.(inds), ket, bra, env)
 end
+function reduced_densitymatrix(inds, ket::InfinitePEPS, env::CTMRGEnv)
+    return reduced_densitymatrix(inds, ket, ket, env)
+end
 
 # Special case 1x1 density matrix:
 # Keep contraction order but try to optimize intermediate permutations:

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -305,16 +305,16 @@ function reduced_densitymatrix(
 
     E_north =
         env.edges[NORTH, mod1(row - 1, end), mod1(col, end)] *
-        env.corners[NORTHEAST, mod1(row - 1, end), mod1(col + 1, end)]
+        twistdual(env.corners[NORTHEAST, mod1(row - 1, end), mod1(col + 1, end)], 1)
     E_east =
         env.edges[EAST, mod1(row, end), mod1(col + 1, end)] *
-        env.corners[SOUTHEAST, mod1(row + 1, end), mod1(col + 1, end)]
+        twistdual(env.corners[SOUTHEAST, mod1(row + 1, end), mod1(col + 1, end)], 1)
     E_south =
         env.edges[SOUTH, mod1(row + 1, end), mod1(col, end)] *
-        env.corners[SOUTHWEST, mod1(row + 1, end), mod1(col - 1, end)]
+        twistdual(env.corners[SOUTHWEST, mod1(row + 1, end), mod1(col - 1, end)], 1)
     E_west =
         env.edges[WEST, mod1(row, end), mod1(col - 1, end)] *
-        env.corners[NORTHWEST, mod1(row - 1, end), mod1(col - 1, end)]
+        twistdual(env.corners[NORTHWEST, mod1(row - 1, end), mod1(col - 1, end)], 1)
 
     @tensor EE_SW[χSE χNW DSb DWb; DSt DWt] :=
         E_south[χSE DSt DSb; χSW] * E_west[χSW DWt DWb; χNW]
@@ -359,18 +359,18 @@ function reduced_densitymatrix2x1(
 
     E_north =
         env.edges[NORTH, mod1(row - 1, end), mod1(col, end)] *
-        env.corners[NORTHEAST, mod1(row - 1, end), mod1(col + 1, end)]
+        twistdual(env.corners[NORTHEAST, mod1(row - 1, end), mod1(col + 1, end)], 1)
     E_northeast = env.edges[EAST, mod1(row, end), mod1(col + 1, end)]
     E_southeast =
         env.edges[EAST, mod1(row + 1, end), mod1(col + 1, end)] *
-        env.corners[SOUTHEAST, mod1(row + 2, end), mod1(col + 1, end)]
+        twistdual(env.corners[SOUTHEAST, mod1(row + 2, end), mod1(col + 1, end)], 1)
     E_south =
         env.edges[SOUTH, mod1(row + 2, end), mod1(col, end)] *
-        env.corners[SOUTHWEST, mod1(row + 2, end), mod1(col - 1, end)]
+        twistdual(env.corners[SOUTHWEST, mod1(row + 2, end), mod1(col - 1, end)], 1)
     E_southwest = env.edges[WEST, mod1(row + 1, end), mod1(col - 1, end)]
     E_northwest =
         env.edges[WEST, mod1(row, end), mod1(col - 1, end)] *
-        env.corners[NORTHWEST, mod1(row - 1, end), mod1(col - 1, end)]
+        twistdual(env.corners[NORTHWEST, mod1(row - 1, end), mod1(col - 1, end)], 1)
 
     @tensor EE_NW[χW χNE DNWt DNt; DNWb DNb] :=
         E_northwest[χW DNWt DNWb; χNW] * E_north[χNW DNt DNb; χNE]

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -326,7 +326,7 @@ end
 
     returnex = quote
         @autoopt @tensor $result := $multiplication_ex
-        return scale!!(ρ, inv(tr(ρ)))
+        return ρ / tr(ρ)
     end
     return macroexpand(@__MODULE__, returnex)
 end

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -323,10 +323,9 @@ end
         ket...,
         map(x -> Expr(:call, :conj, x), bra)...,
     )
-
-    returnex = quote
-        @autoopt @tensor $result := $multiplication_ex
-        return ρ / tr(ρ)
+    multex = :(@autoopt @tensor $result := $multiplication_ex)
+    return quote
+        $(macroexpand(@__MODULE__, multex))
+        return ρ / str(ρ)
     end
-    return macroexpand(@__MODULE__, returnex)
 end

--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -144,7 +144,7 @@ function _contract_state_expr(rowrange, colrange, cartesian_inds=nothing)
                 physicallabel(:O, side, inds_id)
             end
             return tensorexpr(
-                :(bra[mod1($(rmin + i - 1), end), mod1($(cmin + j - 1), end)]),
+                :($(side)[mod1($(rmin + i - 1), end), mod1($(cmin + j - 1), end)]),
                 (physical_label,),
                 (
                     if i == 1

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -8,11 +8,7 @@ function MPSKit.expectation_value(peps::InfinitePEPS, O::LocalOperator, env::CTM
     checklattice(peps, O)
     term_vals = dtmap([O.terms...]) do (inds, operator)  # OhMyThreads can't iterate over O.terms directly
         ρ = reduced_densitymatrix(inds, peps, peps, env)
-        # Note: evaluating this in one go allocates slightly less but is same speed
-        # but not visible in small tests.
-        # tr(operator * ρ) = dot(operator', ρ)
-        # tr(operator * ρ) = dot(operator, ρ) if operator is hermitian (not worth checking)
-        return dot(operator', ρ)
+        return trmul(operator, ρ)
     end
     return sum(term_vals)
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -7,8 +7,8 @@ for a PEPS `peps` using a given CTMRG environment `env`.
 function MPSKit.expectation_value(peps::InfinitePEPS, O::LocalOperator, env::CTMRGEnv)
     checklattice(peps, O)
     term_vals = dtmap([O.terms...]) do (inds, operator)  # OhMyThreads can't iterate over O.terms directly
-        contract_local_operator(inds, operator, peps, peps, env) /
-        contract_local_norm(inds, peps, peps, env)
+        ρ = reduced_densitymatrix(inds, peps, peps, env)
+        return tr(operator * ρ)
     end
     return sum(term_vals)
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -8,7 +8,11 @@ function MPSKit.expectation_value(peps::InfinitePEPS, O::LocalOperator, env::CTM
     checklattice(peps, O)
     term_vals = dtmap([O.terms...]) do (inds, operator)  # OhMyThreads can't iterate over O.terms directly
         ρ = reduced_densitymatrix(inds, peps, peps, env)
-        return tr(operator * ρ)
+        # Note: evaluating this in one go allocates slightly less but is same speed
+        # but not visible in small tests.
+        # tr(operator * ρ) = dot(operator', ρ)
+        # tr(operator * ρ) = dot(operator, ρ) if operator is hermitian (not worth checking)
+        return dot(operator', ρ)
     end
     return sum(term_vals)
 end


### PR DESCRIPTION
Replace the expectation value calculation for PEPS with computing `tr(H * rho)`. 

I checked the contraction costs and the leading cost is the same for both local operators, local norms and local density matrices. (In fact, the optimal contraction order for a single site local operator is exactly first computing the reduced densitymatrix and then contracting with the operator).
The main difference here is that instead of computing both the operator and the norm network, we can simply compute the density matrix once, divide it by its trace, and then evaluate the operator.

I'll try and include some benchmarks as well later, just to prove that everything is behaving as desired, but overall it seems to be between 25-40% faster to evaluate expectation values like this, and the memory usage scales accordingly as well.
Note that this also affects the gradient calculations, and even the compile times since the contraction functions are quite demanding for the compiler.

We should also try and hardcode the "easy" cases to optimize the intermediate permutations, but that might have to wait for a future PR.