### PR TITLE
Simple update for PEPO (3-site version)

### DIFF
--- a/src/algorithms/time_evolution/evoltools.jl
+++ b/src/algorithms/time_evolution/evoltools.jl
@@ -189,7 +189,7 @@ Apply 2-site `gate` on the reduced matrices `a`, `b`
 ```
 """
 function _apply_gate(
-        a::AbstractTensorMap{T, S}, b::AbstractTensorMap{T, S},
+        a::AbstractTensorMap, b::AbstractTensorMap,
         gate::AbstractTensorMap{T, S, 2, 2}, trscheme::TruncationScheme
     ) where {T <: Number, S <: ElementarySpace}
     V = space(b, 1)

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -200,7 +200,7 @@ using the Hamiltonian `ham`, which can contain up to next-nearest-neighbor inter
 ## Keyword Arguments
 
 - `bipartite::Bool=false`: If `true`, enforces the bipartite structure of the PEPS. 
-- `gate_bothsides::Bool=true`: (Effective only for PEPO evolution)
+- `gate_bothsides::Bool=true`: (Effective only for PEPO evolution) If true, apply the Trotter gate to both side of the PEPO. Otherwise, the gate is only applied to the physical codomain legs. 
 - `force_3site::Bool=false`: Forces the use of the 3-site simple update algorithm, even if the Hamiltonian contains only nearest-neighbor terms.
 - `check_interval::Int=500`: Specifies the number of evolution steps between printing progress information.
 
@@ -220,7 +220,7 @@ function simpleupdate(
     @assert !(bipartite && use_3site) "3-site simple update is incompatible with bipartite lattice."
     # TODO: check SiteDependentTruncation is compatible with bipartite structure
     if use_3site
-        return _simpleupdate3site(state, ham, alg, env; check_interval)
+        return _simpleupdate3site(state, ham, alg, env; gate_bothsides, check_interval)
     else
         return _simpleupdate2site(state, ham, alg, env; bipartite, gate_bothsides, check_interval)
     end

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -456,7 +456,7 @@ function _su3site_se!(
     # southwest 3-site cluster and arrow direction within it
     Ms = get_3site_se(state, env, row, col)
     revs = [isdual(space(M, 1)) for M in Ms[2:end]]
-    Vphys = [codomain(M, 1) for M in Ms]
+    Vphys = [codomain(M, 2) for M in Ms]
     normalize!.(Ms, Inf)
     # sites in the cluster
     coords = ((row, col), (row, cp1), (rm1, cp1))
@@ -471,15 +471,15 @@ function _su3site_se!(
             Ms = [first(_fuse_physicalspaces(M)) for M in Ms]
         end
         wts, ϵs, = _cluster_truncate!(Ms, trschemes, revs)
+        if isa(state, InfinitePEPO)
+            Ms = [first(_unfuse_physicalspace(M, Vphy)) for (M, Vphy) in zip(Ms, Vphys)]
+        end
         for (wt, wt_idx) in zip(wts, wt_idxs)
             env[CartesianIndex(wt_idx)] = normalize(wt, Inf)
         end
     end
     invperms_se = isa(state, InfinitePEPS) ? invperms_se_peps : invperms_se_pepo
     for (M, coord, invperm, openaxs, Vphy) in zip(Ms, coords, invperms_se, openaxs_se, Vphys)
-        if isa(state, InfinitePEPO)
-            M = first(_unfuse_physicalspace(M, Vphy))
-        end
         # restore original axes order
         M = permute(M, invperm)
         # remove weights on open axes of the cluster

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -134,18 +134,18 @@ Perform QR decomposition through a PEPS tensor
 ```
 """
 function qr_through(
-        R0::AbstractTensorMap{T, S, 1, 1}, M::AbstractTensorMap{T, S, 1, 4}; normalize::Bool = true
-    ) where {T <: Number, S <: ElementarySpace}
-    @tensor A[-1 -2 -3 -4; -5] := R0[-1; 1] * M[1; -2 -3 -4 -5]
+        R0::MPSBondTensor, M::GenericMPSTensor{S, 4}; normalize::Bool = true
+    ) where {S <: ElementarySpace}
+    @tensor A[-1 -2 -3 -4; -5] := R0[-1; 1] * M[1 -2 -3 -4; -5]
     q, r = leftorth!(A; alg = QRpos())
     @assert isdual(domain(r, 1)) == isdual(codomain(r, 1))
     normalize && normalize!(r, Inf)
     return q, r
 end
 function qr_through(
-        ::Nothing, M::AbstractTensorMap{T, S, 1, 4}; normalize::Bool = true
-    ) where {T <: Number, S <: ElementarySpace}
-    q, r = leftorth(M, ((1, 2, 3, 4), (5,)); alg = QRpos())
+        ::Nothing, M::GenericMPSTensor{S, 4}; normalize::Bool = true
+    ) where {S <: ElementarySpace}
+    q, r = leftorth(M; alg = QRpos())
     @assert isdual(domain(r, 1)) == isdual(codomain(r, 1))
     normalize && normalize!(r, Inf)
     return q, r
@@ -160,18 +160,18 @@ Perform LQ decomposition through a tensor
 ```
 """
 function lq_through(
-        M::AbstractTensorMap{T, S, 1, 4}, L1::AbstractTensorMap{T, S, 1, 1}; normalize::Bool = true
-    ) where {T <: Number, S <: ElementarySpace}
-    @plansor A[-1; -2 -3 -4 -5] := M[-1; -2 -3 -4 1] * L1[1; -5]
-    l, q = rightorth!(A; alg = LQpos())
+        M::GenericMPSTensor{S, 4}, L1::MPSBondTensor; normalize::Bool = true
+    ) where {S <: ElementarySpace}
+    @plansor A[-1 -2 -3 -4; -5] := M[-1 -2 -3 -4; 1] * L1[1; -5]
+    l, q = rightorth!(permute(A, ((1,), (2, 3, 4, 5))); alg = LQpos())
     @assert isdual(domain(l, 1)) == isdual(codomain(l, 1))
     normalize && normalize!(l, Inf)
     return l, q
 end
 function lq_through(
-        M::AbstractTensorMap{T, S, 1, 4}, ::Nothing; normalize::Bool = true
-    ) where {T <: Number, S <: ElementarySpace}
-    l, q = rightorth(M; alg = LQpos())
+        M::GenericMPSTensor{S, 4}, ::Nothing; normalize::Bool = true
+    ) where {S <: ElementarySpace}
+    l, q = rightorth(M, ((1,), (2, 3, 4, 5)); alg = LQpos())
     @assert isdual(domain(l, 1)) == isdual(codomain(l, 1))
     normalize && normalize!(l, Inf)
     return l, q
@@ -180,7 +180,7 @@ end
 """
 Given a cluster `Ms`, find all `R`, `L` matrices on each internal bond
 """
-function _get_allRLs(Ms::Vector{T}) where {T <: PEPSTensor}
+function _get_allRLs(Ms::Vector{T}) where {T <: GenericMPSTensor{<:ElementarySpace, 4}}
     # M1 -- (R1,L1) -- M2 -- (R2,L2) -- M3
     N = length(Ms)
     # get the first R and the last L
@@ -213,11 +213,9 @@ The arrows between `Pa`, `s`, `Pb` are
 ```
 """
 function _proj_from_RL(
-        r::AbstractTensorMap{T, S, 1, 1},
-        l::AbstractTensorMap{T, S, 1, 1};
-        trunc::TruncationScheme = notrunc(),
-        rev::Bool = false,
-    ) where {T <: Number, S <: ElementarySpace}
+        r::MPSBondTensor, l::MPSBondTensor;
+        trunc::TruncationScheme = notrunc(), rev::Bool = false,
+    )
     rl = r * l
     @assert isdual(domain(rl, 1)) == isdual(codomain(rl, 1))
     u, s, vh, ϵ = tsvd!(rl; trunc)
@@ -255,26 +253,52 @@ function _get_allprojs(
 end
 
 """
-Find projectors to truncate internal bonds of the cluster `Ms`
+Find projectors to truncate internal bonds of the cluster `Ms`.
 """
 function _cluster_truncate!(
         Ms::Vector{T}, trschemes::Vector{E}, revs::Vector{Bool}
-    ) where {T <: PEPSTensor, E <: TruncationScheme}
+    ) where {T <: GenericMPSTensor{<:ElementarySpace, 4}, E <: TruncationScheme}
     Rs, Ls = _get_allRLs(Ms)
     Pas, Pbs, wts, ϵs = _get_allprojs(Ms, Rs, Ls, trschemes, revs)
     # apply projectors
     # M1 -- (Pa1,wt1,Pb1) -- M2 -- (Pa2,wt2,Pb2) -- M3
     for (i, (Pa, Pb)) in enumerate(zip(Pas, Pbs))
-        @plansor (Ms[i])[-1; -2 -3 -4 -5] := (Ms[i])[-1; -2 -3 -4 1] * Pa[1; -5]
-        @tensor (Ms[i + 1])[-1; -2 -3 -4 -5] := Pb[-1; 1] * (Ms[i + 1])[1; -2 -3 -4 -5]
+        @plansor (Ms[i])[-1 -2 -3 -4; -5] := (Ms[i])[-1 -2 -3 -4; 1] * Pa[1; -5]
+        @tensor (Ms[i + 1])[-1 -2 -3 -4; -5] := Pb[-1; 1] * (Ms[i + 1])[1 -2 -3 -4; -5]
     end
     return wts, ϵs, Pas, Pbs
 end
 
-function _apply_gatempo!(
-        Ms::Vector{T1}, gs::Vector{T2}
-    ) where {T1 <: PEPSTensor, T2 <: AbstractTensorMap}
+"""
+Apply the gate MPO `gs` on the cluster `Ms`.
+When `gate_ax` is 1 or 2, the gate acts from the physical codomain or domain side.
+
+e.g. Cluster in PEPS with `gate_ax = 1`:
+```
+         ╱       ╱       ╱
+    --- M1 ---- M2 ---- M3 ---
+      ╱ |     ╱ |     ╱ |
+        ↓       ↓       ↓
+        g1 -←-- g2 -←-- g3
+        ↓       ↓       ↓
+```
+
+In the cluster, the axes of each tensor use the MPS order
+```
+    PEPS:           PEPO:
+           3             3  4
+          ╱              | ╱
+    1 -- M -- 5     1 -- M -- 6
+       ╱ |             ╱ |
+      4  2            5  2
+    M[1 2 3 4; 5]  M[1 2 3 4 5; 6]
+```
+"""
+function apply_gatempo!(
+        Ms::Vector{T1}, gs::Vector{T2}; gate_ax::Int = 1
+    ) where {T1 <: GenericMPSTensor{<:ElementarySpace, 4}, T2 <: AbstractTensorMap}
     @assert length(Ms) == length(gs)
+    @assert gate_ax == 1
     @assert all(!isdual(space(g, 1)) for g in gs[2:end])
     # fusers to merge axes on bonds in the gate-cluster product
     # M1 == f1† -- f1 == M2 == f2† -- f2 == M3
@@ -285,62 +309,122 @@ function _apply_gatempo!(
     for (i, M) in enumerate(Ms[2:end])
         isdual(space(M, 1)) && twist!(Ms[i + 1], 1)
     end
+    #= gate on codomain of PEPS
+           -3                         -3                          -3
+          ╱    ┌-┐          ┌-┐      ╱    ┌-┐           ┌-┐      ╱
+    -1 --M--2--┤ |          | ├--2--M--4--┤ |           | ├--2--M-- -5
+       ╱ |     | ├- -5  -1 -┤ |   ╱ |     | ├- -5   -1 -┤ |   ╱ |
+     -4  1     | |          | | -4  1     | |           | | -4  1
+         ├--3--┤ |          | ├--3--┼--5--┤ |           | ├--3--┤
+         -2    └-┘          └-┘    -2     └-┘           └-┘    -2
+    =#
     for (i, (g, M)) in enumerate(zip(gs, Ms))
         @assert !isdual(space(M, 2))
         if i == 1
             fr = fusers[i]
-            @tensor (Ms[i])[-1; -2 -3 -4 -5] := M[-1; 1 -3 -4 2] * g[-2 1 3] * fr'[2 3; -5]
+            @tensor (Ms[i])[-1 -2 -3 -4; -5] := M[-1 1 -3 -4; 2] * g[-2 1 3] * fr'[2 3; -5]
         elseif i == length(Ms)
             fl = fusers[i - 1]
-            @tensor (Ms[i])[-1; -2 -3 -4 -5] := fl[-1; 2 3] * M[2; 1 -3 -4 -5] * g[3 -2 1]
+            @tensor (Ms[i])[-1 -2 -3 -4; -5] := fl[-1; 2 3] * M[2 1 -3 -4; -5] * g[3 -2 1]
         else
             fl, fr = fusers[i - 1], fusers[i]
-            @tensor (Ms[i])[-1; -2 -3 -4 -5] :=
-                fl[-1; 2 3] * M[2; 1 -3 -4 4] * g[3 -2 1 5] * fr'[4 5; -5]
+            @tensor (Ms[i])[-1 -2 -3 -4; -5] := fl[-1; 2 3] * M[2 1 -3 -4; 4] * g[3 -2 1 5] * fr'[4 5; -5]
         end
     end
     return Ms
 end
 
-"""
-Apply the gate MPO on the cluster and truncate the bond
-```
-         ╱       ╱       ╱
-    --- M1 ---- M2 ---- M3 ---
-      ╱ |     ╱ |     ╱ |
-        ↓       ↓       ↓
-        g1 -←-- g2 -←-- g3
-        ↓       ↓       ↓
-```
-In the cluster, the axes of each PEPSTensor are reordered as
-```
-           3
-          ╱
-    1 -- M -- 5     M[1; 2 3 4 5]
-       ╱ |
-     4   2
-```
-"""
 function apply_gatempo!(
-        Ms::Vector{T1}, gs::Vector{T2}; trschemes::Vector{E}
-    ) where {T1 <: PEPSTensor, T2 <: AbstractTensorMap, E <: TruncationScheme}
+        Ms::Vector{T1}, gs::Vector{T2}; gate_ax::Int = 1
+    ) where {T1 <: GenericMPSTensor{<:ElementarySpace, 5}, T2 <: AbstractTensorMap}
     @assert length(Ms) == length(gs)
-    revs = [isdual(space(M, 1)) for M in Ms[2:end]]
-    _apply_gatempo!(Ms, gs)
-    wts, ϵs, = _cluster_truncate!(Ms, trschemes, revs)
-    return wts, ϵs
+    @assert gate_ax == 1 || gate_ax == 2
+    @assert all(!isdual(space(g, 1)) for g in gs[2:end])
+    # fusers to merge axes on bonds in the gate-cluster product
+    # M1 == f1† -- f1 == M2 == f2† -- f2 == M3
+    fusers = map(Ms[2:end], gs[2:end]) do M, g
+        V1, V2 = space(M, 1), space(g, 1)
+        return isomorphism(fuse(V1, V2) ← V1 ⊗ V2)
+    end
+    for (i, M) in enumerate(Ms[2:end])
+        isdual(space(M, 1)) && twist!(Ms[i + 1], 1)
+    end
+    #= gate on codomain of PEPO (gate_ax = 1)
+
+        -3  -4                     -3  -4                      -3  -4
+         | ╱   ┌-┐          ┌-┐     | ╱   ┌-┐           ┌-┐     | ╱
+    -1 --M--2--┤ |          | ├--2--M--4--┤ |           | ├--2--M-- -6
+       ╱ |     | ├- -6  -1 -┤ |   ╱ |     | ├- -6   -1 -┤ |   ╱ |
+     -5  1     | |          | | -5  1     | |           | | -5  1
+         ├--3--┤ |          | ├--3--┼--5--┤ |           | ├--3--┤
+         -2    └-┘          └-┘    -2     └-┘           └-┘    -2
+
+        gate on domain of PEPO (gate_ax = 2)
+
+        -3     ┌-┐          ┌-┐    -3     ┌-┐           ┌-┐    -3
+         ├--3--┤ |          | ├--3--┼--5--┤ |           | ├--3--┤
+         1  -4 | ├- -6  -1 -┤ |     1  -4 | ├- -6   -1 -┤ |     1  -4
+         | ╱   | |          | |     | ╱   | |           | |     | ╱
+    -1 --M--2--┤ |          | ├--2--M--4--┤ |           | ├--2--M-- -6
+       ╱ |     └-┘          └-┘   ╱ |     └-┘           └-┘   ╱ |
+     -5 -2                      -5 -2                       -5 -2
+    =#
+    for (i, (g, M)) in enumerate(zip(gs, Ms))
+        @assert !isdual(space(M, 2))
+        if i == 1
+            fr = fusers[i]
+            if gate_ax == 1
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := M[-1 1 -3 -4 -5; 2] * g[-2 1 3] * fr'[2 3; -6]
+            else
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := M[-1 -2 1 -4 -5; 2] * g[1 -3 3] * fr'[2 3; -6]
+            end
+        elseif i == length(Ms)
+            fl = fusers[i - 1]
+            if gate_ax == 1
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := fl[-1; 2 3] * M[2 1 -3 -4 -5; -6] * g[3 -2 1]
+            else
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := fl[-1; 2 3] * M[2 -2 1 -4 -5; -6] * g[3 1 -3]
+            end
+        else
+            fl, fr = fusers[i - 1], fusers[i]
+            if gate_ax == 1
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := fl[-1; 2 3] * M[2 1 -3 -4 -5; 4] * g[3 -2 1 5] * fr'[4 5; -6]
+            else
+                @tensor (Ms[i])[-1 -2 -3 -4 -5; -6] := fl[-1; 2 3] * M[2 -2 1 -4 -5; 4] * g[3 1 -3 5] * fr'[4 5; -6]
+            end
+        end
+    end
+    return Ms
+end
+
+function _fuse_physicalspaces(O::GenericMPSTensor{S, 5}) where {S <: ElementarySpace}
+    V1, V2 = codomain(O, 2), codomain(O, 3)
+    F = isomorphism(Int, fuse(V1, V2), V1 ⊗ V2)
+    @plansor O_fused[-1 -2 -4 -5; -6] := F[-2; 2 3] * O[-1 2 3 -4 -5; -6]
+    return O_fused, F
+end
+
+function _unfuse_physicalspace(
+        O::GenericMPSTensor{S, 4}, Vout::ElementarySpace, Vin::ElementarySpace = Vout'
+    ) where {S <: ElementarySpace}
+    F = isomorphism(Int, Vout ⊗ Vin, fuse(Vout ⊗ Vin))
+    @plansor O_unfused[-1 -2 -3 -4 -5; -6] := F[-2 -3; 1] * O[-1 1 -4 -5; -6]
+    return O_unfused, F
 end
 
 const openaxs_se = [(NORTH, SOUTH, WEST), (EAST, SOUTH), (NORTH, EAST, WEST)]
-const invperms_se = [((2,), (3, 5, 4, 1)), ((2,), (5, 3, 4, 1)), ((2,), (5, 3, 1, 4))]
-const perms_se = [
-    begin
-            p = invperm((p1..., p2...))
-            ((p[1],), p[2:end])
-        end for (p1, p2) in invperms_se
-]
+const invperms_se_peps = [((2,), (3, 5, 4, 1)), ((2,), (5, 3, 4, 1)), ((2,), (5, 3, 1, 4))]
+const perms_se_peps = map(invperms_se_peps) do (p1, p2)
+    p = invperm((p1..., p2...))
+    return (p[1:(end - 1)], (p[end],))
+end
+const invperms_se_pepo = [((2, 3), (4, 6, 5, 1)), ((2, 3), (6, 4, 5, 1)), ((2, 3), (6, 4, 1, 5))]
+const perms_se_pepo = map(invperms_se_pepo) do (p1, p2)
+    p = invperm((p1..., p2...))
+    return (p[1:(end - 1)], (p[end],))
+end
 """
-Obtain the following 3-site cluster
+Obtain the 3-site cluster in the "southeast corner" of a square plaquette.
 ``` 
     r-1         M3
                 |
@@ -349,108 +433,126 @@ Obtain the following 3-site cluster
         c      c+1
 ```
 """
-function get_3site_se(peps::InfinitePEPS, env::SUWeight, row::Int, col::Int)
-    Nr, Nc = size(peps)
+function get_3site_se(state::InfiniteState, env::SUWeight, row::Int, col::Int)
+    Nr, Nc = size(state)
     rm1, cp1 = _prev(row, Nr), _next(col, Nc)
     coords_se = [(row, col), (row, cp1), (rm1, cp1)]
-    cluster = collect(
-        permute(
-                absorb_weight(
-                    peps.A[CartesianIndex(coord)], env, coord[1], coord[2], openaxs; inv = false
-                ),
-                perm,
-            ) for (coord, openaxs, perm) in zip(coords_se, openaxs_se, perms_se)
-    )
-    return cluster
+    perms_se = isa(state, InfinitePEPS) ? perms_se_peps : perms_se_pepo
+    Ms = map(zip(coords_se, perms_se, openaxs_se)) do (coord, perm, openaxs)
+        M = absorb_weight(state.A[CartesianIndex(coord)], env, coord[1], coord[2], openaxs)
+        return permute(M, perm)
+    end
+    return Ms
 end
 
 function _su3site_se!(
-        peps::InfinitePEPS,
-        gs::Vector{T},
-        env::SUWeight,
-        row::Int,
-        col::Int,
-        trschemes::Vector{E},
+        state::InfiniteState, gs::Vector{T}, env::SUWeight,
+        row::Int, col::Int, trschemes::Vector{E};
+        gate_bothsides::Bool = true
     ) where {T <: AbstractTensorMap, E <: TruncationScheme}
-    Nr, Nc = size(peps)
+    Nr, Nc = size(state)
     @assert 1 <= row <= Nr && 1 <= col <= Nc
     rm1, cp1 = _prev(row, Nr), _next(col, Nc)
-    # southwest 3-site cluster
-    Ms = get_3site_se(peps, env, row, col)
+    # southwest 3-site cluster and arrow direction within it
+    Ms = get_3site_se(state, env, row, col)
+    revs = [isdual(space(M, 1)) for M in Ms[2:end]]
+    Vphys = [codomain(M, 1) for M in Ms]
     normalize!.(Ms, Inf)
     # sites in the cluster
     coords = ((row, col), (row, cp1), (rm1, cp1))
     # weights in the cluster
     wt_idxs = ((1, row, col), (2, row, cp1))
-    wts, ϵ = apply_gatempo!(Ms, gs; trschemes)
-    for (wt, wt_idx) in zip(wts, wt_idxs)
-        env[CartesianIndex(wt_idx)] = normalize(wt, Inf)
+    # apply gate MPOs
+    gate_axs = gate_bothsides ? (1:2) : (1:1)
+    ϵs = nothing
+    for gate_ax in gate_axs
+        apply_gatempo!(Ms, gs; gate_ax)
+        if isa(state, InfinitePEPO)
+            Ms = [first(_fuse_physicalspaces(M)) for M in Ms]
+        end
+        wts, ϵs, = _cluster_truncate!(Ms, trschemes, revs)
+        for (wt, wt_idx) in zip(wts, wt_idxs)
+            env[CartesianIndex(wt_idx)] = normalize(wt, Inf)
+        end
     end
-    for (M, coord, invperm, openaxs) in zip(Ms, coords, invperms_se, openaxs_se)
+    invperms_se = isa(state, InfinitePEPS) ? invperms_se_peps : invperms_se_pepo
+    for (M, coord, invperm, openaxs, Vphy) in zip(Ms, coords, invperms_se, openaxs_se, Vphys)
+        if isa(state, InfinitePEPO)
+            M = first(_unfuse_physicalspace(M, Vphy))
+        end
         # restore original axes order
         M = permute(M, invperm)
         # remove weights on open axes of the cluster
         M = absorb_weight(M, env, coord[1], coord[2], openaxs; inv = true)
-        peps.A[CartesianIndex(coord)] = normalize(M, Inf)
+        state.A[CartesianIndex(coord)] = normalize(M, Inf)
     end
-    return nothing
+    return ϵs
 end
 
 """
-    su3site_iter(peps::InfinitePEPS, gatempos, alg::SimpleUpdate, env::SUWeight)
+    su3site_iter(state::InfinitePEPS, gatempos, alg::SimpleUpdate, env::SUWeight)
+    su3site_iter(densitymatrix::InfinitePEPO, gatempos, alg::SimpleUpdate, env::SUWeight; gate_bothsides::Bool = true)
 
-One round of 3-site simple update. 
+One round of 3-site simple update, which applies the Trotter gate MPOs `gatempos`
+on an InfinitePEPS `state` or InfinitePEPO `densitymatrix`.
 """
 function su3site_iter(
-        peps::InfinitePEPS, gatempos::Vector{G}, alg::SimpleUpdate, env::SUWeight
+        state::InfiniteState, gatempos::Vector{G}, alg::SimpleUpdate, env::SUWeight;
+        gate_bothsides::Bool = true
     ) where {G <: AbstractMatrix}
-    Nr, Nc = size(peps)
+    if state isa InfinitePEPS
+        gate_bothsides = false
+    else
+        @assert size(state, 3) == 1
+    end
+    Nr, Nc = size(state)[1:2]
     (Nr >= 2 && Nc >= 2) || throw(
         ArgumentError(
             "iPEPS unit cell size for simple update should be no smaller than (2, 2)."
         ),
     )
-    peps2, env2 = deepcopy(peps), deepcopy(env)
+    state2, env2 = deepcopy(state), deepcopy(env)
     trscheme = alg.trscheme
     for i in 1:4
-        for site in CartesianIndices(peps2.A)
-            r, c = site[1], site[2]
+        Nr, Nc = size(state2)[1:2]
+        for r in 1:Nr, c in 1:Nc
             gs = gatempos[i][r, c]
             trschemes = [
                 truncation_scheme(trscheme, 1, r, c)
-                truncation_scheme(trscheme, 2, r, _next(c, size(peps2)[2]))
+                truncation_scheme(trscheme, 2, r, _next(c, Nc))
             ]
-            _su3site_se!(peps2, gs, env2, r, c, trschemes)
+            _su3site_se!(state2, gs, env2, r, c, trschemes; gate_bothsides)
         end
-        peps2, env2 = rotl90(peps2), rotl90(env2)
+        state2, env2 = rotl90(state2), rotl90(env2)
         trscheme = rotl90(trscheme)
     end
-    return peps2, env2
+    return state2, env2
 end
 
 """
 Perform 3-site simple update for Hamiltonian `ham`.
 """
 function _simpleupdate3site(
-        peps::InfinitePEPS,
-        ham::LocalOperator,
-        alg::SimpleUpdate,
-        env::SUWeight;
-        check_interval::Int = 500,
+        state::InfiniteState, ham::LocalOperator, alg::SimpleUpdate, env::SUWeight;
+        check_interval::Int = 500, gate_bothsides::Bool = true
     )
     time_start = time()
     # convert Hamiltonian to 3-site exponentiated gate MPOs
+    if state isa InfinitePEPS
+        gate_bothsides = false
+    end
+    dt = gate_bothsides ? (alg.dt / 2) : alg.dt
     gatempos = [
-        _get_gatempos_se(ham, alg.dt),
-        _get_gatempos_se(rotl90(ham), alg.dt),
-        _get_gatempos_se(rot180(ham), alg.dt),
-        _get_gatempos_se(rotr90(ham), alg.dt),
+        _get_gatempos_se(ham, dt),
+        _get_gatempos_se(rotl90(ham), dt),
+        _get_gatempos_se(rot180(ham), dt),
+        _get_gatempos_se(rotr90(ham), dt),
     ]
     wtdiff = 1.0
     env0 = deepcopy(env)
     for count in 1:(alg.maxiter)
         time0 = time()
-        peps, env = su3site_iter(peps, gatempos, alg, env)
+        state, env = su3site_iter(state, gatempos, alg, env; gate_bothsides)
         wtdiff = compare_weights(env, env0)
         converge = (wtdiff < alg.tol)
         cancel = (count == alg.maxiter)
@@ -467,5 +569,5 @@ function _simpleupdate3site(
         end
         converge && break
     end
-    return peps, env, wtdiff
+    return state, env, wtdiff
 end

--- a/src/algorithms/time_evolution/simpleupdate3site.jl
+++ b/src/algorithms/time_evolution/simpleupdate3site.jl
@@ -294,7 +294,7 @@ In the cluster, the axes of each tensor use the MPS order
     M[1 2 3 4; 5]  M[1 2 3 4 5; 6]
 ```
 """
-function apply_gatempo!(
+function _apply_gatempo!(
         Ms::Vector{T1}, gs::Vector{T2}; gate_ax::Int = 1
     ) where {T1 <: GenericMPSTensor{<:ElementarySpace, 4}, T2 <: AbstractTensorMap}
     @assert length(Ms) == length(gs)
@@ -334,7 +334,7 @@ function apply_gatempo!(
     return Ms
 end
 
-function apply_gatempo!(
+function _apply_gatempo!(
         Ms::Vector{T1}, gs::Vector{T2}; gate_ax::Int = 1
     ) where {T1 <: GenericMPSTensor{<:ElementarySpace, 5}, T2 <: AbstractTensorMap}
     @assert length(Ms) == length(gs)
@@ -466,7 +466,7 @@ function _su3site_se!(
     gate_axs = gate_bothsides ? (1:2) : (1:1)
     ϵs = nothing
     for gate_ax in gate_axs
-        apply_gatempo!(Ms, gs; gate_ax)
+        _apply_gatempo!(Ms, gs; gate_ax)
         if isa(state, InfinitePEPO)
             Ms = [first(_fuse_physicalspaces(M)) for M in Ms]
         end

--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -13,19 +13,12 @@ struct InfinitePEPO{T <: PEPOTensor}
     function InfinitePEPO(A::Array{T, 3}) where {T <: PEPOTensor}
         # space checks
         for (d, w, h) in Tuple.(CartesianIndices(A))
-            codomain_physicalspace(A[d, w, h]) ==
-                domain_physicalspace(A[d, w, _next(h, end)]) ||
+            codomain_physicalspace(A[d, w, h]) == domain_physicalspace(A[d, w, _next(h, end)]) ||
                 throw(SpaceMismatch("Physical space at site $((d, w, h)) does not match."))
             north_virtualspace(A[d, w, h]) == south_virtualspace(A[_prev(d, end), w, h])' ||
-                throw(
-                SpaceMismatch(
-                    "North virtual space at site $((d, w, h)) does not match."
-                ),
-            )
+                throw(SpaceMismatch("North virtual space at site $((d, w, h)) does not match."))
             east_virtualspace(A[d, w, h]) == west_virtualspace(A[d, _next(w, end), h])' ||
-                throw(
-                SpaceMismatch("East virtual space at site $((d, w, h)) does not match.")
-            )
+                throw(SpaceMismatch("East virtual space at site $((d, w, h)) does not match."))
         end
         return new{T}(A)
     end

--- a/test/examples/j1j2_finiteT.jl
+++ b/test/examples/j1j2_finiteT.jl
@@ -1,0 +1,54 @@
+using Test
+using Random
+using LinearAlgebra
+using TensorKit
+import MPSKitModels: σˣ, σᶻ
+using PEPSKit
+
+Random.seed!(10235876)
+
+# Benchmark energy from high-temperature expansion
+# at β = 0.3, 0.6
+# Physical Review B 86, 045139 (2012) Fig. 15-16
+bm = [-0.1235, -0.213]
+
+function converge_env(state, χ::Int)
+    trscheme1 = truncdim(χ) & truncerr(1.0e-12)
+    env0 = CTMRGEnv(randn, Float64, state, Vect[SU2Irrep](0 => 1))
+    env, = leading_boundary(env0, state; alg = :sequential, trscheme = trscheme1, tol = 1.0e-10)
+    return env
+end
+
+Nr, Nc = 2, 2
+ham = j1_j2_model(
+    Float64, SU2Irrep, InfiniteSquare(Nr, Nc);
+    J1 = 1.0, J2 = 0.5, sublattice = false
+)
+pepo0 = PEPSKit.infinite_temperature_density_matrix(ham)
+wts0 = SUWeight(pepo0)
+# 7 = 1 (spin-0) + 2 x 3 (spin-1)
+trscheme_pepo = truncdim(7) & truncerr(1.0e-12)
+check_interval = 100
+
+# PEPO approach
+dt, maxiter = 1.0e-3, 600
+alg = SimpleUpdate(dt, 0.0, maxiter, trscheme_pepo)
+pepo, wts, = simpleupdate(pepo0, ham, alg, wts0; check_interval, gate_bothsides = true)
+env = converge_env(InfinitePartitionFunction(pepo), 16)
+energy = expectation_value(pepo, ham, env) / (Nr * Nc)
+@info "β = $(dt * maxiter): tr(ρH) = $(energy)"
+@test energy ≈ bm[2] atol = 5.0e-3
+
+# PEPS (purified PEPO) approach
+dt, maxiter = 1.0e-3, 300
+alg = SimpleUpdate(dt, 0.0, maxiter, trscheme_pepo)
+pepo, wts, = simpleupdate(pepo0, ham, alg, wts0; check_interval, gate_bothsides = false)
+env = converge_env(InfinitePartitionFunction(pepo), 16)
+energy = expectation_value(pepo, ham, env) / (Nr * Nc)
+@info "β = $(dt * maxiter): tr(ρH) = $(energy)"
+@test energy ≈ bm[1] atol = 5.0e-3
+
+env = converge_env(InfinitePEPS(pepo), 16)
+energy = expectation_value(pepo, ham, pepo, env) / (Nr * Nc)
+@info "β = 2 × $(dt * maxiter): ⟨ρ|H|ρ⟩ = $(energy)"
+@test energy ≈ bm[2] atol = 5.0e-3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,9 @@ end
         @time @safetestset "J1-J2 model" begin
             include("examples/j1j2_model.jl")
         end
+        @time @safetestset "J1-J2 model at finite temperature" begin
+            include("examples/j1j2_finiteT.jl")
+        end
         @time @safetestset "P-wave superconductor" begin
             include("examples/pwave.jl")
         end

--- a/test/timeevol/cluster_projectors.jl
+++ b/test/timeevol/cluster_projectors.jl
@@ -89,7 +89,7 @@ end
             Ms2 = deepcopy(Ms1)
             PEPSKit.apply_gatempo!(Ms2, gs)
             fid = fidelity_cluster(
-                [first(PEPSKit._fuse_physicalspaces(M)) for M in Ms1], 
+                [first(PEPSKit._fuse_physicalspaces(M)) for M in Ms1],
                 [first(PEPSKit._fuse_physicalspaces(M)) for M in Ms2]
             )
             @test fid ≈ 1.0

--- a/test/timeevol/cluster_projectors.jl
+++ b/test/timeevol/cluster_projectors.jl
@@ -70,7 +70,7 @@ end
         gs = PEPSKit.gate_to_mpo3(gate)
         @test mpo_to_gate3(gs) ≈ gate
         Ms2 = deepcopy(Ms1)
-        PEPSKit.apply_gatempo!(Ms2, gs)
+        PEPSKit._apply_gatempo!(Ms2, gs)
         fid = fidelity_cluster(Ms1, Ms2)
         @test fid ≈ 1.0
     end
@@ -87,7 +87,7 @@ end
         @test mpo_to_gate3(gs) ≈ gate
         for gate_ax in 1:2
             Ms2 = deepcopy(Ms1)
-            PEPSKit.apply_gatempo!(Ms2, gs)
+            PEPSKit._apply_gatempo!(Ms2, gs)
             fid = fidelity_cluster(
                 [first(PEPSKit._fuse_physicalspaces(M)) for M in Ms1],
                 [first(PEPSKit._fuse_physicalspaces(M)) for M in Ms2]

--- a/test/timeevol/cluster_tools.jl
+++ b/test/timeevol/cluster_tools.jl
@@ -1,5 +1,5 @@
 function _contract_left(
-        M::AbstractTensorMap{T, S, 1, 4}, sl::DiagonalTensorMap{T, S}
+        M::GenericMPSTensor{S, 4}, sl::DiagonalTensorMap{T, S}
     ) where {T <: Number, S <: ElementarySpace}
     M0 = twist(M, filter(ax -> isdual(space(M, ax)), 1:4))
     if isdual(codomain(M, 1))
@@ -13,8 +13,8 @@ function _contract_left(
     return sl1
 end
 function _contract_left(
-        M::AbstractTensorMap{T, S, 1, 4}, ::Nothing
-    ) where {T <: Number, S <: ElementarySpace}
+        M::GenericMPSTensor{S, 4}, ::Nothing
+    ) where {S <: ElementarySpace}
     M0 = twist(M, filter(ax -> isdual(space(M, ax)), 1:4))
     @tensor sl1[e1; e0] := conj(M[w; p n s e1]) * M0[w; p n s e0]
     if isdual(space(sl1, 1))
@@ -24,10 +24,10 @@ function _contract_left(
 end
 
 function _contract_right(
-        M::AbstractTensorMap{T, S, 1, 4}, sr::DiagonalTensorMap{T, S}
+        M::GenericMPSTensor{S, 4}, sr::DiagonalTensorMap{T, S}
     ) where {T <: Number, S <: ElementarySpace}
     M0 = twist(M, filter(ax -> !isdual(space(M, ax)), 2:5))
-    if isdual(domain(M, 4))
+    if isdual(domain(M, 1))
         @tensor sr1[w0; w1] := M0[w0; p n s e0] * sr[e1; e0] * conj(M[w1; p n s e1])
     else
         @tensor sr1[w0; w1] := M0[w0; p n s e0] * sr[e0; e1] * conj(M[w1; p n s e1])
@@ -38,8 +38,8 @@ function _contract_right(
     return sr1
 end
 function _contract_right(
-        M::AbstractTensorMap{T, S, 1, 4}, ::Nothing
-    ) where {T <: Number, S <: ElementarySpace}
+        M::GenericMPSTensor{S, 4}, ::Nothing
+    ) where {S <: ElementarySpace}
     M0 = twist(M, filter(ax -> !isdual(space(M, ax)), 2:5))
     @tensor sr1[w0; w1] := M0[w0; p n s e] * conj(M[w1; p n s e])
     if isdual(space(sr1, 1))
@@ -53,7 +53,7 @@ Verify the generalized left/right orthogonal condition
 """
 function verify_cluster_orth(
         Ms::Vector{T1}, wts::Vector{T2}
-    ) where {T1 <: AbstractTensorMap, T2 <: AbstractTensorMap}
+    ) where {T1 <: GenericMPSTensor{<:ElementarySpace, 4}, T2 <: DiagonalTensorMap}
     N = length(Ms)
     @assert length(wts) == N - 1
     lorths = fill(false, N - 1)
@@ -75,11 +75,12 @@ end
 
 function inner_prod_cluster(
         Ms1::Vector{T1}, Ms2::Vector{T2}
-    ) where {T1 <: AbstractTensorMap, T2 <: AbstractTensorMap}
+    ) where {
+        T1 <: GenericMPSTensor{<:ElementarySpace, 4},
+        T2 <: GenericMPSTensor{<:ElementarySpace, 4},
+    }
     N = length(Ms1)
     @assert length(Ms2) == N
-    @assert all((numout(t) == 1 && numin(t) == 4) for t in Ms1)
-    @assert all((numout(t) == 1 && numin(t) == 4) for t in Ms2)
     @assert all(!isdual(space(t, 2)) for t in Ms1)
     @assert all(!isdual(space(t, 2)) for t in Ms2)
     # not the most efficient implementation
@@ -87,26 +88,29 @@ function inner_prod_cluster(
     for ax in 1:4
         isdual(space(M2, ax)) && twist!(M2, ax)
     end
-    @tensor res[-1 -2] := conj(M1[1; 2 3 4 -1]) * M2[1; 2 3 4 -2]
+    @tensor res[-1 -2] := conj(M1[1 2 3 4; -1]) * M2[1 2 3 4; -2]
     for i in 2:(N - 1)
         M1, M2 = Ms1[i], deepcopy(Ms2[i])
         for ax in 2:4
             isdual(space(M2, ax)) && twist!(M2, ax)
         end
-        @tensor M[-1 -2; -3 -4] := conj(M1[-1; 1 2 3 -3]) * M2[-2; 1 2 3 -4]
+        @tensor M[-1 -2; -3 -4] := conj(M1[-1 1 2 3; -3]) * M2[-2 1 2 3; -4]
         @tensor res[-1 -2] := res[1 2] * M[1 2; -1 -2]
     end
     M1, M2 = Ms1[N], deepcopy(Ms2[N])
     for ax in 2:5
         isdual(space(M2, ax)) && twist!(M2, ax)
     end
-    @tensor M[-1 -2] := conj(M1[-1; 1 2 3 4]) * M2[-2; 1 2 3 4]
+    @tensor M[-1 -2] := conj(M1[-1 1 2 3; 4]) * M2[-2 1 2 3; 4]
     return @tensor res[1 2] * M[1 2]
 end
 
 function fidelity_cluster(
         Ms1::Vector{T1}, Ms2::Vector{T2}
-    ) where {T1 <: AbstractTensorMap, T2 <: AbstractTensorMap}
+    ) where {
+        T1 <: GenericMPSTensor{<:ElementarySpace, 4},
+        T2 <: GenericMPSTensor{<:ElementarySpace, 4},
+    }
     return abs2(inner_prod_cluster(Ms1, Ms2)) /
         (inner_prod_cluster(Ms1, Ms1) * inner_prod_cluster(Ms2, Ms2))
 end


### PR DESCRIPTION
This PR adds the 3-site version of simple update for PEPO, which deals with Hamiltonians containing up to next-nearest neighbor terms. The J1-J2 model is used to test the algorithm by comparing the calculated finite-temperature energy (both tr(ρH) and ⟨ρ|H|ρ⟩) with high-temperature expansion results in https://doi.org/10.1103/PhysRevB.67.014416 (as @ogauthe did in #215). 