### PR TITLE
Remove type restriction on `env₀` in `select_algorithm(::typeof(fixedpoint), ...)`

### DIFF
--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -19,7 +19,7 @@ function select_algorithm end
 
 function select_algorithm(
         ::typeof(fixedpoint),
-        env₀::CTMRGEnv;
+        env₀;
         tol = Defaults.optimizer_tol, # top-level tolerance
         verbosity = 3, # top-level verbosity
         boundary_alg = (;), gradient_alg = (;), optimizer_alg = (;),


### PR DESCRIPTION
Removes the `CTMRGEnv` type restriction on the initial environment argument in `select_algorithm(::typeof(fixedpoint), ...)`. We actually removed a lot of type restrictions already, and this is the last one that blocks using `fixedpoint` with custom external contraction algorithms that use their own environment type. Since there's no real need to restrict the type, I thought it might be best to just drop the restriction.