### PR TITLE
Rename bondenv_fu to bondenv_ctm

### DIFF
--- a/src/algorithms/contractions/bondenv/benv_ctm.jl
+++ b/src/algorithms/contractions/bondenv/benv_ctm.jl
@@ -21,7 +21,7 @@ Axis order: `[DX1 DY1; DX0 DY0]`, as in
     └---------------------┘
 ```
 """
-function bondenv_fu(row::Int, col::Int, X::PEPSOrth, Y::PEPSOrth, env::CTMRGEnv)
+function bondenv_ctm(row::Int, col::Int, X::PEPSOrth, Y::PEPSOrth, env::CTMRGEnv)
     Nr, Nc = size(env.corners)[[2, 3]]
     cm1 = _prev(col, Nc)
     cp1 = _next(col, Nc)

--- a/test/bondenv/benv_ctm.jl
+++ b/test/bondenv/benv_ctm.jl
@@ -31,7 +31,7 @@ for row in 1:Nr, col in 1:Nc
     cp1 = PEPSKit._next(col, Nc)
     A, B = peps.A[row, col], peps.A[row, cp1]
     X, a, b, Y = PEPSKit._qr_bond(A, B)
-    benv = PEPSKit.bondenv_fu(row, col, X, Y, env)
+    benv = PEPSKit.bondenv_ctm(row, col, X, Y, env)
     @assert [isdual(space(benv, ax)) for ax in 1:numind(benv)] == [0, 0, 1, 1]
     Z = PEPSKit.positive_approx(benv)
     # verify that gauge fixing can greatly reduce

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,7 @@ end
             include("bondenv/benv_gaugefix.jl")
         end
         @time @safetestset "Full update bond environment" begin
-            include("bondenv/benv_fu.jl")
+            include("bondenv/benv_ctm.jl")
         end
     end
     if GROUP == "ALL" || GROUP == "TIMEEVOL"


### PR DESCRIPTION
Just want to emphasize that the full update bond environment comes from CTMRG.