### PR TITLE
Fix gauge fixing in `:fixed` mode for non-uniform unit cells from full SVD

### DIFF
--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -281,7 +281,7 @@ function _fix_svd_algorithm(alg::SVDAdjoint, signs, info)
     # embed gauge signs in larger space to fix gauge of full U and V on truncated subspace
     signs_full = map(Iterators.product(1:4, 1:size(signs, 2), 1:size(signs, 3))) do (dir, r, c)
         σ = signs[dir, r, c]
-        space = if dir == NORTH # take unit cell interdependency of signs into account
+        extended_space = if dir == NORTH # take unit cell interdependency of signs into account
             domain(info.U_full[dir, r, _prev(c, end)]) ← codomain(info.V_full[dir, r, _prev(c, end)])
         elseif dir == EAST
             domain(info.U_full[dir, _prev(r, end), c]) ← codomain(info.V_full[dir, _prev(r, end), c])
@@ -290,7 +290,7 @@ function _fix_svd_algorithm(alg::SVDAdjoint, signs, info)
         elseif dir == WEST
             domain(info.U_full[dir, _next(r, end), c]) ← codomain(info.V_full[dir, _next(r, end), c])
         end
-        extended_σ = zeros(scalartype(σ), space)
+        extended_σ = zeros(scalartype(σ), extended_space)
         for (c, b) in blocks(extended_σ)
             σc = block(σ, c)
             kept_dim = size(σc, 1)

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -279,8 +279,18 @@ end
 
 function _fix_svd_algorithm(alg::SVDAdjoint, signs, info)
     # embed gauge signs in larger space to fix gauge of full U and V on truncated subspace
-    signs_full = map(zip(signs, info.S_full)) do (σ, S_full)
-        extended_σ = zeros(scalartype(σ), space(S_full))
+    signs_full = map(Iterators.product(1:4, 1:size(signs, 2), 1:size(signs, 3))) do (dir, r, c)
+        σ = signs[dir, r, c]
+        space = if dir == NORTH # take unit cell interdependency of signs into account
+            domain(info.U_full[dir, r, _prev(c, end)]) ← codomain(info.V_full[dir, r, _prev(c, end)])
+        elseif dir == EAST
+            domain(info.U_full[dir, _prev(r, end), c]) ← codomain(info.V_full[dir, _prev(r, end), c])
+        elseif dir == SOUTH
+            domain(info.U_full[dir, r, _next(c, end)]) ← codomain(info.V_full[dir, r, _next(c, end)])
+        elseif dir == WEST
+            domain(info.U_full[dir, _next(r, end), c]) ← codomain(info.V_full[dir, _next(r, end), c])
+        end
+        extended_σ = zeros(scalartype(σ), space)
         for (c, b) in blocks(extended_σ)
             σc = block(σ, c)
             kept_dim = size(σc, 1)


### PR DESCRIPTION
I noticed that when using `:fixed` mode differentiation the gauge fixing routine would error for non-uniform unit cells when using a full SVD (as opposed a `IterSVD`). This came down the fact that the gauge signs on the full space were initialized with the wrong spaces. Now we explicitly initialize the correct spaces which is also tested in the `test/ctmrg/unitcell.jl` tests.