### PR TITLE
Fix `rotl90`, `rotr90` and `rot180` for `LocalOperator`

### DIFF
--- a/src/algorithms/correlators.jl
+++ b/src/algorithms/correlators.jl
@@ -154,8 +154,9 @@ function correlator_vertical(
     rotated_bra = rotl90(bra)
     rotated_ket = bra === ket ? rotated_bra : rotl90(ket)
 
-    rotated_i = rotl90(i)
-    rotated_j = map(rotl90, js)
+    nc = size(bra, 2) + 1
+    rotated_i = siterotl90(i, nc)
+    rotated_j = map(j -> siterotl90(j, nc), js)
 
     return correlator_horizontal(
         rotated_bra, O, rotated_i, rotated_j, rotated_ket, rotl90(env)

--- a/src/algorithms/correlators.jl
+++ b/src/algorithms/correlators.jl
@@ -154,9 +154,8 @@ function correlator_vertical(
     rotated_bra = rotl90(bra)
     rotated_ket = bra === ket ? rotated_bra : rotl90(ket)
 
-    nc = size(bra, 2) + 1
-    rotated_i = siterotl90(i, nc)
-    rotated_j = map(j -> siterotl90(j, nc), js)
+    rotated_i = siterotl90(i, size(bra))
+    rotated_j = map(j -> siterotl90(j, size(bra)), js)
 
     return correlator_horizontal(
         rotated_bra, O, rotated_i, rotated_j, rotated_ket, rotl90(env)

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -155,26 +155,29 @@ end
 # ----------------------
 
 # rotation of a lattice site
-# TODO: type piracy
-Base.rotl90(site::CartesianIndex{2}) = CartesianIndex(2 - site[2], site[1])
-Base.rotr90(site::CartesianIndex{2}) = CartesianIndex(site[2], 2 - site[1])
-Base.rot180(site::CartesianIndex{2}) = CartesianIndex(2 - site[1], 2 - site[2])
+# (copy logic from Base.rotl90, Base.rotr90, Base.rot180)
+siterotl90(site::CartesianIndex{2}, n::Int) = CartesianIndex(n - site[2], site[1])
+siterotr90(site::CartesianIndex{2}, n::Int) = CartesianIndex(site[2], n - site[1])
+siterot180(site::CartesianIndex{2}, nr::Int, nc::Int) = CartesianIndex(nr - site[1], nc - site[2])
 
 function Base.rotr90(H::LocalOperator)
+    nr = size(H.lattice, 1)
     lattice2 = rotr90(H.lattice)
-    terms2 = ((Tuple(rotr90(site) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotr90(site, nr + 1) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 
 function Base.rotl90(H::LocalOperator)
+    nc = size(H.lattice, 2)
     lattice2 = rotl90(H.lattice)
-    terms2 = ((Tuple(rotl90(site) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotl90(site, nc + 1) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 
 function Base.rot180(H::LocalOperator)
+    nr, nc = size(H.lattice)
     lattice2 = rot180(H.lattice)
-    terms2 = ((Tuple(rot180(site) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterot180(site, nr + 1, nc + 1) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -161,16 +161,16 @@ siterotr90(site::CartesianIndex{2}, n::Int) = CartesianIndex(site[2], n - site[1
 siterot180(site::CartesianIndex{2}, nr::Int, nc::Int) = CartesianIndex(nr - site[1], nc - site[2])
 
 function Base.rotr90(H::LocalOperator)
-    nr = size(H.lattice, 1)
+    nr = size(H.lattice, 1) + 1
     lattice2 = rotr90(H.lattice)
-    terms2 = ((Tuple(siterotr90(site, nr + 1) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotr90(site, nr) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 
 function Base.rotl90(H::LocalOperator)
-    nc = size(H.lattice, 2)
+    nc = size(H.lattice, 2) + 1
     lattice2 = rotl90(H.lattice)
-    terms2 = ((Tuple(siterotl90(site, nc + 1) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotl90(site, nc) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -151,6 +151,17 @@ function VI.scalartype(::Type{<:LocalOperator{T}}) where {T}
     return promote_type((scalartype(last(fieldtypes(p))) for p in fieldtypes(T))...)
 end
 
+# Equivalence
+# -----------
+
+function Base.:(==)(O₁::LocalOperator, O₂::LocalOperator)
+    lat = O₁.lattice == O₂.lattice
+    terms = all(zip(O₁.terms, O₂.terms)) do (t₁, t₂)
+        return t₁ == t₂
+    end
+    return lat && terms
+end
+
 # Rotation
 # ----------------------
 

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -156,28 +156,32 @@ end
 
 # rotation of a lattice site
 # (copy logic from Base.rotl90, Base.rotr90, Base.rot180)
-siterotl90(site::CartesianIndex{2}, n::Int) = CartesianIndex(n - site[2], site[1])
-siterotr90(site::CartesianIndex{2}, n::Int) = CartesianIndex(site[2], n - site[1])
-siterot180(site::CartesianIndex{2}, nr::Int, nc::Int) = CartesianIndex(nr - site[1], nc - site[2])
+function siterotl90(site::CartesianIndex{2}, unitcell::NTuple{2, Int})
+    return CartesianIndex(unitcell[2] + 1 - site[2], site[1])
+end
+function siterotr90(site::CartesianIndex{2}, unitcell::NTuple{2, Int})
+    return CartesianIndex(site[2], unitcell[1] + 1 - site[1])
+end
+function siterot180(site::CartesianIndex{2}, unitcell::NTuple{2, Int})
+    return CartesianIndex(unitcell[1] + 1 - site[1], unitcell[2] + 1 - site[2])
+end
 
 function Base.rotr90(H::LocalOperator)
-    nr = size(H.lattice, 1) + 1
+    Hsize = size(H.lattice)
     lattice2 = rotr90(H.lattice)
-    terms2 = ((Tuple(siterotr90(site, nr) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotr90(site, Hsize) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
-
 function Base.rotl90(H::LocalOperator)
-    nc = size(H.lattice, 2) + 1
+    Hsize = size(H.lattice)
     lattice2 = rotl90(H.lattice)
-    terms2 = ((Tuple(siterotl90(site, nc) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterotl90(site, Hsize) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
-
 function Base.rot180(H::LocalOperator)
-    nr, nc = size(H.lattice)
+    Hsize = size(H.lattice)
     lattice2 = rot180(H.lattice)
-    terms2 = ((Tuple(siterot180(site, nr + 1, nc + 1) for site in sites) => op) for (sites, op) in H.terms)
+    terms2 = ((Tuple(siterot180(site, Hsize) for site in sites) => op) for (sites, op) in H.terms)
     return LocalOperator(lattice2, terms2...)
 end
 

--- a/test/utility/localoperator.jl
+++ b/test/utility/localoperator.jl
@@ -93,7 +93,7 @@ unitcells = [(1, 1), (2, 3), (3, 3), (4, 3)]
     unrotated_inds = collect(CartesianIndices(uc))
     # use reverse(uc) to account for transposing when using rotl90, rotr90 on non-square unit cells
     rr_rotated_inds = rotr90(siterotr90.(collect(CartesianIndices(reverse(uc))), Ref(reverse(uc))))
-    ll_rotated_inds = rotr90(siterotr90.(collect(CartesianIndices(reverse(uc))), Ref(reverse(uc))))
+    ll_rotated_inds = rotl90(siterotl90.(collect(CartesianIndices(reverse(uc))), Ref(reverse(uc))))
     half_rotated_inds = rot180(siterot180.(collect(CartesianIndices(uc)), Ref(uc)))
 
     @test unrotated_inds == rr_rotated_inds

--- a/test/utility/localoperator.jl
+++ b/test/utility/localoperator.jl
@@ -86,3 +86,35 @@ end
     tr_after = tr(last(only(H_shifted.terms)))
     @test abs(tr_before - tr_after) / abs(tr_before) < 1.0e-12
 end
+
+@testset "Operator rotations" begin
+    op_1x1 = LocalOperator([ℂ^2;;], ((1, 1), (1, 2)) => randn(ℂ^2, ℂ^2) ⊗ randn(ℂ^2, ℂ^2))
+    @test rotl90(op_1x1) isa LocalOperator
+    @test rotr90(op_1x1) isa LocalOperator
+    @test rot180(op_1x1) isa LocalOperator
+
+    charges = [
+        U1Irrep(-1 // 2) U1Irrep(1 // 2)
+        U1Irrep(1 // 2) U1Irrep(-1 // 2)
+    ] # staggered charges to make physical spaces non-uniform
+    H₀ = j1_j2_model(ComplexF64, U1Irrep, InfiniteSquare(2, 2))
+    op_2x2 = add_physical_charge(H₀, charges)
+    @test rotl90(op_2x2) isa LocalOperator
+    @test rotr90(op_2x2) isa LocalOperator
+    @test rot180(op_2x2) isa LocalOperator
+
+    lat_2x3 = [
+        ℂ^1 ℂ^2 ℂ^3
+        ℂ^4 ℂ^5 ℂ^6
+    ]
+    terms_2x3 = (
+        ((1, 1), (1, 2)) => randn(ℂ^1, ℂ^1) ⊗ randn(ℂ^2, ℂ^2),
+        ((2, 1), (1, 1)) => randn(ℂ^4, ℂ^4) ⊗ randn(ℂ^1, ℂ^1),
+        ((1, 2), (2, 3)) => randn(ℂ^2, ℂ^2) ⊗ randn(ℂ^6, ℂ^6),
+        ((1, 3), (2, 2)) => randn(ℂ^3, ℂ^3) ⊗ randn(ℂ^5, ℂ^5),
+    )
+    op_2x3 = LocalOperator(lat_2x3, terms_2x3...)
+    @test rotl90(op_2x3) isa LocalOperator
+    @test rotr90(op_2x3) isa LocalOperator
+    @test rot180(op_2x3) isa LocalOperator
+end

--- a/test/utility/localoperator.jl
+++ b/test/utility/localoperator.jl
@@ -101,34 +101,32 @@ unitcells = [(1, 1), (2, 3), (3, 3), (4, 3)]
     @test unrotated_inds == half_rotated_inds
 end
 
-@testset "Operator rotations" begin
-    op_1x1 = LocalOperator([ℂ^2;;], ((1, 1), (1, 2)) => randn(ℂ^2, ℂ^2) ⊗ randn(ℂ^2, ℂ^2))
-    @test rotl90(op_1x1) isa LocalOperator
-    @test rotr90(op_1x1) isa LocalOperator
-    @test rot180(op_1x1) isa LocalOperator
-
-    charges = [
+op_1x1 = LocalOperator([ℂ^2;;], ((1, 1), (1, 2)) => randn(ℂ^2, ℂ^2) ⊗ randn(ℂ^2, ℂ^2))
+op_2x2 = add_physical_charge(
+    j1_j2_model(ComplexF64, U1Irrep, InfiniteSquare(2, 2)),
+    [
         U1Irrep(-1 // 2) U1Irrep(1 // 2)
         U1Irrep(1 // 2) U1Irrep(-1 // 2)
-    ] # staggered charges to make physical spaces non-uniform
-    H₀ = j1_j2_model(ComplexF64, U1Irrep, InfiniteSquare(2, 2))
-    op_2x2 = add_physical_charge(H₀, charges)
-    @test rotl90(op_2x2) isa LocalOperator
-    @test rotr90(op_2x2) isa LocalOperator
-    @test rot180(op_2x2) isa LocalOperator
-
-    lat_2x3 = [
+    ] # staggered charges to create non-uniform physical spaces
+)
+op_2x3 = LocalOperator(
+    [
         ℂ^1 ℂ^2 ℂ^3
         ℂ^4 ℂ^5 ℂ^6
-    ]
-    terms_2x3 = (
+    ],
+
+    (
         ((1, 1), (1, 2)) => randn(ℂ^1, ℂ^1) ⊗ randn(ℂ^2, ℂ^2),
         ((2, 1), (1, 1)) => randn(ℂ^4, ℂ^4) ⊗ randn(ℂ^1, ℂ^1),
         ((1, 2), (2, 3)) => randn(ℂ^2, ℂ^2) ⊗ randn(ℂ^6, ℂ^6),
         ((1, 3), (2, 2)) => randn(ℂ^3, ℂ^3) ⊗ randn(ℂ^5, ℂ^5),
-    )
-    op_2x3 = LocalOperator(lat_2x3, terms_2x3...)
-    @test rotl90(op_2x3) isa LocalOperator
-    @test rotr90(op_2x3) isa LocalOperator
-    @test rot180(op_2x3) isa LocalOperator
+    )...
+)
+operators = [op_1x1, op_2x2, op_2x3]
+@testset "Operator rotations on $(size(op)) operator" for op in operators
+    @test rot180(rot180(op)) == op
+    @test rotl90(rotl90(op)) == rot180(op) == rotr90(rotr90(op))
+    @test physicalspace(rotl90(op)) == rotl90(physicalspace(op))
+    @test physicalspace(rotr90(op)) == rotr90(physicalspace(op))
+    @test physicalspace(rot180(op)) == rot180(physicalspace(op))
 end

--- a/test/utility/localoperator.jl
+++ b/test/utility/localoperator.jl
@@ -1,5 +1,6 @@
 using TensorKit
 using PEPSKit
+using PEPSKit: siterotl90, siterotr90, siterot180
 using MPSKit: add_physical_charge
 using MPSKitModels: a_number, nꜛnꜜ, contract_onesite
 using Test
@@ -85,6 +86,19 @@ end
     # check if trace is properly preserved
     tr_after = tr(last(only(H_shifted.terms)))
     @test abs(tr_before - tr_after) / abs(tr_before) < 1.0e-12
+end
+
+unitcells = [(1, 1), (2, 3), (3, 3), (4, 3)]
+@testset "Site rotations on $uc unitcell" for uc in unitcells
+    unrotated_inds = collect(CartesianIndices(uc))
+    # use reverse(uc) to account for transposing when using rotl90, rotr90 on non-square unit cells
+    rr_rotated_inds = rotr90(siterotr90.(collect(CartesianIndices(reverse(uc))), Ref(reverse(uc))))
+    ll_rotated_inds = rotr90(siterotr90.(collect(CartesianIndices(reverse(uc))), Ref(reverse(uc))))
+    half_rotated_inds = rot180(siterot180.(collect(CartesianIndices(uc)), Ref(uc)))
+
+    @test unrotated_inds == rr_rotated_inds
+    @test unrotated_inds == ll_rotated_inds
+    @test unrotated_inds == half_rotated_inds
 end
 
 @testset "Operator rotations" begin


### PR DESCRIPTION
I stumbled upon this bug when I was trying to run SU for Hamiltonians with non-uniform physical spaces. It turns out that the rotation functions for `LocalOperator`s would only work for $1\times1$ unit cells or uniform lattices - this should fix it. (I hope my cold-ridden brain actually did the right thing to fix it but I added some tests so it should be fine, hopefully.) I also renamed the functions for index rotations to remove the type piracy.