### PR TITLE
Improve normalizations during simple update

### DIFF
--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -45,6 +45,8 @@ function _su_xbond!(
     sqrtsB = ntuple(dir -> (dir == WEST), 4)
     A = _absorb_weights(A, peps.weights, row, col, Tuple(1:4), sqrtsA, false)
     B = _absorb_weights(B, peps.weights, row, cp1, Tuple(1:4), sqrtsB, false)
+    normalize!(A, Inf)
+    normalize!(B, Inf)
     # apply gate
     X, a, b, Y = _qr_bond(A, B)
     a, s, b, ϵ = _apply_gate(a, b, gate, trscheme)
@@ -53,10 +55,13 @@ function _su_xbond!(
     _allfalse = ntuple(Returns(false), 3)
     A = _absorb_weights(A, peps.weights, row, col, (NORTH, SOUTH, WEST), _allfalse, true)
     B = _absorb_weights(B, peps.weights, row, cp1, (NORTH, SOUTH, EAST), _allfalse, true)
+    normalize!(A, Inf)
+    normalize!(B, Inf)
+    normalize!(s, Inf)
     # update tensor dict and weight on current bond 
     # (max element of weight is normalized to 1)
     peps.vertices[row, col], peps.vertices[row, cp1] = A, B
-    peps.weights[1, row, col] = s / norm(s, Inf)
+    peps.weights[1, row, col] = s
     return ϵ
 end
 

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -390,7 +390,7 @@ function _su3site_se!(
     wt_idxs = ((1, row, col), (2, row, cp1))
     wts, ϵ = apply_gatempo!(Ms, gs; trschemes)
     for (wt, wt_idx) in zip(wts, wt_idxs)
-        peps.weights[CartesianIndex(wt_idx)] = wt / norm(wt, Inf)
+        peps.weights[CartesianIndex(wt_idx)] = normalize(wt, Inf)
     end
     for (M, coord, invperm, axs) in zip(Ms, coords, invperms_se, openaxs_se)
         # restore original axes order
@@ -398,7 +398,7 @@ function _su3site_se!(
         # remove weights on open axes of the cluster
         _allfalse = ntuple(Returns(false), length(axs))
         M = _absorb_weights(M, peps.weights, coord[1], coord[2], axs, _allfalse, true)
-        peps.vertices[CartesianIndex(coord)] = M / norm(M, Inf)
+        peps.vertices[CartesianIndex(coord)] = normalize(M, Inf)
     end
     return nothing
 end

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -383,6 +383,7 @@ function _su3site_se!(
     rm1, cp1 = _prev(row, Nr), _next(col, Nc)
     # southwest 3-site cluster
     Ms = get_3site_se(peps, row, col)
+    normalize!.(Ms, Inf)
     # sites in the cluster
     coords = ((row, col), (row, cp1), (rm1, cp1))
     # weights in the cluster
@@ -397,7 +398,7 @@ function _su3site_se!(
         # remove weights on open axes of the cluster
         _allfalse = ntuple(Returns(false), length(axs))
         M = _absorb_weights(M, peps.weights, coord[1], coord[2], axs, _allfalse, true)
-        peps.vertices[CartesianIndex(coord)] = M * (100.0 / norm(M, Inf))
+        peps.vertices[CartesianIndex(coord)] = M / norm(M, Inf)
     end
     return nothing
 end

--- a/test/timeevol/cluster_projectors.jl
+++ b/test/timeevol/cluster_projectors.jl
@@ -7,7 +7,6 @@ import MPSKitModels: hubbard_space
 using PEPSKit: sdiag_pow, _cluster_truncate!
 include("cluster_tools.jl")
 
-nrm = 20
 Vspaces = [
     (ℂ^2, ℂ^4, (ℂ^12)'),
     (
@@ -25,7 +24,7 @@ Vspaces = [
         Vvirs[n + 1] = V
         Ms1 = map(1:N) do i
             Vw, Ve = Vvirs[i], Vvirs[i + 1]
-            return rand(Vw ← Vphy' ⊗ Vns ⊗ Vns' ⊗ Ve) / nrm
+            return normalize(rand(Vw ← Vphy' ⊗ Vns ⊗ Vns' ⊗ Ve), Inf)
         end
         revs = [isdual(space(M, 1)) for M in Ms1[2:end]]
         # no truncation
@@ -33,9 +32,7 @@ Vspaces = [
         wts2, ϵs, = _cluster_truncate!(Ms2, fill(FixedSpaceTruncation(), N-1), revs)
         @test all((ϵ == 0) for ϵ in ϵs)
         absorb_wts_cluster!(Ms2, wts2)
-        for (i, M) in enumerate(Ms2)
-            Ms2[i] *= 0.05 / norm(M, Inf)
-        end
+        normalize!.(Ms2, Inf)
         @test fidelity_cluster(Ms1, Ms2) ≈ 1.0
         lorths, rorths = verify_cluster_orth(Ms2, wts2)
         @test all(lorths) && all(rorths)
@@ -44,9 +41,7 @@ Vspaces = [
         wts3, ϵs, = _cluster_truncate!(Ms3, fill(truncspace(Vns), N-1), revs)
         @test all((i == n) || (ϵ == 0) for (i, ϵ) in enumerate(ϵs))
         absorb_wts_cluster!(Ms3, wts3)
-        for (i, M) in enumerate(Ms3)
-            Ms3[i] *= 0.05 / norm(M, Inf)
-        end
+        normalize!.(Ms3)
         ϵ = ϵs[n]
         wt2, wt3 = wts2[n], wts3[n]
         fid3, fid3_ = fidelity_cluster(Ms1, Ms3), fidelity_cluster(Ms2, Ms3)
@@ -64,7 +59,7 @@ end
         Vvirs[n + 1] = V
         Ms1 = map(1:N) do i
             Vw, Ve = Vvirs[i], Vvirs[i + 1]
-            return rand(Vw ← Vphy' ⊗ Vns ⊗ Vns' ⊗ Ve) / nrm
+            return normalize(rand(Vw ← Vphy' ⊗ Vns ⊗ Vns' ⊗ Ve), Inf)
         end
         unit = id(Vphy)
         gate = reduce(⊗, fill(unit, 3))


### PR DESCRIPTION
This is a minor improvement to properly normalize the tensors during simple update. 

Previously, after absorbing the weights into the vertex tensors, the norm of the vertex tensors may become too small, causing issues for the following SVD truncation (the singular values can be too small as well). 