### PR TITLE
Remove support for integer space specifiers in state and environment constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ctmrg_tol = 1e-10
 grad_tol = 1e-4
 
 # initialize a PEPS and CTMRG environment
-peps₀ = InfinitePEPS(2, D)
+peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(D))
 env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χ)), peps₀; tol=ctmrg_tol)
 
 # ground state search

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,7 +41,7 @@ ctmrg_tol = 1e-10
 grad_tol = 1e-4
 
 # initialize a PEPS and CTMRG environment
-peps₀ = InfinitePEPS(2, D)
+peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(D))
 env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χ)), peps₀; tol=ctmrg_tol)
 
 # ground state search

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -128,19 +128,7 @@ end
 function _fill_edge_physical_spaces(
         D_north::S, D_east::S = D_north; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: VectorSpace}
-    return fill(D_north, unitcell), fill(D_east, unitcell)
-end
-function _fill_edge_physical_spaces(
-        Ds_north::M, Ds_east::M = Ds_north; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {M <: Matrix{<:VectorSpace}}
-    @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
-    return map(ProductSpace, Ds_north), map(ProductSpace, Ds_east)
-end
-function _fill_edge_physical_spaces(
-        Ds_north::M, Ds_east::M = Ds_north; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {M <: Matrix{<:ProductSpace}}
-    @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
-    return Ds_north, Ds_east
+    return fill(ProductSpace(D_north), unitcell), fill(ProductSpace(D_east), unitcell)
 end
 
 # expand virtual environment spaces to unit cell size

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -136,6 +136,12 @@ function _fill_edge_physical_spaces(
     @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
     return map(ProductSpace, Ds_north), map(ProductSpace, Ds_east)
 end
+function _fill_edge_physical_spaces(
+        Ds_north::M, Ds_east::M = Ds_north; unitcell::Tuple{Int, Int} = (1, 1)
+    ) where {M <: Matrix{<:ProducSpace}}
+    @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
+    return Ds_north, Ds_east
+end
 
 # expand virtual environment spaces to unit cell size
 function _fill_environment_virtual_spaces(
@@ -143,6 +149,13 @@ function _fill_environment_virtual_spaces(
         unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return fill(chis_north, unitcell), fill(chis_east, unitcell), fill(chis_south, unitcell), fill(chis_west, unitcell)
+end
+function _fill_environment_virtual_spaces(
+        chis_north::M, chis_east::M = chis_north, chis_south::M = chis_north, chis_west::M = chis_north;
+        unitcell::Tuple{Int, Int} = (1, 1)
+    ) where {M <: AbstractMatrix{<:ElementarySpace}}
+    @assert size(chis_north) == size(chis_east) == size(chis_south) == size(chis_west) == unitcell "Incompatible size"
+    return chis_north, chis_east, chis_south, chis_west
 end
 
 """

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -138,7 +138,7 @@ function _fill_edge_physical_spaces(
 end
 function _fill_edge_physical_spaces(
         Ds_north::M, Ds_east::M = Ds_north; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {M <: Matrix{<:ProducSpace}}
+    ) where {M <: Matrix{<:ProductSpace}}
     @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
     return Ds_north, Ds_east
 end

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -63,7 +63,7 @@ of the corresponding edge tensor for each direction. Specifically, for a given s
 Each entry of the `Ds_north` and `Ds_east` matrices corresponds to an effective local space
 of the partition function, and can be represented as an `ElementarySpace` (e.g. for the case
 of a partition function defined in terms of local rank-4 tensors) or a `ProductSpace` (e.g.
-for the case of a partition function representing overlaps of PEPSs and PEPOs).
+for the case of a network representing overlaps of PEPSs and PEPOs).
 """
 function CTMRGEnv(
         f, T, Ds_north::A, Ds_east::A, chis_north::B, chis_east::B = chis_north,

--- a/src/environments/ctmrg_environments.jl
+++ b/src/environments/ctmrg_environments.jl
@@ -126,12 +126,12 @@ end
 
 # expand physical edge spaces to unit cell size
 function _fill_edge_physical_spaces(
-        D_north::S, D_east::S = D_north, unitcell::Tuple{Int, Int} = (1, 1)
+        D_north::S, D_east::S = D_north; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: VectorSpace}
     return fill(D_north, unitcell), fill(D_east, unitcell)
 end
 function _fill_edge_physical_spaces(
-        Ds_north::M, Ds_east::M = Ds_north, unitcell::Tuple{Int, Int} = (1, 1)
+        Ds_north::M, Ds_east::M = Ds_north; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {M <: Matrix{<:VectorSpace}}
     @assert size(Ds_north) == size(Ds_east) == unitcell "Incompatible size"
     return map(ProductSpace, Ds_north), map(ProductSpace, Ds_east)
@@ -139,7 +139,7 @@ end
 
 # expand virtual environment spaces to unit cell size
 function _fill_environment_virtual_spaces(
-        chis_north::S, chis_east::S = chis_north, chis_south::S = chis_north, chis_west::S = chis_north,
+        chis_north::S, chis_east::S = chis_north, chis_south::S = chis_north, chis_west::S = chis_north;
         unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return fill(chis_north, unitcell), fill(chis_east, unitcell), fill(chis_south, unitcell), fill(chis_west, unitcell)
@@ -166,8 +166,8 @@ function CTMRGEnv(
     ) where {S <: VectorSpace}
     return CTMRGEnv(
         f, T,
-        _fill_edge_physical_spaces(D_north, D_east, unitcell)...,
-        _fill_environment_virtual_spaces(virtual_spaces..., unitcell)...,
+        _fill_edge_physical_spaces(D_north, D_east; unitcell)...,
+        _fill_environment_virtual_spaces(virtual_spaces...; unitcell)...,
     )
 end
 
@@ -201,7 +201,8 @@ of the corresponding edge tensor for each direction. Specifically, for a given s
 function CTMRGEnv(f, T, network::InfiniteSquareNetwork, virtual_spaces...)
     Ds_north = _north_edge_physical_spaces(network)
     Ds_east = _east_edge_physical_spaces(network)
-    return CTMRGEnv(f, T, Ds_north, Ds_east, virtual_spaces...; unitcell = size(network))
+    virtual_spaces = _fill_environment_virtual_spaces(virtual_spaces...; unitcell = size(network))
+    return CTMRGEnv(f, T, Ds_north, Ds_east, virtual_spaces...)
 end
 function CTMRGEnv(network::Union{InfiniteSquareNetwork, InfinitePartitionFunction, InfinitePEPS}, virtual_spaces...)
     return CTMRGEnv(randn, scalartype(network), network, virtual_spaces...)

--- a/src/states/infinitepartitionfunction.jl
+++ b/src/states/infinitepartitionfunction.jl
@@ -50,13 +50,8 @@ of the PEPS tensor at each site in the unit cell as a matrix. Each individual sp
 specified as either an `Int` or an `ElementarySpace`.
 """
 function InfinitePartitionFunction(
-        Nspaces::A, Espaces::A
-    ) where {A <: AbstractMatrix{<:ElementarySpaceLike}}
-    return InfinitePartitionFunction(randn, ComplexF64, Nspaces, Espaces)
-end
-function InfinitePartitionFunction(
         f, T, Nspaces::M, Espaces::M = Nspaces
-    ) where {M <: AbstractMatrix{<:ElementarySpaceLike}}
+    ) where {M <: AbstractMatrix{<:ElementarySpace}}
     size(Nspaces) == size(Espaces) ||
         throw(ArgumentError("Input spaces should have equal sizes."))
 
@@ -68,6 +63,9 @@ function InfinitePartitionFunction(
     end
 
     return InfinitePartitionFunction(A)
+end
+function InfinitePartitionFunction(Nspaces::A, args...) where {A <: Union{AbstractMatrix{<:ElementarySpace}, ElementarySpace}}
+    return InfinitePartitionFunction(randn, ComplexF64, Nspaces, args...)
 end
 
 """
@@ -99,22 +97,15 @@ end
 """
     InfinitePartitionFunction(
         [f=randn, T=ComplexF64,] Pspace::S, Nspace::S, [Espace::S]; unitcell=(1,1)
-    ) where {S<:ElementarySpaceLike}
+    ) where {S<:ElementarySpace}
 
 Create an InfinitePartitionFunction by specifying its physical, north and east spaces and unit cell.
 Spaces can be specified either via `Int` or via `ElementarySpace`.
 """
 function InfinitePartitionFunction(
-        Nspace::S, Espace::S = Nspace; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {S <: ElementarySpaceLike}
-    return InfinitePartitionFunction(
-        randn, ComplexF64, fill(Nspace, unitcell), fill(Espace, unitcell)
-    )
-end
-function InfinitePartitionFunction(
         f, T, Nspace::S, Espace::S = Nspace; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {S <: ElementarySpaceLike}
-    return InfinitePartitionFunction(f, T, fill(Nspace, unitcell), fill(Espace, unitcell))
+    ) where {S <: ElementarySpace}
+    return InfinitePartitionFunction(f, T, _fill_state_virtual_spaces(Nspace, Espace; unitcell)...)
 end
 
 ## Unit cell interface

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -89,12 +89,12 @@ end
 
 # expand physical PEPS spaces to unit cell size
 function _fill_state_physical_spaces(
-        Pspace::S, unitcell::Tuple{Int, Int} = (1, 1)
+        Pspace::S; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return fill(Pspace, unitcell)
 end
 function _fill_state_virtual_spaces(
-        Nspace::S, Espace::S = Nspace, unitcell::Tuple{Int, Int} = (1, 1)
+        Nspace::S, Espace::S = Nspace; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return (fill(Nspace, unitcell), fill(Espace, unitcell))
 end
@@ -110,8 +110,8 @@ function InfinitePEPS(
     ) where {S <: ElementarySpace}
     return InfinitePEPS(
         f, T,
-        _fill_state_physical_spaces(Pspace, unitcell),
-        _fill_state_virtual_spaces(vspaces..., unitcell)...,
+        _fill_state_physical_spaces(Pspace; unitcell),
+        _fill_state_virtual_spaces(vspaces...; unitcell)...,
     )
 end
 

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -111,7 +111,7 @@ function InfinitePEPS(
     return InfinitePEPS(
         f, T,
         _fill_state_physical_spaces(Pspace, unitcell),
-        _fill_state_virtual_spaces(vspaces...; unitcell)...,
+        _fill_state_virtual_spaces(vspaces..., unitcell)...,
     )
 end
 

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -93,22 +93,10 @@ function _fill_state_physical_spaces(
     ) where {S <: ElementarySpace}
     return fill(Pspace, unitcell)
 end
-function _fill_state_physical_spaces(
-        Pspaces::M; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {M <: AbstractMatrix{<:ElementarySpace}}
-    @assert size(Pspaces) == unitcell || @warn "Input physical spaces size does not match unit cell size."
-    return Pspaces
-end
 function _fill_state_virtual_spaces(
         Nspace::S, Espace::S = Nspace; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return fill(Nspace, unitcell), fill(Espace, unitcell)
-end
-function _fill_state_virtual_spaces(
-        Nspaces::M, Espaces::M = Nspaces; unitcell::Tuple{Int, Int} = (1, 1)
-    ) where {M <: AbstractMatrix{<:ElementarySpace}}
-    @assert size(Nspaces) == size(Espaces) == unitcell || @warn "Input virtual spaces size does not match unit cell size."
-    return Nspaces, Espaces
 end
 
 """

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -91,7 +91,7 @@ end
 function _fill_state_physical_spaces(
         Pspace::S, unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
-    return fill(Pspace, unitcell), fill(Espace, unitcell)
+    return fill(Pspace, unitcell)
 end
 function _fill_state_virtual_spaces(
         Nspace::S, Espace::S = Nspace, unitcell::Tuple{Int, Int} = (1, 1)

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -87,16 +87,28 @@ function InfinitePEPS(A::T; unitcell::Tuple{Int, Int} = (1, 1)) where {T <: PEPS
     return InfinitePEPS(fill(A, unitcell))
 end
 
-# expand physical PEPS spaces to unit cell size
+# expand PEPS spaces to unit cell size
 function _fill_state_physical_spaces(
         Pspace::S; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return fill(Pspace, unitcell)
 end
+function _fill_state_physical_spaces(
+        Pspaces::M; unitcell::Tuple{Int, Int} = (1, 1)
+    ) where {M <: AbstractMatrix{<:ElementarySpace}}
+    @assert size(Pspaces) == unitcell || @warn "Input physical spaces size does not match unit cell size."
+    return Pspaces
+end
 function _fill_state_virtual_spaces(
         Nspace::S, Espace::S = Nspace; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
-    return (fill(Nspace, unitcell), fill(Espace, unitcell))
+    return fill(Nspace, unitcell), fill(Espace, unitcell)
+end
+function _fill_state_virtual_spaces(
+        Nspaces::M, Espaces::M = Nspaces; unitcell::Tuple{Int, Int} = (1, 1)
+    ) where {M <: AbstractMatrix{<:ElementarySpace}}
+    @assert size(Nspaces) == size(Espaces) == unitcell || @warn "Input virtual spaces size does not match unit cell size."
+    return Nspaces, Espaces
 end
 
 """

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -43,7 +43,7 @@ Create an `InfinitePEPS` by specifying the physical, north virtual and east virt
 of the PEPS tensor at each site in the unit cell as a matrix.
 """
 function InfinitePEPS(
-        f, T, Pspaces::M, Nspaces::M, Espaces::M = Nspaces
+        f, T::Type{<:Number}, Pspaces::M, Nspaces::M, Espaces::M = Nspaces
     ) where {M <: AbstractMatrix{<:ElementarySpace}}
     size(Pspaces) == size(Nspaces) == size(Espaces) ||
         throw(ArgumentError("Input spaces should have equal sizes."))
@@ -115,10 +115,9 @@ end
     InfinitePEPS([f=randn, T=ComplexF64,] Pspace, Nspace, [Espace]; unitcell=(1,1))
 
 Create an InfinitePEPS by specifying its physical, north and east spaces and unit cell.
-Spaces can be specified either via `Int` or via `ElementarySpace`.
 """
 function InfinitePEPS(
-        f, T, Pspace::S, vspaces...; unitcell::Tuple{Int, Int} = (1, 1)
+        f, T::Type{<:Number}, Pspace::S, vspaces...; unitcell::Tuple{Int, Int} = (1, 1)
     ) where {S <: ElementarySpace}
     return InfinitePEPS(
         f, T,

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -58,9 +58,9 @@ function InfinitePEPS(
     return InfinitePEPS(A)
 end
 function InfinitePEPS(
-        Pspaces::A, virtual_spaces...
+        Pspaces::A, virtual_spaces...; kwargs...
     ) where {A <: Union{AbstractMatrix{<:ElementarySpace}, ElementarySpace}}
-    return InfinitePEPS(randn, ComplexF64, Pspaces, virtual_spaces...)
+    return InfinitePEPS(randn, ComplexF64, Pspaces, virtual_spaces...; kwargs...)
 end
 
 """

--- a/test/ctmrg/fixed_iterscheme.jl
+++ b/test/ctmrg/fixed_iterscheme.jl
@@ -32,7 +32,7 @@ atol = 1.0e-5
 
     # initialize states
     Random.seed!(2394823842)
-    psi = InfinitePEPS(2, χbond; unitcell)
+    psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(χbond); unitcell)
     n = InfiniteSquareNetwork(psi)
 
     env_conv1, = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg)
@@ -62,7 +62,7 @@ end
 
     # initialize states
     Random.seed!(91283219347)
-    psi = InfinitePEPS(2, χbond)
+    psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(χbond))
     n = InfiniteSquareNetwork(psi)
     env₀ = CTMRGEnv(psi, ComplexSpace(χenv))
     env_conv1, = leading_boundary(env₀, psi, ctm_alg_iter)

--- a/test/ctmrg/flavors.jl
+++ b/test/ctmrg/flavors.jl
@@ -57,7 +57,7 @@ end
     Ds = ComplexSpace.(fill(2, 3, 3))
     χs = ComplexSpace.([16 17 18; 15 20 21; 14 19 22])
     psi = InfinitePEPS(Ds, Ds, Ds)
-    env = CTMRGEnv(psi, rand(10:20, 3, 3), rand(10:20, 3, 3))
+    env = CTMRGEnv(psi, ComplexSpace.(rand(10:20, 3, 3)), ComplexSpace.(rand(10:20, 3, 3)))
     env2, = leading_boundary(
         env, psi; alg, maxiter = 1, trscheme = FixedSpaceTruncation(), projector_alg
     )

--- a/test/ctmrg/flavors.jl
+++ b/test/ctmrg/flavors.jl
@@ -14,7 +14,7 @@ projector_algs = [:halfinfinite, :fullinfinite]
     Iterators.product(unitcells, projector_algs)
     # compute environments
     Random.seed!(32350283290358)
-    psi = InfinitePEPS(2, χbond; unitcell)
+    psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(χbond); unitcell)
     env_sequential, = leading_boundary(
         CTMRGEnv(psi, ComplexSpace(χenv)), psi; alg = :sequential, projector_alg
     )
@@ -54,8 +54,8 @@ end
 # test fixedspace actually fixes space
 @testset "Fixedspace truncation using $alg and $projector_alg" for (alg, projector_alg) in
     Iterators.product([:sequential, :simultaneous], projector_algs)
-    Ds = fill(2, 3, 3)
-    χs = [16 17 18; 15 20 21; 14 19 22]
+    Ds = ComplexSpace.(fill(2, 3, 3))
+    χs = ComplexSpace.([16 17 18; 15 20 21; 14 19 22])
     psi = InfinitePEPS(Ds, Ds, Ds)
     env = CTMRGEnv(psi, rand(10:20, 3, 3), rand(10:20, 3, 3))
     env2, = leading_boundary(

--- a/test/ctmrg/jacobian_real_linear.jl
+++ b/test/ctmrg/jacobian_real_linear.jl
@@ -19,7 +19,7 @@ Dbond, χenv = 2, 16
 
 @testset "$iterscheme and $ctm_alg" for (iterscheme, ctm_alg) in algs
     Random.seed!(123521938519)
-    state = InfinitePEPS(2, Dbond)
+    state = InfinitePEPS(ComplexSpace(2), ComplexSpace(Dbond))
     env, = leading_boundary(CTMRGEnv(state, ComplexSpace(χenv)), state, ctm_alg)
 
     # follow code of _rrule

--- a/test/ctmrg/unitcell.jl
+++ b/test/ctmrg/unitcell.jl
@@ -27,11 +27,11 @@ function test_unitcell(
 
     # compute random expecation value to test matching bonds
     random_op = LocalOperator(
-        PEPSKit._to_space.(Pspaces),
+        Pspaces,
         [
             (c,) => randn(
                     scalartype(peps),
-                    PEPSKit._to_space(Pspaces[c]), PEPSKit._to_space(Pspaces[c]),
+                    Pspaces[c], Pspaces[c],
                 ) for c in CartesianIndices(unitcell)
         ]...,
     )
@@ -53,23 +53,6 @@ function random_dualize!(M::AbstractMatrix{<:ElementarySpace})
     mask = rand([true, false], size(M))
     M[mask] .= adjoint.(M[mask])
     return M
-end
-
-@testset "Integer space specifiers with $ctm_alg" for ctm_alg in ctm_algs
-    unitcell = (3, 3)
-
-    Pspaces = rand(2:3, unitcell...)
-    Nspaces = rand(2:4, unitcell...)
-    Espaces = rand(2:4, unitcell...)
-    chis_north = rand(5:10, unitcell...)
-    chis_east = rand(5:10, unitcell...)
-    chis_south = rand(5:10, unitcell...)
-    chis_west = rand(5:10, unitcell...)
-
-    test_unitcell(
-        ctm_alg, unitcell,
-        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
 end
 
 @testset "Random Cartesian spaces with $ctm_alg" for ctm_alg in ctm_algs

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -18,7 +18,7 @@ E_ref = -0.6602310934799577
     # initialize states
     Random.seed!(123)
     H = heisenberg_XYZ(InfiniteSquare())
-    peps₀ = InfinitePEPS(2, Dbond)
+    peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(Dbond))
     env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenv)), peps₀)
 
     # optimize energy and compute correlation lengths
@@ -34,7 +34,7 @@ end
     Random.seed!(456)
     unitcell = (1, 2)
     H = heisenberg_XYZ(InfiniteSquare(unitcell...))
-    peps₀ = InfinitePEPS(2, Dbond; unitcell)
+    peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(Dbond); unitcell)
     env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenv)), peps₀)
 
     # optimize energy and compute correlation lengths

--- a/test/examples/j1j2_model.jl
+++ b/test/examples/j1j2_model.jl
@@ -12,7 +12,7 @@ using OptimKit
 # initialize states
 Random.seed!(91283219347)
 H = j1_j2_model(InfiniteSquare(); J2 = 0.25)
-peps₀ = product_peps(2, χbond; noise_amp = 1.0e-1)
+peps₀ = product_peps(ComplexSpace(2), ComplexSpace(χbond); noise_amp = 1.0e-1)
 peps₀ = symmetrize!(peps₀, RotateReflect())
 env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenv)), peps₀)
 

--- a/test/examples/tf_ising.jl
+++ b/test/examples/tf_ising.jl
@@ -24,7 +24,7 @@ gradtol = 1.0e-3
 # initialize states
 H = transverse_field_ising(InfiniteSquare(); g)
 Random.seed!(2928528935)
-peps₀ = InfinitePEPS(2, χbond)
+peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(χbond))
 env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenv)), peps₀)
 
 # find fixedpoint

--- a/test/utility/svd_wrapper.jl
+++ b/test/utility/svd_wrapper.jl
@@ -126,7 +126,7 @@ end
 # ctm_alg = CTMRG(; tol=1e-10, verbosity=2, svd_alg=SVDAdjoint())
 # Random.seed!(91283219347)
 # H = heisenberg_XYZ(InfiniteSquare())
-# psi = InfinitePEPS(2, χbond)
+# psi = InfinitePEPS(ComplexSpace(2), ComplexSpace(χbond))
 # env = leading_boundary(CTMRGEnv(psi, ComplexSpace(χenv)), psi, ctm_alg);
 # hienv = HalfInfiniteEnv(
 #     env.corners[1],

--- a/test/utility/symmetrization.jl
+++ b/test/utility/symmetrization.jl
@@ -4,7 +4,7 @@ using PEPSKit: herm_depth, herm_width, _fit_spaces
 using TensorKit
 
 @testset "ReflectDepth" for unitcell in [(1, 1), (2, 2), (3, 3)]
-    peps = InfinitePEPS(2, 2; unitcell)
+    peps = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell)
 
     peps_depth = symmetrize!(deepcopy(peps), ReflectDepth())
     peps_reflect = _fit_spaces(
@@ -14,7 +14,7 @@ using TensorKit
 end
 
 @testset "ReflectWidth" for unitcell in [(1, 1), (2, 2), (3, 3)]
-    peps = InfinitePEPS(2, 2; unitcell)
+    peps = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell)
 
     peps_width = symmetrize!(deepcopy(peps), ReflectWidth())
     peps_reflect = _fit_spaces(
@@ -24,7 +24,7 @@ end
 end
 
 @testset "Rotate" for unitcell in [(1, 1), (2, 2), (3, 3)]
-    peps = InfinitePEPS(2, 2; unitcell)
+    peps = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell)
 
     peps_rot = symmetrize!(deepcopy(peps), Rotate())
     @test peps_rot ≈ _fit_spaces(rotl90(peps_rot), peps_rot)
@@ -33,7 +33,7 @@ end
 end
 
 @testset "RotateReflect" for unitcell in [(1, 1), (2, 2), (3, 3)]
-    peps = InfinitePEPS(2, 2; unitcell)
+    peps = InfinitePEPS(ComplexSpace(2), ComplexSpace(2); unitcell)
 
     peps_full = symmetrize!(deepcopy(peps), RotateReflect())
     @test peps_full ≈ _fit_spaces(rotl90(peps_full), peps_full)


### PR DESCRIPTION
See #265.

I also tried to simplify the constructors a bit in the process by splitting out the filling of the physical and virtual spaces depending on how were provided. I at least removed a bunch of things, not sure if this actually made things simpler.
