### PR TITLE
Require manual construction of TimeEvolver for Simple Update

### DIFF
--- a/examples/heisenberg_su/main.jl
+++ b/examples/heisenberg_su/main.jl
@@ -79,7 +79,8 @@ nstep = 10000
 trunc_peps = truncerror(; atol = 1.0e-10) & truncrank(Dbond)
 alg = SimpleUpdate(; trunc = trunc_peps, bipartite = true)
 for (dt, tol) in zip(dts, tols)
-    global peps, wts, = time_evolve(peps, H, dt, nstep, alg, wts; tol, check_interval = 500)
+    evolver = TimeEvolver(peps, H, dt, nstep, alg, wts)
+    global peps, wts, = time_evolve(evolver, H; tol, check_interval = 500)
 end
 
 md"""

--- a/examples/hubbard_su/main.jl
+++ b/examples/hubbard_su/main.jl
@@ -67,7 +67,8 @@ maxiter = 20000
 for (dt, tol, Dbond) in zip(dts, tols, Ds)
     trunc = truncerror(; atol = 1.0e-10) & truncrank(Dbond)
     alg = SimpleUpdate(; trunc, bipartite = false)
-    global peps, wts, = time_evolve(peps, H, dt, maxiter, alg, wts; tol, check_interval = 2000)
+    evolver = TimeEvolver(peps, H, dt, maxiter, alg, wts)
+    global peps, wts, = time_evolve(evolver, H; tol, check_interval = 2000)
 end
 
 md"""

--- a/examples/j1j2_su/main.jl
+++ b/examples/j1j2_su/main.jl
@@ -57,7 +57,8 @@ for J2 in 0.1:0.1:0.5
     H = real(
         j1_j2_model(ComplexF64, symm, InfiniteSquare(Nr, Nc); J1, J2, sublattice = false),
     )
-    global peps, wts, = time_evolve(peps, H, dt, nstep, alg, wts; tol, check_interval)
+    evolver = TimeEvolver(peps, H, dt, nstep, alg, wts)
+    global peps, wts, = time_evolve(evolver, H; tol, check_interval)
 end
 
 md"""
@@ -70,7 +71,8 @@ tols = [1.0e-9, 1.0e-9]
 J2 = 0.5
 H = real(j1_j2_model(ComplexF64, symm, InfiniteSquare(Nr, Nc); J1, J2, sublattice = false))
 for (dt, tol) in zip(dts, tols)
-    global peps, wts, = time_evolve(peps, H, dt, nstep, alg, wts; tol)
+    evolver = TimeEvolver(peps, H, dt, nstep, alg, wts)
+    global peps, wts, = time_evolve(evolver, H; tol)
 end
 
 md"""

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -245,8 +245,7 @@ end
 
 function MPSKit.time_evolve(
         it::TimeEvolver{<:SimpleUpdate}, H::LocalOperator;
-        tol::Float64 = 1.0e-8, check_interval::Int = 500,
-        observables::Vector{<:LocalOperator} = LocalOperator[]
+        tol::Float64 = 1.0e-8, check_interval::Int = 500
     )
     time_start = time()
     @info "--- Time evolution (simple update), dt = $(it.dt) ---"
@@ -268,10 +267,6 @@ function MPSKit.time_evolve(
                 "SU iter %-7d: E ≈ %.5f, |Δλ| = %.3e. Time = %.3f s/it",
                 iter, real(energy), diff, time1 - time0
             )
-            if !isempty(observables)
-                expvals = [expectation_value(psi, obs, ctmenv) for obs in observables]
-                @info "Observables ≈ $(expvals)."
-            end
         end
         if (iter == it.nstep) && (diff >= tol)
             @warn "SU: bond weights have not converged."

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -266,7 +266,7 @@ function MPSKit.time_evolve(
             @info "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
             @info @sprintf(
                 "SU iter %-7d: E ≈ %.5f, |Δλ| = %.3e. Time = %.3f s/it",
-                iter, energy, diff, time1 - time0
+                iter, real(energy), diff, time1 - time0
             )
             if !isempty(observables)
                 expvals = [expectation_value(psi, obs, ctmenv) for obs in observables]

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -180,9 +180,7 @@ function Base.iterate(it::TimeEvolver{<:SimpleUpdate}, state = it.state)
 end
 
 """
-    timestep(
-        it::TimeEvolver{<:SimpleUpdate}, psi::InfiniteState, env::SUWeight
-    ) -> (psi, env, info)
+$(SIGNATURES)
 
 Given the `TimeEvolver` iterator `it`, perform one step of time evolution
 on the input state `psi` and its environment `env`.
@@ -202,17 +200,10 @@ function MPSKit.timestep(
 end
 
 """
-    time_evolve(
-        it::TimeEvolver{<:SimpleUpdate}; 
-        tol::Float64 = 0.0, check_interval::Int = 500
-    ) -> (psi, env, info)
+$(SIGNATURES)
 
 Perform time evolution to the end of `TimeEvolver` iterator `it`,
-or until convergence of `SUWeight` set by a positive `tol`.
-
-- Setting `tol > 0` enables convergence check (for imaginary time evolution of InfinitePEPS only).
-    For other usages it should not be changed.
-- `check_interval` sets the number of iterations between outputs of information.
+`check_interval` sets the number of iterations between outputs of information.
 """
 function MPSKit.time_evolve(
         it::TimeEvolver{<:SimpleUpdate}; check_interval::Int = 500
@@ -243,13 +234,20 @@ function MPSKit.time_evolve(
     return
 end
 
+"""
+$(SIGNATURES)
+
+Perform time evolution until convergence of `TimeEvolver` iterator `it`.
+For `SimpleUpdate`, convergence is determined by the change of `SUWeight`
+between two iterations being smaller than `tol`.
+"""
 function MPSKit.time_evolve(
-        it::TimeEvolver{<:SimpleUpdate}, H::LocalOperator;
+        it::TimeEvolver{<:SimpleUpdate, G, S}, H::LocalOperator;
         tol::Float64 = 1.0e-8, check_interval::Int = 500
-    )
+    ) where {G, S <: SUState{<:InfinitePEPS}}
     time_start = time()
     @info "--- Time evolution (simple update), dt = $(it.dt) ---"
-    @assert (it.state.psi isa InfinitePEPS) && it.alg.imaginary_time "Only imaginary time evolution of InfinitePEPS allows convergence checking."
+    @assert it.alg.imaginary_time "Only imaginary time evolution allows convergence checking."
     env0, time0 = it.state.env, time()
     for (psi, env, info) in it
         iter = it.state.iter

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -148,14 +148,14 @@ function su_iter(
             (!alg.bipartite) && continue
             if d == 1
                 rp1, cp1 = _next(r, Nr), _next(c, Nc)
-                state2[rp1, cp1] = deepcopy(state2[r, c])
-                state2[rp1, c] = deepcopy(state2[r, cp1])
-                env2[1, rp1, cp1] = deepcopy(env2[1, r, c])
+                state2[rp1, cp1] = copy(state2[r, c])
+                state2[rp1, c] = copy(state2[r, cp1])
+                env2[1, rp1, cp1] = copy(env2[1, r, c])
             else
                 rm1, cm1 = _prev(r, Nr), _prev(c, Nc)
-                state2[rm1, cm1] = deepcopy(state2[r, c])
-                state2[r, cm1] = deepcopy(state2[rm1, c])
-                env2[2, rm1, cm1] = deepcopy(env2[2, r, c])
+                state2[rm1, cm1] = copy(state2[r, c])
+                state2[r, cm1] = copy(state2[rm1, c])
+                env2[2, rm1, cm1] = copy(env2[2, r, c])
             end
         else
             # N-site MPO gate (N ≥ 2)
@@ -215,34 +215,21 @@ or until convergence of `SUWeight` set by a positive `tol`.
 - `check_interval` sets the number of iterations between outputs of information.
 """
 function MPSKit.time_evolve(
-        it::TimeEvolver{<:SimpleUpdate};
-        tol::Float64 = 0.0, check_interval::Int = 500
+        it::TimeEvolver{<:SimpleUpdate}; check_interval::Int = 500
     )
     time_start = time()
-    check_convergence = (tol > 0)
     @info "--- Time evolution (simple update), dt = $(it.dt) ---"
-    if check_convergence
-        @assert (it.state.psi isa InfinitePEPS) && it.alg.imaginary_time "Only imaginary time evolution of InfinitePEPS allows convergence checking."
-    end
     env0, time0 = it.state.env, time()
     for (psi, env, info) in it
         iter = it.state.iter
         diff = compare_weights(env0, env)
-        stop = (iter == it.nstep) || (diff < tol)
+        stop = (iter == it.nstep)
         showinfo = (check_interval > 0) &&
             ((iter % check_interval == 0) || (iter == 1) || stop)
         time1 = time()
         if showinfo
             @info "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
             @info @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, diff, time1 - time0)
-        end
-        if check_convergence
-            if (iter == it.nstep) && (diff >= tol)
-                @warn "SU: bond weights have not converged."
-            end
-            if diff < tol
-                @info "SU: bond weights have converged."
-            end
         end
         if stop
             time_end = time()
@@ -256,30 +243,50 @@ function MPSKit.time_evolve(
     return
 end
 
-"""
-    time_evolve(
-        psi0::Union{InfinitePEPS, InfinitePEPO}, H::LocalOperator, dt::Number, nstep::Int,
-        alg::SimpleUpdate, env0::SUWeight; symmetrize_gates::Bool = false,
-        tol::Float64 = 0.0, t0::Number = 0.0, check_interval::Int = 500
-    ) -> (psi, env, info)
-
-Perform time evolution on the initial iPEPS or iPEPO `psi0` and
-initial environment `env0` with Hamiltonian `H`, using `SimpleUpdate`
-algorithm `alg`, time step `dt` for `nstep` number of steps. 
-
-- Set `symmetrize_gates = true` for second-order Trotter decomposition.
-- Set `tol > 0` to enable convergence check (for imaginary time evolution of iPEPS only).
-    For other usages it should not be changed.
-- Use `t0` to specify the initial time of the evolution.
-- `check_interval` sets the interval to output information. Output during the evolution can be turned off by setting `check_interval <= 0`.
-- `info` is a NamedTuple containing information of the evolution, 
-    including the time `info.t` evolved since `psi0`.
-"""
 function MPSKit.time_evolve(
-        psi0::InfiniteState, H::LocalOperator, dt::Number, nstep::Int,
-        alg::SimpleUpdate, env0::SUWeight; symmetrize_gates::Bool = false,
-        tol::Float64 = 0.0, t0::Number = 0.0, check_interval::Int = 500
+        it::TimeEvolver{<:SimpleUpdate}, H::LocalOperator;
+        tol::Float64 = 1.0e-8, check_interval::Int = 500,
+        observables::Vector{<:LocalOperator} = LocalOperator[]
     )
-    it = TimeEvolver(psi0, H, dt, nstep, alg, env0; t0, symmetrize_gates)
-    return time_evolve(it; tol, check_interval)
+    time_start = time()
+    @info "--- Time evolution (simple update), dt = $(it.dt) ---"
+    @assert (it.state.psi isa InfinitePEPS) && it.alg.imaginary_time "Only imaginary time evolution of InfinitePEPS allows convergence checking."
+    env0, time0 = it.state.env, time()
+    for (psi, env, info) in it
+        iter = it.state.iter
+        diff = compare_weights(env0, env)
+        stop = (iter == it.nstep) || (diff < tol)
+        showinfo = (check_interval > 0) &&
+            ((iter % check_interval == 0) || (iter == 1) || stop)
+        time1 = time()
+        if showinfo
+            # TODO: convert to BPEnv instead
+            ctmenv = CTMRGEnv(env)
+            energy = expectation_value(psi, H, ctmenv) / prod(size(psi))
+            @info "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
+            @info @sprintf(
+                "SU iter %-7d: E ≈ %.5f, |Δλ| = %.3e. Time = %.3f s/it",
+                iter, energy, diff, time1 - time0
+            )
+            if !isempty(observables)
+                expvals = [expectation_value(psi, obs, ctmenv) for obs in observables]
+                @info "Observables ≈ $(expvals)."
+            end
+        end
+        if (iter == it.nstep) && (diff >= tol)
+            @warn "SU: bond weights have not converged."
+        end
+        if diff < tol
+            @info "SU: bond weights have converged."
+        end
+        if stop
+            time_end = time()
+            @info @sprintf("Time evolution finished in %.2f s", time_end - time_start)
+            return psi, env, info
+        else
+            env0 = env
+        end
+        time0 = time()
+    end
+    return
 end

--- a/test/bondenv/benv_ctm.jl
+++ b/test/bondenv/benv_ctm.jl
@@ -19,7 +19,7 @@ function get_hubbard_peps(t::Float64 = 1.0, U::Float64 = 8.0)
     wts = SUWeight(peps)
     alg = SimpleUpdate(; trunc = truncerror(; atol = 1.0e-10) & truncrank(4))
     evolver = TimeEvolver(peps, H, 1.0e-2, 10000, alg, wts)
-    peps, = time_evolve(evolver; tol = 1.0e-8, check_interval = 2000)
+    peps, = time_evolve(evolver, H; tol = 1.0e-8, check_interval = 2000)
     normalize!.(peps.A, Inf)
     return peps
 end

--- a/test/bondenv/benv_ctm.jl
+++ b/test/bondenv/benv_ctm.jl
@@ -31,7 +31,8 @@ function get_hubbard_pepo(t::Float64 = 1.0, U::Float64 = 8.0)
     alg = SimpleUpdate(;
         trunc = truncerror(; atol = 1.0e-10) & truncrank(4), bipartite = false
     )
-    pepo, = time_evolve(pepo, H, 2.0e-3, 500, alg, wts; check_interval = 100)
+    evolver = TimeEvolver(pepo, H, 2.0e-3, 500, alg, wts)
+    pepo, = time_evolve(evolver; check_interval = 100)
     normalize!.(pepo.A, Inf)
     return pepo
 end

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -123,7 +123,8 @@ end
         Dbond2 = (n == 2) ? Dbond + 2 : Dbond
         trunc = truncerror(; atol = 1.0e-10) & truncrank(Dbond2)
         alg = SimpleUpdate(; trunc, bipartite = false)
-        peps, wts, = time_evolve(peps, ham, dt, nstep, alg, wts; tol)
+        evolver = TimeEvolver(peps, ham, dt, nstep, alg, wts)
+        peps, wts, = time_evolve(evolver, ham; tol)
     end
 
     # measure physical quantities with CTMRG

--- a/test/timeevol/cluster_projectors.jl
+++ b/test/timeevol/cluster_projectors.jl
@@ -3,7 +3,7 @@ using TensorKit
 using PEPSKit
 using LinearAlgebra
 using Random
-import MPSKitModels: hubbard_space
+import MPSKitModels: hubbard_space, e_number
 using PEPSKit: sdiag_pow, _cluster_truncate!, _flip_virtuals!, _next
 using MPSKit: GenericMPSTensor, MPSBondTensor
 include("cluster_tools.jl")
@@ -117,15 +117,17 @@ end
     end
     wts0 = SUWeight(peps0)
     ham = hubbard_model(Float64, Trivial, U1Irrep, InfiniteSquare(Nr, Nc); t = 1.0, U = 6.0, mu = 3.0)
+    observables = [
+        LocalOperator(physicalspace(ham), [(1, 1)] => e_number(Float64, Trivial, U1Irrep)),
+    ]
     # applying 2-site gates decomposed to MPO or not,
     # resulting energy should be almost the same
     e_sites = map((true, false)) do force_mpo
         peps, wts = deepcopy(peps0), deepcopy(wts0)
         trunc = truncerror(; atol = 1.0e-10) & truncrank(4)
         alg = SimpleUpdate(; trunc, force_mpo)
-        peps, wts, = time_evolve(
-            peps, ham, 0.01, 10000, alg, wts; tol = 1.0e-6, check_interval = 1000
-        )
+        evolver = TimeEvolver(peps, ham, 0.01, 10000, alg, wts)
+        peps, wts, = time_evolve(evolver, ham; tol = 1.0e-6, observables, check_interval = 1000)
         normalize!.(peps.A, Inf)
         env = CTMRGEnv(wts)
         for trunc in truncs_env

--- a/test/timeevol/cluster_projectors.jl
+++ b/test/timeevol/cluster_projectors.jl
@@ -117,9 +117,6 @@ end
     end
     wts0 = SUWeight(peps0)
     ham = hubbard_model(Float64, Trivial, U1Irrep, InfiniteSquare(Nr, Nc); t = 1.0, U = 6.0, mu = 3.0)
-    observables = [
-        LocalOperator(physicalspace(ham), [(1, 1)] => e_number(Float64, Trivial, U1Irrep)),
-    ]
     # applying 2-site gates decomposed to MPO or not,
     # resulting energy should be almost the same
     e_sites = map((true, false)) do force_mpo
@@ -127,7 +124,7 @@ end
         trunc = truncerror(; atol = 1.0e-10) & truncrank(4)
         alg = SimpleUpdate(; trunc, force_mpo)
         evolver = TimeEvolver(peps, ham, 0.01, 10000, alg, wts)
-        peps, wts, = time_evolve(evolver, ham; tol = 1.0e-6, observables, check_interval = 1000)
+        peps, wts, = time_evolve(evolver, ham; tol = 1.0e-6, check_interval = 1000)
         normalize!.(peps.A, Inf)
         env = CTMRGEnv(wts)
         for trunc in truncs_env

--- a/test/timeevol/j1j2_finiteT.jl
+++ b/test/timeevol/j1j2_finiteT.jl
@@ -5,9 +5,8 @@ import MPSKitModels: σˣ, σᶻ
 using PEPSKit
 
 # Benchmark energy from high-temperature expansion
-# at β = 0.3, 0.6
-# Physical Review B 86, 045139 (2012) Fig. 15-16
-bm = [-0.1235, -0.213]
+const βs = [0.2, 0.4, 0.6]
+const bm = [-0.08624893, -0.15688984, -0.21300888]
 
 function converge_env(state, χ::Int)
     trunc1 = truncrank(χ) & truncerror(; atol = 1.0e-12)
@@ -25,35 +24,19 @@ pepo0 = PEPSKit.infinite_temperature_density_matrix(ham)
 wts0 = SUWeight(pepo0)
 # 7 = 1 (spin-0) + 2 x 3 (spin-1)
 trunc_pepo = truncrank(7) & truncerror(; atol = 1.0e-12)
-check_interval = 100
-dt, nstep = 1.0e-3, 600
+dt, nstep, check_interval = 5.0e-3, 40, 40
 
-# PEPO approach
-alg = SimpleUpdate(; trunc = trunc_pepo, purified = false)
-evolver = TimeEvolver(pepo0, ham, dt, nstep, alg, wts0)
-pepo, wts, info = time_evolve(evolver; check_interval)
-env = converge_env(InfinitePartitionFunction(pepo), 16)
-energy = expectation_value(pepo, ham, env) / (Nr * Nc)
-@info "β = $(dt * nstep): tr(ρH) = $(energy)"
-@test dt * nstep ≈ info.t
-@test energy ≈ bm[2] atol = 5.0e-3
-
-# PEPS (purified PEPO) approach
-alg = SimpleUpdate(; trunc = trunc_pepo, purified = true)
-evolver = TimeEvolver(pepo0, ham, dt, nstep, alg, wts0)
-pepo, wts, info = time_evolve(evolver; check_interval)
-env = converge_env(InfinitePartitionFunction(pepo), 16)
-energy = expectation_value(pepo, ham, env) / (Nr * Nc)
-@info "β = $(dt * nstep) / 2: tr(ρH) = $(energy)"
-@test energy ≈ bm[1] atol = 5.0e-3
-
-# test BP gauge fixing for purified iPEPO
-bp_alg = BeliefPropagation(; maxiter = 100, tol = 1.0e-9)
-bp_env, = leading_boundary(BPEnv(ones, Float64, pepo), pepo, bp_alg)
-pepo, = gauge_fix(pepo, BPGauge(), bp_env)
-
-env = converge_env(InfinitePEPS(pepo), 16)
-energy = expectation_value(pepo, ham, pepo, env) / (Nr * Nc)
-@info "β = $(dt * nstep): ⟨ρ|H|ρ⟩ = $(energy)"
-@test dt * nstep ≈ info.t
-@test energy ≈ bm[2] atol = 5.0e-3
+@testset "Simple update" begin
+    alg = SimpleUpdate(; trunc = trunc_pepo, purified = true)
+    pepo, wts = deepcopy(pepo0), deepcopy(wts0)
+    for (β, bme) in zip(βs, bm)
+        t0 = β - βs[1]
+        evolver = TimeEvolver(pepo, ham, dt, nstep, alg, wts)
+        pepo, wts, info = time_evolve(evolver; t0, check_interval)
+        # measure energy
+        env = converge_env(InfinitePEPS(pepo), 16)
+        energy = expectation_value(pepo, ham, pepo, env) / (Nr * Nc)
+        @info "β = $(info.t): ⟨ρ|H|ρ⟩ = $(energy)"
+        @test energy ≈ bme atol = 5.0e-3
+    end
+end

--- a/test/timeevol/j1j2_finiteT.jl
+++ b/test/timeevol/j1j2_finiteT.jl
@@ -31,8 +31,8 @@ dt, nstep, check_interval = 5.0e-3, 40, 40
     pepo, wts = deepcopy(pepo0), deepcopy(wts0)
     for (β, bme) in zip(βs, bm)
         t0 = β - βs[1]
-        evolver = TimeEvolver(pepo, ham, dt, nstep, alg, wts)
-        pepo, wts, info = time_evolve(evolver; t0, check_interval)
+        evolver = TimeEvolver(pepo, ham, dt, nstep, alg, wts; t0)
+        pepo, wts, info = time_evolve(evolver; check_interval)
         # measure energy
         env = converge_env(InfinitePEPS(pepo), 16)
         energy = expectation_value(pepo, ham, pepo, env) / (Nr * Nc)

--- a/test/timeevol/sitedep_truncation.jl
+++ b/test/timeevol/sitedep_truncation.jl
@@ -32,7 +32,7 @@ end
     bonddims = stack([[6 4; 4 6], [5 7; 7 5]]; dims = 1)
     trunc = SiteDependentTruncation(collect(truncrank(d) for d in bonddims))
     alg = SimpleUpdate(; trunc, bipartite = true)
-    peps, env, = time_evolve(peps0, ham, 1.0e-2, 4, alg, env0)
+    peps, env, = time_evolve(TimeEvolver(peps0, ham, 1.0e-2, 4, alg, env0))
     @test get_bonddims(peps) == bonddims
     @test get_bonddims(env) == bonddims
     # check bipartite structure is preserved
@@ -59,12 +59,12 @@ end
     alg = SimpleUpdate(; trunc)
     # 2-site SU
     ham = j1_j2_model(Float64, Trivial, InfiniteSquare(Nr, Nc); J2 = 0.0, sublattice = false)
-    peps, env, = time_evolve(peps0, ham, 1.0e-2, 4, alg, env0)
+    peps, env, = time_evolve(TimeEvolver(peps0, ham, 1.0e-2, 4, alg, env0))
     @test get_bonddims(peps) == bonddims
     @test get_bonddims(env) == bonddims
     # 3-site SU
     ham = j1_j2_model(Float64, Trivial, InfiniteSquare(Nr, Nc); J2 = 0.2, sublattice = false)
-    peps, env, = time_evolve(peps0, ham, 1.0e-2, 4, alg, env0)
+    peps, env, = time_evolve(TimeEvolver(peps0, ham, 1.0e-2, 4, alg, env0))
     @test get_bonddims(peps) == bonddims
     @test get_bonddims(env) == bonddims
 end

--- a/test/timeevol/tf_ising_finiteT.jl
+++ b/test/timeevol/tf_ising_finiteT.jl
@@ -65,14 +65,6 @@ dt, nstep = 1.0e-3, 400
     @test β ≈ info.t
     @test isapprox(abs.(result_β), bm_β, rtol = 1.0e-2)
 
-    # use `approximate` to reach 2β
-    pepo2, = approximate(pepo, pepo, LocalApprox(trunc_pepo))
-    normalize!.(pepo2.A)
-    env2 = converge_env(InfinitePartitionFunction(pepo2), 16)
-    result_2β = measure_mag(pepo2, env2)
-    @info "tr(σ(x,z)ρ) at T = $(1 / (2β)): $(result_2β)."
-    @test isapprox(abs.(result_2β), bm_2β, rtol = 5.0e-3)
-
     # continue to get results at 2β, or T = 1.25
     evolver = TimeEvolver(pepo, ham, dt, nstep, alg, wts; t0 = β, symmetrize_gates)
     pepo, wts, info = time_evolve(evolver)

--- a/test/timeevol/tf_ising_finiteT.jl
+++ b/test/timeevol/tf_ising_finiteT.jl
@@ -51,7 +51,8 @@ dt, nstep = 1.0e-3, 400
 
     # PEPO approach: results at β, or T = 2.5
     alg = SimpleUpdate(; trunc = trunc_pepo, purified = false, bipartite, force_mpo)
-    pepo, wts, info = time_evolve(pepo0, ham, dt, nstep, alg, wts0; symmetrize_gates)
+    evolver = TimeEvolver(pepo0, ham, dt, nstep, alg, wts0; symmetrize_gates)
+    pepo, wts, info = time_evolve(evolver)
 
     ## BP gauge fixing
     bp_alg = BeliefPropagation(; maxiter = 100, tol = 1.0e-9, bipartite)
@@ -64,8 +65,17 @@ dt, nstep = 1.0e-3, 400
     @test β ≈ info.t
     @test isapprox(abs.(result_β), bm_β, rtol = 1.0e-2)
 
+    # use `approximate` to reach 2β
+    pepo2, = approximate(pepo, pepo, LocalApprox(trunc_pepo))
+    normalize!.(pepo2.A)
+    env2 = converge_env(InfinitePartitionFunction(pepo2), 16)
+    result_2β = measure_mag(pepo2, env2)
+    @info "tr(σ(x,z)ρ) at T = $(1 / (2β)): $(result_2β)."
+    @test isapprox(abs.(result_2β), bm_2β, rtol = 5.0e-3)
+
     # continue to get results at 2β, or T = 1.25
-    pepo, wts, info = time_evolve(pepo, ham, dt, nstep, alg, wts; t0 = β, symmetrize_gates)
+    evolver = TimeEvolver(pepo, ham, dt, nstep, alg, wts; t0 = β, symmetrize_gates)
+    pepo, wts, info = time_evolve(evolver)
     env = converge_env(InfinitePartitionFunction(pepo), 16)
     result_2β = measure_mag(pepo, env)
     @info "tr(σ(x,z)ρ) at T = $(1 / (2β)): $(result_2β)."
@@ -74,7 +84,8 @@ dt, nstep = 1.0e-3, 400
 
     # Purification approach: results at 2β, or T = 1.25
     alg = SimpleUpdate(; trunc = trunc_pepo, purified = true, bipartite, force_mpo)
-    pepo, wts, info = time_evolve(pepo0, ham, dt, 2 * nstep, alg, wts0; symmetrize_gates)
+    evolver = TimeEvolver(pepo0, ham, dt, 2 * nstep, alg, wts0; symmetrize_gates)
+    pepo, wts, info = time_evolve(evolver)
     env = converge_env(InfinitePEPS(pepo), 8)
     result_2β′ = measure_mag(pepo, env; purified = true)
     @info "⟨ρ|σ(x,z)|ρ⟩ at T = $(1 / (2β)): $(result_2β′)."

--- a/test/timeevol/timestep.jl
+++ b/test/timeevol/timestep.jl
@@ -3,14 +3,16 @@ using Random
 using TensorKit
 using PEPSKit
 
+Nr, Nc = 2, 2
+H = real(heisenberg_XYZ(ComplexF64, Trivial, InfiniteSquare(Nr, Nc); Jx = 1, Jy = 1, Jz = 1))
+Pspace, Vspace = ℂ^2, ℂ^4
+ψ0 = InfinitePEPS(rand, Float64, Pspace, Vspace; unitcell = (Nr, Nc))
+dt, nstep = 0.1, 20
+trunc = truncerror(; atol = 1.0e-10) & truncrank(4)
+
 @testset "SimpleUpdate timestep" begin
-    Nr, Nc = 2, 2
-    H = real(heisenberg_XYZ(ComplexF64, Trivial, InfiniteSquare(Nr, Nc); Jx = 1, Jy = 1, Jz = 1))
-    Pspace, Vspace = ℂ^2, ℂ^4
-    ψ0 = InfinitePEPS(rand, Float64, Pspace, Vspace; unitcell = (Nr, Nc))
+    alg = SimpleUpdate(; trunc)
     env0 = SUWeight(ψ0)
-    alg = SimpleUpdate(; trunc = truncerror(; atol = 1.0e-10) & truncrank(4))
-    dt, nstep = 1.0e-2, 50
     # manual timestep
     evolver = TimeEvolver(ψ0, H, dt, nstep, alg, env0)
     ψ1, env1, info1 = deepcopy(ψ0), deepcopy(env0), nothing
@@ -18,7 +20,8 @@ using PEPSKit
         ψ1, env1, info1 = timestep(evolver, ψ1, env1)
     end
     # time_evolve
-    ψ2, env2, info2 = time_evolve(ψ0, H, dt, nstep, alg, env0)
+    evolver = TimeEvolver(ψ0, H, dt, nstep, alg, env0)
+    ψ2, env2, info2 = time_evolve(evolver)
     # for-loop syntax
     ## manually reset internal state of evolver
     evolver.state = PEPSKit.SUState(0, 0.0, ψ0, env0)


### PR DESCRIPTION
This PR implements proposals in #355.

- A `TimeEvolver` struct needs to be explicitly constructed before calling `time_evolve`, instead of being automatically created by the latter internally.
- When searching for ground state, the Hamiltonian is a required argument of `time_evolve` to monitor the change of energy (although SimpleUpdate does not use it for convergence checking).
- ~During imaginary time evolution for iPEPS ground state, one can monitor the expectation value of the Hamiltonian and optionally an additional vector `observables` of `LocalOperator`s. In Simple Update, the expectation values are evaluated with the `SUWeight` by converting it to `CTMRGEnv`. It should be changed to `BPEnv` in the future once it also supports arbitrary coordinates.~

TODO:

- [ ] Clean up docstrings.
- [x] Update examples to explicitly construct a `TimeEvolver` for time evolution.