### PR TITLE
Fix dimension mismatches in SVD pullback due to `rank_atol`

### DIFF
--- a/src/utility/eigh.jl
+++ b/src/utility/eigh.jl
@@ -327,7 +327,7 @@ end
 ## Reverse-rule algorithms
 #
 
-function _get_pullback_gauge_tol(verbosity::Int)
+function _get_pullback_gauge_atol(verbosity::Int)
     if verbosity ≤ 0 # never print gauge sensitivity
         return (_) -> Inf
     elseif verbosity == 1 # print gauge sensitivity above default atol
@@ -346,7 +346,7 @@ function ChainRulesCore.rrule(
     ) where {F <: Union{<:LAPACK_EighAlgorithm, <:FixedEig}, R <: FullEighPullback}
     D̃, Ṽ, info = eigh_trunc(t, alg; trunc)
     D, V, inds = info.D_full, info.V_full, info.truncation_indices # untruncated decomposition
-    gtol = _get_pullback_gauge_tol(alg.rrule_alg.verbosity)
+    gtol = _get_pullback_gauge_atol(alg.rrule_alg.verbosity)
 
     function eigh_trunc!_full_pullback(ΔDV)
         Δt = eigh_pullback!(
@@ -370,7 +370,7 @@ function ChainRulesCore.rrule(
         trunc::TruncationStrategy = notrunc(),
     ) where {F <: Union{<:LAPACK_EighAlgorithm, <:FixedEig, IterEigh}, R <: TruncEighPullback}
     D, V, info = eigh_trunc(t, alg; trunc)
-    gtol = _get_pullback_gauge_tol(alg.rrule_alg.verbosity)
+    gtol = _get_pullback_gauge_atol(alg.rrule_alg.verbosity)
 
     function eigh_trunc!_trunc_pullback(ΔDV)
         Δf = eigh_trunc_pullback!(

--- a/src/utility/qr.jl
+++ b/src/utility/qr.jl
@@ -113,7 +113,7 @@ function ChainRulesCore.rrule(
         alg::QRAdjoint{F, R},
     ) where {F <: Union{LAPACK_HouseholderQR, FixedQR}, R <: QRPullback}
     QR = left_orth(t, alg)
-    gtol = _get_pullback_gauge_tol(alg.rrule_alg.verbosity)
+    gtol = _get_pullback_gauge_atol(alg.rrule_alg.verbosity)
 
     function left_orth!_pullback(ΔQR)
         Δt = zeros(scalartype(t), space(t))

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -355,7 +355,7 @@ end
 ## Reverse-rule algorithms
 #
 
-_get_pullback_rank_atol() = MatrixAlgebraKit.default_pullback_rank_atol
+_get_pullback_rank_atol(::Any) = MatrixAlgebraKit.default_pullback_rank_atol
 _get_pullback_rank_atol(::Union{<:FixedSVD, IterSVD}) = A -> zero(scalartype(A)) # truncated SVDs shouldn't change rank in pullback
 
 # svd_trunc! rrule wrapping MatrixAlgebraKit's svd_pullback!

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -355,6 +355,9 @@ end
 ## Reverse-rule algorithms
 #
 
+_get_pullback_rank_atol() = MatrixAlgebraKit.default_pullback_rank_atol
+_get_pullback_rank_atol(::Union{<:FixedSVD, IterSVD}) = A -> zero(scalartype(A)) # truncated SVDs shouldn't change rank in pullback
+
 # svd_trunc! rrule wrapping MatrixAlgebraKit's svd_pullback!
 function ChainRulesCore.rrule(
         ::typeof(svd_trunc!),
@@ -366,13 +369,14 @@ function ChainRulesCore.rrule(
 
     Ũ, S̃, Ṽ⁺, info = svd_trunc(t, alg; trunc)
     U, S, V⁺, inds = info.U_full, info.S_full, info.V_full, info.truncation_indices # untruncated decomposition
-    gtol = _get_pullback_gauge_tol(alg.rrule_alg.verbosity)
+    rtol = _get_pullback_rank_atol(alg.fwd_alg)
+    gtol = _get_pullback_gauge_atol(alg.rrule_alg.verbosity)
 
     function svd_trunc!_full_pullback(ΔUSV′)
         ΔUSV = unthunk.(ΔUSV′)
         Δt = svd_pullback!(
             zeros(scalartype(t), space(t)), t, (U, S, V⁺), ΔUSV, inds;
-            gauge_atol = gtol(ΔUSV), degeneracy_atol = alg.rrule_alg.degeneracy_atol,
+            rank_atol = rtol(t), gauge_atol = gtol(ΔUSV), degeneracy_atol = alg.rrule_alg.degeneracy_atol,
         )
         return NoTangent(), Δt, NoTangent()
     end
@@ -391,13 +395,14 @@ function ChainRulesCore.rrule(
         trunc::TruncationStrategy = notrunc(),
     ) where {F, R <: TruncSVDPullback}
     U, S, V⁺, info = svd_trunc(t, alg; trunc)
-    gtol = _get_pullback_gauge_tol(alg.rrule_alg.verbosity)
+    rtol = _get_pullback_rank_atol(alg.fwd_alg)
+    gtol = _get_pullback_gauge_atol(alg.rrule_alg.verbosity)
 
     function svd_trunc!_trunc_pullback(ΔUSV′)
         ΔUSV = unthunk.(ΔUSV′)
         Δf = svd_trunc_pullback!(
             zeros(scalartype(t), space(t)), t, (U, S, V⁺), ΔUSV;
-            gauge_atol = gtol(ΔUSV), degeneracy_atol = alg.rrule_alg.degeneracy_atol,
+            rank_atol = rtol(t), gauge_atol = gtol(ΔUSV), degeneracy_atol = alg.rrule_alg.degeneracy_atol,
         )
         return NoTangent(), Δf, NoTangent()
     end

--- a/src/utility/svd.jl
+++ b/src/utility/svd.jl
@@ -356,7 +356,7 @@ end
 #
 
 _get_pullback_rank_atol(::Any) = MatrixAlgebraKit.default_pullback_rank_atol
-_get_pullback_rank_atol(::Union{<:FixedSVD, IterSVD}) = A -> zero(scalartype(A)) # truncated SVDs shouldn't change rank in pullback
+_get_pullback_rank_atol(::Union{<:FixedSVD, IterSVD}) = A -> real(zero(scalartype(A))) # truncated SVDs shouldn't change rank in pullback
 
 # svd_trunc! rrule wrapping MatrixAlgebraKit's svd_pullback!
 function ChainRulesCore.rrule(


### PR DESCRIPTION
As described in #351, there was the possibility for a `DimensionMismatch` error due to the non-zero default `rank_atol` in MatrixAlgebraKit's SVD pullbacks. Here I set `rank_atol=0` explicitly for `FixedSVD` and `IterSVD` pullbacks, so that error shouldn't happen again.

I'm not quite sure how to test this, so if anybody has an idea, let me know.