### PR TITLE
Fix correlator for fermionic PEPS

### DIFF
--- a/src/algorithms/correlators.jl
+++ b/src/algorithms/correlators.jl
@@ -38,6 +38,7 @@ function correlator_horizontal(
             )
             T = TransferMatrix(Atop, sandwich, _dag(Abot))
             Vo = Vo * T
+            twistdual!(T.below, 2:numout(T.below))
             Vn = Vn * T
             i += CartesianIndex(0, 1)
         end
@@ -53,6 +54,7 @@ function correlator_horizontal(
         )
         T = TransferMatrix(Atop, sandwich, _dag(Abot))
         Vo = Vo * T
+        twistdual!(T.below, 2:numout(T.below))
         Vn = Vn * T
         i += CartesianIndex(0, 1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,9 @@ end
         @time @safetestset "Rotation of InfiniteWeightPEPS" begin
             include("utility/iwpeps_rotation.jl")
         end
+        @time @safetestset "Correlators" begin
+            include("utility/correlator.jl")
+        end
     end
     if GROUP == "ALL" || GROUP == "EXAMPLES"
         @time @safetestset "Transverse Field Ising model" begin

--- a/test/utility/correlator.jl
+++ b/test/utility/correlator.jl
@@ -1,0 +1,28 @@
+using Test
+using Random
+using TensorKit
+using PEPSKit
+import MPSKitModels: TJOperators as tJ
+
+Pspace = tJ.tj_space(Trivial, Trivial)
+Vspace = Vect[FermionParity](0 => 2, 1 => 2)
+Espace = Vect[FermionParity](0 => 3, 1 => 3)
+Random.seed!(100)
+peps = InfinitePEPS(rand, ComplexF64, Pspace, Vspace; unitcell=(2, 2));
+env = CTMRGEnv(rand, ComplexF64, peps, Espace);
+lattice = collect(space(t, 1) for t in peps.A)
+
+site0 = CartesianIndex(1, 1)
+maxsep = 6
+site1s = collect(site0 + CartesianIndex(0, i) for i in 1:maxsep)
+
+op = tJ.S_exchange(ComplexF64, Trivial, Trivial);
+
+vals1 = correlator(peps, op, site0, site1s, env)
+vals2 = collect(
+    begin
+        O = LocalOperator(lattice, (site0, site1) => op)
+        val = expectation_value(peps, O, env)
+    end for site1 in site1s
+)
+@test vals1 ≈ vals2

--- a/test/utility/correlator.jl
+++ b/test/utility/correlator.jl
@@ -13,8 +13,8 @@ env = CTMRGEnv(rand, ComplexF64, peps, Espace);
 lattice = collect(space(t, 1) for t in peps.A)
 
 site0 = CartesianIndex(1, 1)
-maxsep = 6
-site1s = collect(site0 + CartesianIndex(0, i) for i in 1:maxsep)
+maxsep = 8
+site1s = collect(site0 + CartesianIndex(0, i) for i in 2:2:maxsep)
 
 op = tJ.S_exchange(ComplexF64, Trivial, Trivial);
 

--- a/test/utility/correlator.jl
+++ b/test/utility/correlator.jl
@@ -19,10 +19,8 @@ site1s = collect(site0 + CartesianIndex(0, i) for i in 1:maxsep)
 op = tJ.S_exchange(ComplexF64, Trivial, Trivial);
 
 vals1 = correlator(peps, op, site0, site1s, env)
-vals2 = collect(
-    begin
-        O = LocalOperator(lattice, (site0, site1) => op)
-        val = expectation_value(peps, O, env)
-    end for site1 in site1s
-)
+vals2 = collect(begin
+    O = LocalOperator(lattice, (site0, site1) => op)
+    val = expectation_value(peps, O, env)
+end for site1 in site1s)
 @test vals1 ≈ vals2


### PR DESCRIPTION
This PR fixes same-row/column correlator for fermionic PEPS (issue #231). A new test file `test/utility/correlator.jl` is also added.

The problem was caused by some extra twists required by VUMPS, which should not be present for the evaluation of expectation values. In VUMPS, a column transfer matrix is constructed as follows (see e.g. Eq. A31 in SciPost Phys. 18, 012 (2025))

![Screenshot 2025-07-07 at 16 17 48](https://github.com/user-attachments/assets/1d4b218e-acc5-485b-81c9-6e6adb645410)

Extra twists are required on the physical legs of the "bra" MPS in the bottom. In `correlator` it is replaced by the south-edge CTM tensor. However, when evaluating expectation values, there should be no twists in the network. 

When calculating the numerator `Vo` (which contains the operator to be measured), the following function is called (the extra virtual leg in the operator MPO contributed one more leg to `GL`):
https://github.com/QuantumKitHub/PEPSKit.jl/blob/59a7f9d8b39bff7ed797bc5da1766e115cd50282/src/algorithms/contractions/vumps_contractions.jl#L41-L54
This is a new function specifically added in #210 for correlator calculation, so there are no twists. However, when `Vn` is calculated, the following function is called:
https://github.com/QuantumKitHub/PEPSKit.jl/blob/59a7f9d8b39bff7ed797bc5da1766e115cd50282/src/algorithms/contractions/vumps_contractions.jl#L5-L13
It is originally intended for VUMPS, so there are the aforementioned twists (added in #174). Thus the fix is to cancel the twists when calculating `Vn` (see added lines in `src/algorithms/correlators.jl`. Though one thing I'm uncertain is whether *inverse* twists should be used. 