### PR TITLE
Make physicalspace etc periodic for infinite networks

### DIFF
--- a/src/networks/infinitesquarenetwork.jl
+++ b/src/networks/infinitesquarenetwork.jl
@@ -55,7 +55,10 @@ end
 
 ## Spaces
 
-virtualspace(n::InfiniteSquareNetwork, r::Int, c::Int, dir) = virtualspace(n[r, c], dir)
+function virtualspace(n::InfiniteSquareNetwork, r::Int, c::Int, dir)
+    Nr, Nc = size(n)
+    return virtualspace(n[mod1(r, Nr), mod1(c, Nc)], dir)
+end
 
 ## Vector interface
 

--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -147,9 +147,18 @@ end
 ## Spaces
 
 TensorKit.spacetype(::Type{P}) where {P <: InfinitePEPO} = spacetype(eltype(P))
-virtualspace(T::InfinitePEPO, r::Int, c::Int, h::Int, dir) = virtualspace(T[r, c, h], dir)
-domain_physicalspace(T::InfinitePEPO, r::Int, c::Int) = domain_physicalspace(T[r, c, 1])
-codomain_physicalspace(T::InfinitePEPO, r::Int, c::Int) = codomain_physicalspace(T[r, c, end])
+function virtualspace(T::InfinitePEPO, r::Int, c::Int, h::Int, dir)
+    Nr, Nc, Nh = size(T)
+    return virtualspace(T[mod1(r, Nr), mod1(c, Nc), mod1(h, Nh)], dir)
+end
+function domain_physicalspace(T::InfinitePEPO, r::Int, c::Int)
+    Nr, Nc, = size(T)
+    return domain_physicalspace(T[mod1(r, Nr), mod1(c, Nc), 1])
+end
+function codomain_physicalspace(T::InfinitePEPO, r::Int, c::Int)
+    Nr, Nc, = size(T)
+    return codomain_physicalspace(T[mod1(r, Nr), mod1(c, Nc), end])
+end
 physicalspace(T::InfinitePEPO) = [physicalspace(T, row, col) for row in axes(T, 1), col in axes(T, 2)]
 function physicalspace(T::InfinitePEPO, r::Int, c::Int)
     codomain_physicalspace(T, r, c) == domain_physicalspace(T, r, c) || throw(

--- a/src/states/infinitepartitionfunction.jl
+++ b/src/states/infinitepartitionfunction.jl
@@ -139,7 +139,10 @@ end
 ## Spaces
 
 TensorKit.spacetype(::Type{T}) where {T <: InfinitePartitionFunction} = spacetype(eltype(T))
-virtualspace(n::InfinitePartitionFunction, r::Int, c::Int, dir) = virtualspace(n[r, c], dir)
+function virtualspace(n::InfinitePartitionFunction, r::Int, c::Int, dir)
+    Nr, Nc = size(n)
+    return virtualspace(n[mod1(r, Nr), mod1(c, Nc)], dir)
+end
 
 ## InfiniteSquareNetwork interface
 

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -143,9 +143,15 @@ end
 
 TensorKit.spacetype(::Type{T}) where {T <: InfinitePEPS} = spacetype(eltype(T))
 virtualspace(n::InfinitePEPS, dir) = virtualspace.(unitcell(n), dir)
-virtualspace(n::InfinitePEPS, r::Int, c::Int, dir) = virtualspace(n[r, c], dir)
+function virtualspace(n::InfinitePEPS, r::Int, c::Int, dir)
+    Nr, Nc = size(n)
+    return virtualspace(n[mod1(r, Nr), mod1(c, Nc)], dir)
+end
 physicalspace(n::InfinitePEPS) = physicalspace.(unitcell(n))
-physicalspace(n::InfinitePEPS, r::Int, c::Int) = physicalspace(n[r, c])
+function physicalspace(n::InfinitePEPS, r::Int, c::Int)
+    Nr, Nc = size(n)
+    return physicalspace(n[mod1(r, Nr), mod1(c, Nc)])
+end
 
 ## InfiniteSquareNetwork interface
 


### PR DESCRIPTION
This PR makes the functions `physicalspace`, `virtualspace` etc periodic for infinite networks (InfinitePEPS, PEPO, ParitionFunction), so that `physicalspace(network, r, c)` works when `r, c` are beyond the range {1, ..., Nr}, {1, ..., Nc}.

(As a temporary solution before #287 is done.)