### PR TITLE
Fix InfinitePEPO rotation

### DIFF
--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -208,9 +208,12 @@ end
 
 ## Rotations
 
-Base.rotl90(A::InfinitePEPO) = InfinitePEPO(stack(rotl90, eachslice(unitcell(A); dims = 3)))
-Base.rotr90(A::InfinitePEPO) = InfinitePEPO(stack(rotr90, eachslice(unitcell(A); dims = 3)))
-Base.rot180(A::InfinitePEPO) = InfinitePEPO(stack(rot180, eachslice(unitcell(A); dims = 3)))
+Base.rotl90(A::InfinitePEPO) =
+    InfinitePEPO(stack(rotl90, eachslice(rotl90.(unitcell(A)); dims = 3)))
+Base.rotr90(A::InfinitePEPO) =
+    InfinitePEPO(stack(rotr90, eachslice(rotr90.(unitcell(A)); dims = 3)))
+Base.rot180(A::InfinitePEPO) =
+    InfinitePEPO(stack(rot180, eachslice(rot180.(unitcell(A)); dims = 3)))
 
 ## Chainrules
 

--- a/test/utility/suweight_rotation.jl
+++ b/test/utility/suweight_rotation.jl
@@ -39,6 +39,28 @@ function test_rotation(peps::InfinitePEPS, wts::SUWeight)
     return
 end
 
+function test_rotation(pepo::InfinitePEPO, wts::SUWeight)
+    @assert size(pepo, 3) == 1
+    for n in 1:4
+        rot = compose_n(rotl90, n)
+        A1 = InfinitePEPO(
+            collect(
+                absorb_weight(pepo.A[idx], wts, idx[1], idx[2], Tuple(1:4)) for
+                    idx in CartesianIndices(pepo.A)
+            ),
+        )
+        pepo2, wts2 = rot(pepo), rot(wts)
+        A2 = InfinitePEPO(
+            collect(
+                absorb_weight(pepo2.A[idx], wts2, idx[1], idx[2], Tuple(1:4)) for
+                    idx in CartesianIndices(pepo2.A)
+            ),
+        )
+        @test A2 ≈ rot(A1)
+    end
+    return
+end
+
 Vphy = Vect[FermionParity ⊠ U1Irrep]((0, 0) => 1, (1, 1 // 2) => 1, (1, -1 // 2) => 2)
 Vs = (
     # Espace
@@ -48,6 +70,7 @@ Vs = (
 )
 Nr, Nc = 2, 3
 peps = InfinitePEPS(rand, Float64, Vphy, Vs[2], Vs[1]'; unitcell = (Nr, Nc))
+pepo = InfinitePEPO(rand, Float64, Vphy, Vs[2], Vs[1]'; unitcell = (Nr, Nc, 1))
 wts = collect(
     tsvd(rand(Float64, Vs[dir] ← Vs[dir]))[2] for dir in 1:2, r in 1:Nr, c in 1:Nc
 )
@@ -58,3 +81,4 @@ wts = SUWeight(wts)
 
 test_rotation(wts)
 test_rotation(peps, wts)
+test_rotation(pepo, wts)


### PR DESCRIPTION
The old implementation of `rotl90` etc. for InfinitePEPO only rotated the arrangement of each tensor in the PEPO unit cell, but forgot to rotate each tensor themselves (i.e. permute their legs). This PR fixes this issue. 