### PR TITLE
Remove redefinition of `tensorexpr`

### DIFF
--- a/src/algorithms/contractions/localoperator.jl
+++ b/src/algorithms/contractions/localoperator.jl
@@ -1,15 +1,5 @@
 # Contraction of local operators on arbitrary lattice locations
 # -------------------------------------------------------------
-
-# currently need this because MPSKit restricts tensor names to symbols
-_totuple(t) = t isa Tuple ? t : tuple(t)
-MPSKit.tensorexpr(ex::Expr, inds::Tuple) = Expr(:ref, ex, _totuple(inds)...)
-function MPSKit.tensorexpr(ex::Expr, indout, indin)
-    return Expr(
-        :typed_vcat, ex, Expr(:row, _totuple(indout)...), Expr(:row, _totuple(indin)...)
-    )
-end
-
 function tensorlabel(args...)
     return Symbol(ntuple(i -> iseven(i) ? :_ : args[(i + 1) >> 1], 2 * length(args) - 1)...)
 end


### PR DESCRIPTION
This PR removes the following redefinition of `MPSKit.tensorexpr`:

https://github.com/QuantumKitHub/PEPSKit.jl/blob/f482711efc31f1f10cc77801decea394e851808c/src/algorithms/contractions/localoperator.jl#L4-L11

When I look at the current MPSKit v0.13.6 (actually, since v0.12.6 or https://github.com/QuantumKitHub/MPSKit.jl/pull/256), MPSKit no longer "restricts tensor names to symbols":

https://github.com/QuantumKitHub/MPSKit.jl/blob/440acdb19fb12b7b9e45b2b02ad865ab8adb66a1/src/utility/utility.jl#L123-L128
```julia
tensorexpr(name, inds) = Expr(:ref, name, _totuple(inds)...)
function tensorexpr(name, indout, indin)
    return Expr(
        :typed_vcat, name, Expr(:row, _totuple(indout)...), Expr(:row, _totuple(indin)...)
    )
end
```
Since now PEPSKit depends on MPSKit v0.13 or higher, we should be able to remove the redefinition of `tensorexpr` safely.