### PR TITLE
[Perf] reuse `renormalize_west_edge` for all directions

### DIFF
--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1168,7 +1168,7 @@ end
 function renormalize_north_edge(
     E_north::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
 )
-    A_west = map(t -> permute(t, ((1,), (3, 4, 5, 2))), A)
+    A_west = (permute(ket(A), ((1,), (3, 4, 5, 2))), permute(bra(A), ((1,), (3, 4, 5, 2))))
     return renormalize_west_edge(E_north, P_left, P_right, A_west)
 end
 function renormalize_north_edge(E_north::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
@@ -1206,7 +1206,7 @@ end
 function renormalize_east_edge(
     E_east::CTMRG_PEPS_EdgeTensor, P_bottom, P_top, A::PEPSSandwich
 )
-    A_west = map(t -> permute(t, ((1,), (4, 5, 2, 3))), A)
+    A_west = (permute(ket(A), ((1,), (4, 5, 2, 3))), permute(bra(A), ((1,), (4, 5, 2, 3))))
     return renormalize_west_edge(E_east, P_bottom, P_top, A_west)
 end
 function renormalize_east_edge(E_east::CTMRG_PF_EdgeTensor, P_bottom, P_top, A::PFTensor)
@@ -1243,7 +1243,7 @@ end
 function renormalize_south_edge(
     E_south::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
 )
-    A_west = map(t -> permute(t, ((1,), (5, 2, 3, 4))), A)
+    A_west = (permute(ket(A), ((1,), (5, 2, 3, 4))), permute(bra(A), ((1,), (5, 2, 3, 4))))
     return renormalize_west_edge(E_south, P_left, P_right, A_west)
 end
 function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1169,10 +1169,6 @@ function renormalize_north_edge(E_north, P_left, P_right, A)
     A_west = _rotl90_localsandwich(A)
     return renormalize_west_edge(E_north, P_left, P_right, A_west)
 end
-function renormalize_north_edge(E_north::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
-    return @autoopt @tensor edge[χ_W D_S; χ_E] :=
-        E_north[χ1 D1; χ2] * A[D5 D_S; D1 D3] * P_left[χ2 D3; χ_E] * P_right[χ_W; χ1 D5]
-end
 
 """
     renormalize_east_edge((row, col), env, P_top, P_bottom, network::InfiniteSquareNetwork{P})
@@ -1205,10 +1201,6 @@ function renormalize_east_edge(E_east, P_bottom, P_top, A)
     A_west = _rot180_localsandwich(A)
     return renormalize_west_edge(E_east, P_bottom, P_top, A_west)
 end
-function renormalize_east_edge(E_east::CTMRG_PF_EdgeTensor, P_bottom, P_top, A::PFTensor)
-    return @autoopt @tensor edge[χ_N D_W; χ_S] :=
-        E_east[χ1 D1; χ2] * A[D_W D3; D5 D1] * P_bottom[χ2 D3; χ_S] * P_top[χ_N; χ1 D5]
-end
 
 """
     renormalize_south_edge((row, col), env, P_left, P_right, network::InfiniteSquareNetwork{P})
@@ -1239,10 +1231,6 @@ end
 function renormalize_south_edge(E_south, P_left, P_right, A)
     A_west = _rotr90_localsandwich(A)
     return renormalize_west_edge(E_south, P_left, P_right, A_west)
-end
-function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
-    return @autoopt @tensor edge[χ_E D_N; χ_W] :=
-        E_south[χ1 D1; χ2] * A[D3 D1; D_N D5] * P_left[χ2 D3; χ_W] * P_right[χ_E; χ1 D5]
 end
 
 """

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1168,7 +1168,7 @@ end
 function renormalize_north_edge(
     E_north::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
 )
-    A_west = (permute(ket(A), ((1,), (3, 4, 5, 2))), permute(bra(A), ((1,), (3, 4, 5, 2))))
+    A_west = _rotl90_localsandwich(A)
     return renormalize_west_edge(E_north, P_left, P_right, A_west)
 end
 function renormalize_north_edge(E_north::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
@@ -1206,7 +1206,7 @@ end
 function renormalize_east_edge(
     E_east::CTMRG_PEPS_EdgeTensor, P_bottom, P_top, A::PEPSSandwich
 )
-    A_west = (permute(ket(A), ((1,), (4, 5, 2, 3))), permute(bra(A), ((1,), (4, 5, 2, 3))))
+    A_west = _rot180_localsandwich(A)
     return renormalize_west_edge(E_east, P_bottom, P_top, A_west)
 end
 function renormalize_east_edge(E_east::CTMRG_PF_EdgeTensor, P_bottom, P_top, A::PFTensor)
@@ -1243,7 +1243,7 @@ end
 function renormalize_south_edge(
     E_south::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
 )
-    A_west = (permute(ket(A), ((1,), (5, 2, 3, 4))), permute(bra(A), ((1,), (5, 2, 3, 4))))
+    A_west = _rotr90_localsandwich(A)
     return renormalize_west_edge(E_south, P_left, P_right, A_west)
 end
 function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1165,9 +1165,7 @@ function renormalize_north_edge(
         network[row, col], # so here it's fine
     )
 end
-function renormalize_north_edge(
-    E_north::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
-)
+function renormalize_north_edge(E_north, P_left, P_right, A)
     A_west = _rotl90_localsandwich(A)
     return renormalize_west_edge(E_north, P_left, P_right, A_west)
 end
@@ -1203,9 +1201,7 @@ function renormalize_east_edge(
         network[row, col],
     )
 end
-function renormalize_east_edge(
-    E_east::CTMRG_PEPS_EdgeTensor, P_bottom, P_top, A::PEPSSandwich
-)
+function renormalize_east_edge(E_east, P_bottom, P_top, A)
     A_west = _rot180_localsandwich(A)
     return renormalize_west_edge(E_east, P_bottom, P_top, A_west)
 end
@@ -1240,9 +1236,7 @@ function renormalize_south_edge(
     )
 end
 
-function renormalize_south_edge(
-    E_south::CTMRG_PEPS_EdgeTensor, P_left, P_right, A::PEPSSandwich
-)
+function renormalize_south_edge(E_south, P_left, P_right, A)
     A_west = _rotr90_localsandwich(A)
     return renormalize_west_edge(E_south, P_left, P_right, A_west)
 end

--- a/test/ctmrg/unitcell.jl
+++ b/test/ctmrg/unitcell.jl
@@ -113,4 +113,47 @@ end
     chis = [Venv Venv; Venv Venv]
 
     test_unitcell(ctm_alg, unitcell, Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+
+    # 4x4 unit cell with all 32 inequivalent bonds
+    #
+    #    32     4     7    10
+    #     |     |     |     |
+    #  3--A--1--B--5--C--8--D--3
+    #     |     |     |     |
+    #     2     6     9    11
+    #     |     |     |     |
+    # 14--E-12--F-15--G-17--H-14
+    #     |     |     |     |
+    #    13    16    18    19
+    #     |     |     |     |
+    # 22--I-20--J-23--K-25--L-22
+    #     |     |     |     |
+    #    21    24    26    27
+    #     |     |     |     |
+    # 29--M-28--N-30--O-31--P-29
+    #     |     |     |     |
+    #    32     4     7    10
+
+    phys_space = Vect[U1Irrep](1 => 1, -1 => 1)
+    corner_space = Vect[U1Irrep](0 => 1, 1 => 1, -1 => 1)
+    vspaces = map(i -> Vect[U1Irrep](0 => 1 + i % 4, 1 => i ÷ 4 % 4, -2 => i ÷ 16), 1:32)
+    @test length(Set(vspaces)) == 32
+
+    Espaces = [
+        vspaces[1] vspaces[5] vspaces[8] vspaces[3]
+        vspaces[12] vspaces[15] vspaces[17] vspaces[14]
+        vspaces[20] vspaces[23] vspaces[25] vspaces[22]
+        vspaces[28] vspaces[30] vspaces[31] vspaces[29]
+    ]
+
+    Nspaces = [
+        vspaces[32] vspaces[4] vspaces[7] vspaces[10]
+        vspaces[2] vspaces[6] vspaces[9] vspaces[11]
+        vspaces[13] vspaces[16] vspaces[18] vspaces[19]
+        vspaces[21] vspaces[24] vspaces[26] vspaces[27]
+    ]
+    Pspaces = map(_ -> phys_space, Iterators.product(1:4, 1:4))
+    chis = map(_ -> corner_space, Iterators.product(1:4, 1:4))
+
+    test_unitcell(ctm_alg, unitcell, Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
 end

--- a/test/ctmrg/unitcell.jl
+++ b/test/ctmrg/unitcell.jl
@@ -152,8 +152,8 @@ end
         vspaces[13] vspaces[16] vspaces[18] vspaces[19]
         vspaces[21] vspaces[24] vspaces[26] vspaces[27]
     ]
-    Pspaces = map(_ -> phys_space, Iterators.product(1:4, 1:4))
-    chis = map(_ -> corner_space, Iterators.product(1:4, 1:4))
+    Pspaces = fill(phys_space, (4, 4))
+    chis = fill(corner_space, (4, 4))
 
     test_unitcell(ctm_alg, unitcell, Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
 end

--- a/test/ctmrg/unitcell.jl
+++ b/test/ctmrg/unitcell.jl
@@ -116,7 +116,7 @@ end
 
     # 4x4 unit cell with all 32 inequivalent bonds
     #
-    #    32     4     7    10
+    #    10     4     7    32
     #     |     |     |     |
     #  3--A--1--B--5--C--8--D--3
     #     |     |     |     |
@@ -132,7 +132,7 @@ end
     #     |     |     |     |
     # 29--M-28--N-30--O-31--P-29
     #     |     |     |     |
-    #    32     4     7    10
+    #    10     4     7    32
 
     phys_space = Vect[U1Irrep](1 => 1, -1 => 1)
     corner_space = Vect[U1Irrep](0 => 1, 1 => 1, -1 => 1)
@@ -147,7 +147,7 @@ end
     ]
 
     Nspaces = [
-        vspaces[32] vspaces[4] vspaces[7] vspaces[10]
+        vspaces[10] vspaces[4] vspaces[7] vspaces[32]
         vspaces[2] vspaces[6] vspaces[9] vspaces[11]
         vspaces[13] vspaces[16] vspaces[18] vspaces[19]
         vspaces[21] vspaces[24] vspaces[26] vspaces[27]


### PR DESCRIPTION
This PR rewrites `renormalize_north_edge`, `renormalize_east_edge` and `renormalize_south_edge` to have them reuse `renormalize_west_edge`. `renormalize_west_edge` was rewritten in #229 to optimize the permutations. This PR fixes #220, part of #205.

- the formatter made changes in the tensor diagrams. I can undo them if you prefer minimizing the diff
- I added a test for a 4x4 unit cell with each bond different