### PR TITLE
[perf] avoid `@autoopt` for partition function

### DIFF
--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -96,9 +96,9 @@ function enlarge_northeast_corner(
         E_east::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
     return @tensor begin
-        EC[χ_W DN; χ2] := E_north[χ_W DN; χ1] * C_northeast[χ1; χ2]
-        ECE[χ_W χ_S; DN DE] := EC[χ_W DN; χ2] * E_east[χ2 DE; χ_S]
-        corner[χ_W D_W; χ_S D_S] := ECE[χ_W χ_S; DN DE] * A[D_W D_S; DN DE]
+        EC[DN χ_W; χ2] := E_north[χ_W DN; χ1] * C_northeast[χ1; χ2]
+        ECE[DN DE; χ_S χ_W] := EC[DN χ_W; χ2] * E_east[χ2 DE; χ_S]
+        corner[χ_W D_W; χ_S D_S] :=  A[D_W D_S; DN DE] * ECE[DN DE; χ_S χ_W]
     end
 end
 

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -98,7 +98,7 @@ function enlarge_northeast_corner(
     return @tensor begin
         EC[DN χ_W; χ2] := E_north[χ_W DN; χ1] * C_northeast[χ1; χ2]
         ECE[DN DE; χ_S χ_W] := EC[DN χ_W; χ2] * E_east[χ2 DE; χ_S]
-        corner[χ_W D_W; χ_S D_S] :=  A[D_W D_S; DN DE] * ECE[DN DE; χ_S χ_W]
+        corner[χ_W D_W; χ_S D_S] := A[D_W D_S; DN DE] * ECE[DN DE; χ_S χ_W]
     end
 end
 

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -54,8 +54,11 @@ function enlarge_northwest_corner(
         E_west::CTMRG_PF_EdgeTensor, C_northwest::CTMRGCornerTensor,
         E_north::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @autoopt @tensor corner[χ_S D_S; χ_E D_E] :=
-        E_west[χ_S D1; χ1] * C_northwest[χ1; χ2] * E_north[χ2 D2; χ_E] * A[D1 D_S; D2 D_E]
+    return @tensor begin
+        EC[χ_S DW; χ2] := E_west[χ_S DW; χ1] * C_northwest[χ1; χ2]
+        ECE[χ_S χ_E; DW DN] := EC[χ_S DW; χ2] * E_north[χ2 DN; χ_E]
+        corner[χ_S D_S; χ_E D_E] := ECE[χ_S χ_E; DW DN] * A[DW D_S; DN D_E]
+    end
 end
 
 """
@@ -92,8 +95,11 @@ function enlarge_northeast_corner(
         E_north::CTMRG_PF_EdgeTensor, C_northeast::CTMRGCornerTensor,
         E_east::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @autoopt @tensor corner[χ_W D_W; χ_S D_S] :=
-        E_north[χ_W D1; χ1] * C_northeast[χ1; χ2] * E_east[χ2 D2; χ_S] * A[D_W D_S; D1 D2]
+    return @tensor begin
+        EC[χ_W DN; χ2] := E_north[χ_W DN; χ1] * C_northeast[χ1; χ2]
+        ECE[χ_W χ_S; DN DE] := EC[χ_W DN; χ2] * E_east[χ2 DE; χ_S]
+        corner[χ_W D_W; χ_S D_S] := ECE[χ_W χ_S; DN DE] * A[D_W D_S; DN DE]
+    end
 end
 
 """
@@ -130,8 +136,11 @@ function enlarge_southeast_corner(
         E_east::CTMRG_PF_EdgeTensor, C_southeast::CTMRGCornerTensor,
         E_south::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @autoopt @tensor corner[χ_N D_N; χ_W D_W] :=
-        E_east[χ_N D1; χ1] * C_southeast[χ1; χ2] * E_south[χ2 D2; χ_W] * A[D_W D2; D_N D1]
+    return @tensor begin
+        EC[χ_N D1; χ2] := E_east[χ_N D1; χ1] * C_southeast[χ1; χ2]
+        ECE[χ_N χ_W; D1 D2] := EC[χ_N D1; χ2] * E_south[χ2 D2; χ_W]
+        corner[χ_N D_N; χ_W D_W] := ECE[χ_N χ_W; D1 D2] * A[D_W D2; D_N D1]
+    end
 end
 
 """
@@ -168,8 +177,11 @@ function enlarge_southwest_corner(
         E_south::CTMRG_PF_EdgeTensor, C_southwest::CTMRGCornerTensor,
         E_west::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @autoopt @tensor corner[χ_E D_E; χ_N D_N] :=
-        E_south[χ_E D1; χ1] * C_southwest[χ1; χ2] * E_west[χ2 D2; χ_N] * A[D2 D1; D_N D_E]
+    return @tensor begin
+        EC[χ_E D1; χ2] := E_south[χ_E D1; χ1] * C_southwest[χ1; χ2]
+        ECE[χ_E χ_N; D2 D1] := EC[χ_E D1; χ2] * E_west[χ2 D2; χ_N]
+        corner[χ_E D_E; χ_N D_N] := ECE[χ_E χ_N; D2 D1] * A[D2 D1; D_N D_E]
+    end
 end
 
 # Projector contractions
@@ -1067,8 +1079,11 @@ function renormalize_west_edge(
     end
 end
 function renormalize_west_edge(E_west::CTMRG_PF_EdgeTensor, P_bottom, P_top, A::PFTensor)
-    return @autoopt @tensor edge[χ_S D_E; χ_N] :=
-        E_west[χ1 D1; χ2] * A[D1 D5; D3 D_E] * P_bottom[χ2 D3; χ_N] * P_top[χ_S; χ1 D5]
+    return @tensor begin
+        PE[χ_S χNW; D_W D_S] := P_top[χ_S; χSW D_S] * E_west[χSW D_W; χNW]
+        PEA[χ_S D_E; χNW D_N] := PE[χ_S χNW; D_W D_S] * A[D_W D_S; D_N D_E]
+        edge[χ_S D_E; χ_N] := PEA[χ_S D_E; χNW D_N] * P_bottom[χNW D_N; χ_N]
+    end
 end
 
 # Gauge fixing contractions

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1046,7 +1046,7 @@ end
 function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
     # specialize to avoid extra permute on A when calling renormalize_west_edge
     return @tensor begin
-        P_leftp = permute(P_leftp, ((3, 2), (1,)))  # impose χ_W as 1st leg
+        P_leftp = permute(P_left, ((3, 2), (1,)))  # impose χ_W as 1st leg
         PE[χ_W χSE; D_W D_S] := P_leftp[χ_W D_W; χSW] * E_south[χSE D_S; χSW]
         PEA[χ_W D_N; χSE D_E] := PE[χ_W χSE; D_W D_S] * A[D_W D_S; D_N D_E]
         edge[χ_E D_N; χ_W] := PEA[χ_W D_N; χSE D_E] * P_right[χ_E; χSE D_E]

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1046,8 +1046,8 @@ end
 function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
     # specialize to avoid extra permute on A when calling renormalize_west_edge
     return @tensor begin
-        temp[χ_W D_W; χSW] := P_left[χSW D_W; χ_W]  # impose χ_W as 1st leg
-        PE[χ_W χSE; D_W D_S] := temp[χ_W D_W; χSW] * E_south[χSE D_S; χSW]
+        P_leftp = permute(P_leftp, ((3, 2), (1,)))  # impose χ_W as 1st leg
+        PE[χ_W χSE; D_W D_S] := P_leftp[χ_W D_W; χSW] * E_south[χSE D_S; χSW]
         PEA[χ_W D_N; χSE D_E] := PE[χ_W χSE; D_W D_S] * A[D_W D_S; D_N D_E]
         edge[χ_E D_N; χ_W] := PEA[χ_W D_N; χSE D_E] * P_right[χ_E; χSE D_E]
     end

--- a/src/algorithms/contractions/ctmrg_contractions.jl
+++ b/src/algorithms/contractions/ctmrg_contractions.jl
@@ -1024,6 +1024,16 @@ function renormalize_south_edge(E_south, P_left, P_right, A)
     return renormalize_west_edge(E_south, P_left, P_right, A_west)
 end
 
+function renormalize_south_edge(E_south::CTMRG_PF_EdgeTensor, P_left, P_right, A::PFTensor)
+    # specialize to avoid extra permute on A when calling renormalize_west_edge
+    return @tensor begin
+        temp[χ_W D_W; χSW] := P_left[χSW D_W; χ_W]  # impose χ_W as 1st leg
+        PE[χ_W χSE; D_W D_S] := temp[χ_W D_W; χSW] * E_south[χSE D_S; χSW]
+        PEA[χ_W D_N; χSE D_E] := PE[χ_W χSE; D_W D_S] * A[D_W D_S; D_N D_E]
+        edge[χ_E D_N; χ_W] := PEA[χ_W D_N; χSE D_E] * P_right[χ_E; χSE D_E]
+    end
+end
+
 """
     renormalize_west_edge((row, col), env, P_top, P_bottom, network::InfiniteSquareNetwork{P})
     renormalize_west_edge(E_west, P_top, P_bottom, A::P)

--- a/test/ctmrg/partition_function.jl
+++ b/test/ctmrg/partition_function.jl
@@ -5,6 +5,21 @@ using PEPSKit
 using TensorKit
 using QuadGK
 
+
+@testset "Check spaces in partition function CTMRG" begin
+    zA = randn(ℂ^6 ⊗ ℂ^8 ← ℂ^4 ⊗ ℂ^2)
+    zB = randn(ℂ^2 ⊗ ℂ^9 ← ℂ^5 ⊗ ℂ^6)
+    zC = randn(ℂ^7 ⊗ ℂ^4 ← ℂ^8 ⊗ ℂ^3)
+    zD = randn(ℂ^3 ⊗ ℂ^5 ← ℂ^9 ⊗ ℂ^7)
+
+    Z = InfinitePartitionFunction([zA zB; zC zD])
+    χenv = ℂ^12
+    env0 = CTMRGEnv(Z, χenv)
+    env, = leading_boundary(env0, Z; alg = :simultaneous, maxiter = 3, projector_alg = :fullinfinite)
+    @test env isa CTMRGEnv
+end
+
+
 ## Setup
 
 """


### PR DESCRIPTION
This PR is a follow-up to #229 and #237. It replaces `@autoopt` by explicit contraction scheme in CTMRG partition function contractions. I assumed the optimal permutation was the same as for a wavefunction and reproduced the same order.

I do not really understand which constraints are imposed by planar non-braiding categories, so I may be doing illegal permutations. I do not know how to check for these, I am happy to learn.