### PR TITLE
Increase test coverage for CTMRG contractions

### DIFF
--- a/src/algorithms/contractions/ctmrg/enlarge_corner.jl
+++ b/src/algorithms/contractions/ctmrg/enlarge_corner.jl
@@ -36,7 +36,7 @@ function enlarge_northwest_corner(
         E_west::CTMRG_PEPS_EdgeTensor, C_northwest::CTMRGCornerTensor,
         E_north::CTMRG_PEPS_EdgeTensor, A::PEPSSandwich,
     )
-    return @tensor begin
+    @tensor begin
         EC[χS DWt DWb; χ2] := E_west[χS DWt DWb; χ1] * C_northwest[χ1; χ2]
         # already putting χE in front here to make next permute cheaper
         ECE[χS χE DWb DNb; DWt DNt] := EC[χS DWt DWb; χ2] * E_north[χ2 DNt DNb; χE]
@@ -45,16 +45,18 @@ function enlarge_northwest_corner(
         corner[χS DSt DSb; χE DEt DEb] :=
             ECEket[χS χE DEt DSt; DWb DNb d] * conj(bra(A)[d; DNb DEb DSb DWb])
     end
+    return corner
 end
 function enlarge_northwest_corner(
         E_west::CTMRG_PF_EdgeTensor, C_northwest::CTMRGCornerTensor,
         E_north::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @tensor begin
+    @tensor begin
         EC[χ_S DW; χ2] := E_west[χ_S DW; χ1] * C_northwest[χ1; χ2]
         ECE[χ_S χ_E; DW DN] := EC[χ_S DW; χ2] * E_north[χ2 DN; χ_E]
         corner[χ_S D_S; χ_E D_E] := ECE[χ_S χ_E; DW DN] * A[DW D_S; DN D_E]
     end
+    return corner
 end
 
 @generated function enlarge_northwest_corner(
@@ -103,7 +105,7 @@ function enlarge_northeast_corner(
         E_north::CTMRG_PEPS_EdgeTensor, C_northeast::CTMRGCornerTensor,
         E_east::CTMRG_PEPS_EdgeTensor, A::PEPSSandwich,
     )
-    return @tensor begin
+    @tensor begin
         EC[χW DNt DNb; χ2] := E_north[χW DNt DNb; χ1] * C_northeast[χ1; χ2]
         # already putting χE in front here to make next permute cheaper
         ECE[χW χS DNb DEb; DNt DEt] := EC[χW DNt DNb; χ2] * E_east[χ2 DEt DEb; χS]
@@ -112,16 +114,18 @@ function enlarge_northeast_corner(
         corner[χW DWt DWb; χS DSt DSb] :=
             ECEket[χW χS DSt DWt; DNb DEb d] * conj(bra(A)[d; DNb DEb DSb DWb])
     end
+    return corner
 end
 function enlarge_northeast_corner(
         E_north::CTMRG_PF_EdgeTensor, C_northeast::CTMRGCornerTensor,
         E_east::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @tensor begin
+    @tensor begin
         EC[DN χ_W; χ2] := E_north[χ_W DN; χ1] * C_northeast[χ1; χ2]
         ECE[DN DE; χ_S χ_W] := EC[DN χ_W; χ2] * E_east[χ2 DE; χ_S]
         corner[χ_W D_W; χ_S D_S] := A[D_W D_S; DN DE] * ECE[DN DE; χ_S χ_W]
     end
+    return corner
 end
 
 @generated function enlarge_northeast_corner(
@@ -170,7 +174,7 @@ function enlarge_southeast_corner(
         E_east::CTMRG_PEPS_EdgeTensor, C_southeast::CTMRGCornerTensor,
         E_south::CTMRG_PEPS_EdgeTensor, A::PEPSSandwich,
     )
-    return @tensor begin
+    @tensor begin
         EC[χN DEt DEb; χ2] := E_east[χN DEt DEb; χ1] * C_southeast[χ1; χ2]
         # already putting χE in front here to make next permute cheaper
         ECE[χN χW DEb DSb; DEt DSt] := EC[χN DEt DEb; χ2] * E_south[χ2 DSt DSb; χW]
@@ -179,16 +183,18 @@ function enlarge_southeast_corner(
         corner[χN DNt DNb; χW DWt DWb] :=
             ECEket[χN χW DNt DWt; DEb DSb d] * conj(bra(A)[d; DNb DEb DSb DWb])
     end
+    return corner
 end
 function enlarge_southeast_corner(
         E_east::CTMRG_PF_EdgeTensor, C_southeast::CTMRGCornerTensor,
         E_south::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @tensor begin
+    @tensor begin
         EC[χ_N D1; χ2] := E_east[χ_N D1; χ1] * C_southeast[χ1; χ2]
         ECE[χ_N χ_W; D1 D2] := EC[χ_N D1; χ2] * E_south[χ2 D2; χ_W]
         corner[χ_N D_N; χ_W D_W] := ECE[χ_N χ_W; D1 D2] * A[D_W D2; D_N D1]
     end
+    return corner
 end
 
 @generated function enlarge_southeast_corner(
@@ -237,7 +243,7 @@ function enlarge_southwest_corner(
         E_south::CTMRG_PEPS_EdgeTensor, C_southwest::CTMRGCornerTensor,
         E_west::CTMRG_PEPS_EdgeTensor, A::PEPSSandwich,
     )
-    return @tensor begin
+    @tensor begin
         EC[χE DSt DSb; χ2] := E_south[χE DSt DSb; χ1] * C_southwest[χ1; χ2]
         # already putting χE in front here to make next permute cheaper
         ECE[χE χN DSb DWb; DSt DWt] := EC[χE DSt DSb; χ2] * E_west[χ2 DWt DWb; χN]
@@ -246,16 +252,18 @@ function enlarge_southwest_corner(
         corner[χE DEt DEb; χN DNt DNb] :=
             ECEket[χE χN DNt DEt; DSb DWb d] * conj(bra(A)[d; DNb DEb DSb DWb])
     end
+    return corner
 end
 function enlarge_southwest_corner(
         E_south::CTMRG_PF_EdgeTensor, C_southwest::CTMRGCornerTensor,
         E_west::CTMRG_PF_EdgeTensor, A::PFTensor,
     )
-    return @tensor begin
+    @tensor begin
         EC[χ_E D1; χ2] := E_south[χ_E D1; χ1] * C_southwest[χ1; χ2]
         ECE[χ_E χ_N; D2 D1] := EC[χ_E D1; χ2] * E_west[χ2 D2; χ_N]
         corner[χ_E D_E; χ_N D_N] := ECE[χ_E χ_N; D2 D1] * A[D2 D1; D_N D_E]
     end
+    return corner
 end
 
 @generated function enlarge_southwest_corner(

--- a/src/algorithms/contractions/ctmrg/expr.jl
+++ b/src/algorithms/contractions/ctmrg/expr.jl
@@ -73,12 +73,12 @@ function _pepo_edge_expr(edgename, codom_label, dom_label, dir, H::Int, args...)
     return tensorexpr(
         edgename,
         (
-            envlabel(codom_label, args...),
+            envlabel(codom_label),
             virtuallabel(dir, :top, args...),
             ntuple(i -> virtuallabel(dir, :mid, i, args...), H)...,
             virtuallabel(dir, :bot, args...),
         ),
-        (envlabel(dom_label, args...),),
+        (envlabel(dom_label),),
     )
 end
 
@@ -146,9 +146,9 @@ function _pepo_codomain_projector_expr(
     )
     return tensorexpr(
         projname,
-        (envlabel(codom_label, args...),),
+        (envlabel(codom_label),),
         (
-            envlabel(dom_label, args...),
+            envlabel(dom_label),
             virtuallabel(dom_dir, :top, args...),
             ntuple(i -> virtuallabel(dom_dir, :mid, i, args...), H)...,
             virtuallabel(dom_dir, :bot, args...),
@@ -162,11 +162,158 @@ function _pepo_domain_projector_expr(
     return tensorexpr(
         projname,
         (
-            envlabel(codom_label, args...),
+            envlabel(codom_label),
             virtuallabel(codom_dir, :top, args...),
             ntuple(i -> virtuallabel(codom_dir, :mid, i, args...), H)...,
             virtuallabel(codom_dir, :bot, args...),
         ),
-        (envlabel(dom_label, args...),),
+        (envlabel(dom_label),),
     )
+end
+
+## HalfInfiniteEnv expressions
+
+function _half_infinite_environment_expr_parts(H)
+    # site 1 (codomain)
+    C1_e = _corner_expr(:C_1, :WNW, :NNW)
+    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
+    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
+    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east = :NC)
+
+    # site 2 (domain)
+    C2_e = _corner_expr(:C_2, :NNE, :ENE)
+    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
+    E4_e = _pepo_edge_expr(:E_4, :ENE, :SE, :E, H, 2)
+    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(:A_2, H, 2; contract_west = :NC)
+
+    return C1_e, E1_e, E2_e, ket1_e, bra1_e, pepo1_es, C2_e, E3_e, E4_e, ket2_e, bra2_e, pepo2_es
+end
+
+function _half_infinite_environment_expr(H)
+
+    C1_e, E1_e, E2_e, ket1_e, bra1_e, pepo1_es, C2_e, E3_e, E4_e, ket2_e, bra2_e, pepo2_es =
+        _half_infinite_environment_expr_parts(H)
+
+    partial_expr = Expr(
+        :call, :*,
+        E1_e, C1_e, E2_e,
+        ket1_e, Expr(:call, :conj, bra1_e), pepo1_es...,
+        E3_e, C2_e, E4_e,
+        ket2_e, Expr(:call, :conj, bra2_e), pepo2_es...,
+    )
+
+    return partial_expr
+end
+
+function _half_infinite_environment_conj_expr(H)
+
+    C1_e, E1_e, E2_e, ket1_e, bra1_e, pepo1_es, C2_e, E3_e, E4_e, ket2_e, bra2_e, pepo2_es =
+        _half_infinite_environment_expr_parts(H)
+
+    partial_expr = Expr(
+        :call, :*,
+        Expr(:call, :conj, E1_e), Expr(:call, :conj, C1_e), Expr(:call, :conj, E2_e),
+        Expr(:call, :conj, ket1_e), bra1_e, map(x -> Expr(:call, :conj, x), pepo1_es)...,
+        Expr(:call, :conj, E3_e), Expr(:call, :conj, C2_e), Expr(:call, :conj, E4_e),
+        Expr(:call, :conj, ket2_e), bra2_e, map(x -> Expr(:call, :conj, x), pepo2_es)...,
+    )
+
+    return partial_expr
+end
+
+## FullInfiniteEnv expressions
+
+function _full_infinite_environment_expr_parts(H)
+    # site 1 (codomain)
+    C1_e = _corner_expr(:C_1, :WNW, :NNW)
+    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
+    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
+    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east = :NC)
+
+    # site 2
+    C2_e = _corner_expr(:C_2, :NNE, :ENE)
+    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
+    E4_e = _pepo_edge_expr(:E_4, :ENE, :EC, :E, H, 2)
+    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(
+        :A_2, H, 2; contract_west = :NC, contract_south = :EC
+    )
+
+    # site 3
+    C3_e = _corner_expr(:C_3, :ESE, :SSE)
+    E5_e = _pepo_edge_expr(:E_5, :EC, :ESE, :E, H, 3)
+    E6_e = _pepo_edge_expr(:E_6, :SSE, :SC, :S, H, 3)
+    ket3_e, bra3_e, pepo3_es = _pepo_sandwich_expr(
+        :A_3, H, 3; contract_north = :EC, contract_west = :SC
+    )
+
+    # site 4 (domain)
+    C4_e = _corner_expr(:C_4, :SSW, :WSW)
+    E7_e = _pepo_edge_expr(:E_7, :SC, :SSW, :S, H, 4)
+    E8_e = _pepo_edge_expr(:E_8, :WSW, :NW, :W, H, 4)
+    ket4_e, bra4_e, pepo4_es = _pepo_sandwich_expr(:A_4, H, 4; contract_east = :SC)
+
+    return (
+        E1_e, C1_e, E2_e,
+        ket1_e, bra1_e, pepo1_es,
+        E3_e, C2_e, E4_e,
+        ket2_e, bra2_e, pepo2_es,
+        E5_e, C3_e, E6_e,
+        ket3_e, bra3_e, pepo3_es,
+        E7_e, C4_e, E8_e,
+        ket4_e, bra4_e, pepo4_es,
+    )
+end
+
+function _full_infinite_environment_expr(H)
+    (
+        E1_e, C1_e, E2_e,
+        ket1_e, bra1_e, pepo1_es,
+        E3_e, C2_e, E4_e,
+        ket2_e, bra2_e, pepo2_es,
+        E5_e, C3_e, E6_e,
+        ket3_e, bra3_e, pepo3_es,
+        E7_e, C4_e, E8_e,
+        ket4_e, bra4_e, pepo4_es,
+    ) = _full_infinite_environment_expr_parts(H)
+
+    partial_expr = Expr(
+        :call, :*,
+        E1_e, C1_e, E2_e,
+        ket1_e, Expr(:call, :conj, bra1_e), pepo1_es...,
+        E3_e, C2_e, E4_e,
+        ket2_e, Expr(:call, :conj, bra2_e), pepo2_es...,
+        E5_e, C3_e, E6_e,
+        ket3_e, Expr(:call, :conj, bra3_e), pepo3_es...,
+        E7_e, C4_e, E8_e,
+        ket4_e, Expr(:call, :conj, bra4_e), pepo4_es...,
+    )
+
+    return partial_expr
+end
+
+function _full_infinite_environment_conj_expr(H)
+    (
+        E1_e, C1_e, E2_e,
+        ket1_e, bra1_e, pepo1_es,
+        E3_e, C2_e, E4_e,
+        ket2_e, bra2_e, pepo2_es,
+        E5_e, C3_e, E6_e,
+        ket3_e, bra3_e, pepo3_es,
+        E7_e, C4_e, E8_e,
+        ket4_e, bra4_e, pepo4_es,
+    ) = _full_infinite_environment_expr_parts(H)
+
+    partial_expr = Expr(
+        :call, :*,
+        Expr(:call, :conj, E1_e), Expr(:call, :conj, C1_e), Expr(:call, :conj, E2_e),
+        Expr(:call, :conj, ket1_e), bra1_e, map(x -> Expr(:call, :conj, x), pepo1_es)...,
+        Expr(:call, :conj, E3_e), Expr(:call, :conj, C2_e), Expr(:call, :conj, E4_e),
+        Expr(:call, :conj, ket2_e), bra2_e, map(x -> Expr(:call, :conj, x), pepo2_es)...,
+        Expr(:call, :conj, E5_e), Expr(:call, :conj, C3_e), Expr(:call, :conj, E6_e),
+        Expr(:call, :conj, ket3_e), bra3_e, map(x -> Expr(:call, :conj, x), pepo3_es)...,
+        Expr(:call, :conj, E7_e), Expr(:call, :conj, C4_e), Expr(:call, :conj, E8_e),
+        Expr(:call, :conj, ket4_e), bra4_e, map(x -> Expr(:call, :conj, x), pepo4_es)...,
+    )
+
+    return partial_expr
 end

--- a/src/algorithms/contractions/ctmrg/fullinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/fullinf_env.jl
@@ -67,7 +67,6 @@ Alternatively, contract the environment with a vector `x` acting on it
     E_8 -- A_4 -- A_3 -- E_5
      |      |      |      |
     C_4 -- E_7 -- E_6 -- C_3
-
 ```
 
 or contract the adjoint environment with `x`, e.g. as needed for iterative solvers.
@@ -132,40 +131,6 @@ end
 function full_infinite_environment(
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
-        x::AbstractTensor{T, S, 3},
-        A_1::P, A_2::P, A_3::P, A_4::P,
-    ) where {T, S, P <: PEPSSandwich}
-    return @autoopt @tensor env_x[χ_out D_outabove D_outbelow] :=
-        E_1[χ_out D1 D2; χ1] * C_1[χ1; χ2] * E_2[χ2 D3 D4; χ3] *
-        ket(A_1)[d1; D3 D11 D_outabove D1] * conj(bra(A_1)[d1; D4 D12 D_outbelow D2]) *
-        ket(A_2)[d2; D5 D7 D9 D11] * conj(bra(A_2)[d2; D6 D8 D10 D12]) *
-        E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ6] *
-        E_5[χ6 D13 D14; χ7] * C_3[χ7; χ8] * E_6[χ8 D15 D16; χ9] *
-        ket(A_3)[d3; D9 D13 D15 D17] * conj(bra_3[d3; D10 D14 D16 D18]) *
-        ket(A_4)[d4; D_xabove D17 D19 D21] * conj(bra(A_4)[d4; D_xbelow D18 D20 D22]) *
-        E_7[χ9 D19 D20; χ10] * C_4[χ10; χ11] * E_8[χ11 D21 D22; χ_x] *
-        x[χ_x D_xabove D_xbelow]
-end
-function full_infinite_environment(
-        x::AbstractTensor{T, S, 3},
-        C_1, C_2, C_3, C_4,
-        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
-        A_1::P, A_2::P, A_3::P, A_4::P,
-    ) where {T, S, P <: PEPSSandwich}
-    return @autoopt @tensor x_env[χ_in D_inabove D_inbelow] :=
-        x[χ_x D_xabove D_xbelow] *
-        E_1[χ_x D1 D2; χ1] * C_1[χ1; χ2] * E_2[χ2 D3 D4; χ3] *
-        ket(A_1)[d1; D3 D11 D_xabove D1] * conj(bra(A_1)[d1; D4 D12 D_xbelow D2]) *
-        ket(A_2)[d2; D5 D7 D9 D11] * conj(bra(A_2)[d2; D6 D8 D10 D12]) *
-        E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ6] *
-        E_5[χ6 D13 D14; χ7] * C_3[χ7; χ8] * E_6[χ8 D15 D16; χ9] *
-        ket(A_3)[d3; D9 D13 D15 D17] * conj(bra(A_3)[d3; D10 D14 D16 D18]) *
-        ket(A_4)[d4; D_inabove D17 D19 D21] * conj(bra(A_4)[d4; D_inbelow D18 D20 D22]) *
-        E_7[χ9 D19 D20; χ10] * C_4[χ10; χ11] * E_8[χ11 D21 D22; χ_in]
-end
-function full_infinite_environment(
-        C_1, C_2, C_3, C_4,
-        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
         A_1::P, A_2::P, A_3::P, A_4::P,
     ) where {P <: PFTensor}
     return @autoopt @tensor env[χ_out D_out; χ_in D_in] :=
@@ -177,6 +142,50 @@ function full_infinite_environment(
         A_3[D17 D15; D9 D13] *
         A_4[D21 D19; D_in D17] *
         E_7[χ9 D19; χ10] * C_4[χ10; χ11] * E_8[χ11 D21; χ_in]
+end
+@generated function full_infinite_environment(
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}, A_3::PEPOSandwich{H}, A_4::PEPOSandwich{H},
+    ) where {H}
+    # return projector expression
+    env_e = _pepo_env_expr(:env, :SW, :NW, :S, :N, 1, 4, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _full_infinite_environment_expr(H)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
+end
+
+# right linear map action: tensorcontract(env, x)
+# TODO: if we want multiplication action env * x, we need additional twists
+function full_infinite_environment(
+        env::AbstractTensorMap{T, S, N, N}, x::AbstractTensor{T, S, N}
+    ) where {T, S, N}
+    return half_infinite_environment(env, x)
+end
+function full_infinite_environment(
+        henv1::AbstractTensorMap{T, S, N, N}, henv2::AbstractTensorMap{T, S, N, N},
+        x::AbstractTensor{T, S, N}
+    ) where {T, S, N}
+    return half_infinite_environment(henv1, henv2, x)
+end
+function full_infinite_environment(
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        x::AbstractTensor{T, S, 3},
+        A_1::P, A_2::P, A_3::P, A_4::P,
+    ) where {T, S, P <: PEPSSandwich}
+    return @autoopt @tensor env_x[χ_out D_outabove D_outbelow] :=
+        E_1[χ_out D1 D2; χ1] * C_1[χ1; χ2] * E_2[χ2 D3 D4; χ3] *
+        ket(A_1)[d1; D3 D11 D_outabove D1] * conj(bra(A_1)[d1; D4 D12 D_outbelow D2]) *
+        ket(A_2)[d2; D5 D7 D9 D11] * conj(bra(A_2)[d2; D6 D8 D10 D12]) *
+        E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ6] *
+        E_5[χ6 D13 D14; χ7] * C_3[χ7; χ8] * E_6[χ8 D15 D16; χ9] *
+        ket(A_3)[d3; D9 D13 D15 D17] * conj(bra(A_3)[d3; D10 D14 D16 D18]) *
+        ket(A_4)[d4; D_xabove D17 D19 D21] * conj(bra(A_4)[d4; D_xbelow D18 D20 D22]) *
+        E_7[χ9 D19 D20; χ10] * C_4[χ10; χ11] * E_8[χ11 D21 D22; χ_x] *
+        x[χ_x D_xabove D_xbelow]
 end
 function full_infinite_environment(
         C_1, C_2, C_3, C_4,
@@ -195,6 +204,56 @@ function full_infinite_environment(
         E_7[χ9 D19; χ10] * C_4[χ10; χ11] * E_8[χ11 D21; χ_x] *
         x[χ_x D_x]
 end
+@generated function full_infinite_environment(
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        x::AbstractTensor{T, S, N},
+        A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}, A_3::PEPOSandwich{H}, A_4::PEPOSandwich{H},
+    ) where {T, S, N, H}
+    @assert N == H + 3
+
+    # codomain vector (output)
+    env_x_e = _pepo_env_arg_expr(:env_x, :SW, :S, 1, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _full_infinite_environment_expr(H)
+
+    # domain vector (input)
+    x_e = _pepo_env_arg_expr(:x, :NW, :N, 4, H)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * $x_e))
+end
+
+# left linear map action via adjoint: tensorcontract(env', x) (kind of...)
+# TODO: if we want multiplication action env' * x, we need additional twists
+function full_infinite_environment(
+        x::AbstractTensor{T, S, N}, env::AbstractTensorMap{T, S, N, N},
+    ) where {T, S, N}
+    return half_infinite_environment(x, env)
+end
+function full_infinite_environment(
+        x::AbstractTensor{T, S, N},
+        henv1::AbstractTensorMap{T, S, N, N}, henv2::AbstractTensorMap{T, S, N, N},
+    ) where {T, S, N}
+    return half_infinite_environment(x, henv1, henv2)
+end
+function full_infinite_environment(
+        x::AbstractTensor{T, S, 3},
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        A_1::P, A_2::P, A_3::P, A_4::P,
+    ) where {T, S, P <: PEPSSandwich}
+    return @autoopt @tensor x_env[χ_in D_inabove D_inbelow] :=
+        x[χ_x D_xabove D_xbelow] *
+        conj(E_1[χ_x D1 D2; χ1]) * conj(C_1[χ1; χ2]) * conj(E_2[χ2 D3 D4; χ3]) *
+        conj(ket(A_1)[d1; D3 D11 D_xabove D1]) * bra(A_1)[d1; D4 D12 D_xbelow D2] *
+        conj(ket(A_2)[d2; D5 D7 D9 D11]) * bra(A_2)[d2; D6 D8 D10 D12] *
+        conj(E_3[χ3 D5 D6; χ4]) * conj(C_2[χ4; χ5]) * conj(E_4[χ5 D7 D8; χ6]) *
+        conj(E_5[χ6 D13 D14; χ7]) * conj(C_3[χ7; χ8]) * conj(E_6[χ8 D15 D16; χ9]) *
+        conj(ket(A_3)[d3; D9 D13 D15 D17]) * bra(A_3)[d3; D10 D14 D16 D18] *
+        conj(ket(A_4)[d4; D_inabove D17 D19 D21]) * bra(A_4)[d4; D_inbelow D18 D20 D22] *
+        conj(E_7[χ9 D19 D20; χ10]) * conj(C_4[χ10; χ11]) * conj(E_8[χ11 D21 D22; χ_in])
+end
 function full_infinite_environment(
         x::AbstractTensor{T, S, 2},
         C_1, C_2, C_3, C_4,
@@ -203,99 +262,14 @@ function full_infinite_environment(
     ) where {T, S, P <: PFTensor}
     return @autoopt @tensor x_env[χ_in D_in] :=
         x[χ_x D_x] *
-        E_1[χ_x D1; χ1] * C_1[χ1; χ2] * E_2[χ2 D3; χ3] *
-        A_1[D1 D_x; D3 D11] *
-        A_2[D11 D9; D5 D7] *
-        E_3[χ3 D5; χ4] * C_2[χ4; χ5] * E_4[χ5 D7; χ6] *
-        E_5[χ6 D13; χ7] * C_3[χ7; χ8] * E_6[χ8 D15; χ9] *
-        A_3[D17 D15; D9 D13] *
-        A_4[D21 D19; D_in D17] *
-        E_7[χ9 D19; χ10] * C_4[χ10; χ11] * E_8[χ11 D21; χ_in]
-end
-
-
-## FullInfiniteEnvironment contractions
-
-# reuse partial multiplication expression; TODO: return quadrants separately?
-function _full_infinite_environment_expr(H)
-    # site 1 (codomain)
-    C1_e = _corner_expr(:C_1, :WNW, :NNW)
-    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
-    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
-    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east = :NC)
-
-    # site 2
-    C2_e = _corner_expr(:C_2, :NNE, :ENE)
-    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
-    E4_e = _pepo_edge_expr(:E_4, :ENE, :EC, :E, H, 2)
-    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(
-        :A_2, H, 2; contract_west = :NC, contract_south = :EC
-    )
-
-    # site 3
-    C3_e = _corner_expr(:C_3, :WSW, :SSW)
-    E5_e = _pepo_edge_expr(:E_5, :EC, :WSW, :E, H, 3)
-    E6_e = _pepo_edge_expr(:E_6, :SSW, :SC, :S, H, 3)
-    ket3_e, bra3_e, pepo3_es = _pepo_sandwich_expr(
-        :A_3, H, 3; contract_north = :EC, contract_west = :SC
-    )
-
-    # site 4 (domain)
-    C4_e = _corner_expr(:C_4, :SSW, :WSW)
-    E7_e = _pepo_edge_expr(:E_7, :SC, :SSW, :S, H, 4)
-    E8_e = _pepo_edge_expr(:E_8, :WSW, :NW, :W, H, 4)
-    ket4_e, bra4_e, pepo4_es = _pepo_sandwich_expr(:A_4, H, 4; contract_east = :SC)
-
-    partial_expr = Expr(
-        :call, :*,
-        E1_e, C1_e, E2_e,
-        ket1_e, Expr(:call, :conj, bra1_e),
-        pepo1_es...,
-        E3_e, C2_e, E4_e,
-        ket2_e, Expr(:call, :conj, bra2_e),
-        pepo2_es...,
-        E5_e, C3_e, E6_e,
-        ket3_e, Expr(:call, :conj, bra3_e),
-        pepo3_es...,
-        E7_e, C4_e, E8_e,
-        ket4_e, Expr(:call, :conj, bra4_e),
-        pepo4_es...,
-    )
-
-    return partial_expr
-end
-
-@generated function full_infinite_environment(
-        C_1, C_2, C_3, C_4,
-        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
-        A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}, A_3::PEPOSandwich{H}, A_4::PEPOSandwich{H},
-    ) where {H}
-    # return projector expression
-    env_e = _pepo_env_expr(:env, :SW, :NW, :S, :N, 1, 4, N - 1)
-
-    # reuse partial multiplication expression
-    proj_expr = _full_infinite_environment_expr(H)
-
-    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
-end
-@generated function full_infinite_environment(
-        C_1, C_2, C_3, C_4,
-        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
-        x::AbstractTensor{T, S, N},
-        A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}, A_3::PEPOSandwich{H}, A_4::PEPOSandwich{H},
-    ) where {T, S, N, H}
-    @assert N == H + 3
-
-    # codomain vecor (output)
-    env_x_e = _pepo_env_arg_expr(:env, :SW, :S, 1, N - 1)
-
-    # reuse partial multiplication expression
-    proj_expr = _full_infinite_environment_expr(H)
-
-    # domain vector (input)
-    x_e = _pepo_env_arg_expr(:env, :NW, :N, 4, N - 1)
-
-    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * x_e))
+        conj(E_1[χ_x D1; χ1]) * conj(C_1[χ1; χ2]) * conj(E_2[χ2 D3; χ3]) *
+        conj(A_1[D1 D_x; D3 D11]) *
+        conj(A_2[D11 D9; D5 D7]) *
+        conj(E_3[χ3 D5; χ4]) * conj(C_2[χ4; χ5]) * conj(E_4[χ5 D7; χ6]) *
+        conj(E_5[χ6 D13; χ7]) * conj(C_3[χ7; χ8]) * conj(E_6[χ8 D15; χ9]) *
+        conj(A_3[D17 D15; D9 D13]) *
+        conj(A_4[D21 D19; D_in D17]) *
+        conj(E_7[χ9 D19; χ10]) * conj(C_4[χ10; χ11]) * conj(E_8[χ11 D21; χ_in])
 end
 @generated function full_infinite_environment(
         x::AbstractTensor{T, S, N},
@@ -305,14 +279,14 @@ end
     ) where {T, S, N, H}
     @assert N == H + 3
 
-    # codomain vecor (input)
-    x_e = _pepo_env_arg_expr(:env, :SW, :S, 1, N - 1)
+    # codomain vector (input)
+    x_e = _pepo_env_arg_expr(:x, :SW, :S, 1, H)
 
     # reuse partial multiplication expression
-    proj_expr = _full_infinite_environment_expr(H)
+    proj_expr = _full_infinite_environment_conj_expr(H)
 
     # domain vector (output)
-    x_env_e = _pepo_env_arg_expr(:env, :NW, :N, 4, N - 1)
+    x_env_e = _pepo_env_arg_expr(:x_env, :NW, :N, 4, H)
 
     return macroexpand(
         @__MODULE__, :(return @autoopt @tensor $x_env_e := $x_e * $proj_expr)

--- a/src/algorithms/contractions/ctmrg/fullinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/fullinf_env.jl
@@ -157,14 +157,24 @@ end
     return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
 end
 
-# right linear map action: tensorcontract(env, x)
-# TODO: if we want multiplication action env * x, we need additional twists
+# right linear map action: env * x
 function full_infinite_environment(
         env::AbstractTensorMap{T, S, N, N}, x::AbstractTensor{T, S, N}
     ) where {T, S, N}
     return half_infinite_environment(env, x)
 end
 function full_infinite_environment(
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        x::AbstractTensor{T, S, N},
+        A_1, A_2, A_3, A_4,
+    ) where {T, S, N}
+    xt = twistdual(x, 1:N)
+    return _full_infinite_environment(
+        C_1, C_2, C_3, C_4, E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8, xt, A_1, A_2, A_3, A_4
+    )
+end
+function _full_infinite_environment(
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
         x::AbstractTensor{T, S, 3},
@@ -181,7 +191,7 @@ function full_infinite_environment(
         E_7[χ9 D19 D20; χ10] * C_4[χ10; χ11] * E_8[χ11 D21 D22; χ_x] *
         x[χ_x D_xabove D_xbelow]
 end
-function full_infinite_environment(
+function _full_infinite_environment(
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
         x::AbstractTensor{T, S, 2},
@@ -198,7 +208,7 @@ function full_infinite_environment(
         E_7[χ9 D19; χ10] * C_4[χ10; χ11] * E_8[χ11 D21; χ_x] *
         x[χ_x D_x]
 end
-@generated function full_infinite_environment(
+@generated function _full_infinite_environment(
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
         x::AbstractTensor{T, S, N},
@@ -218,14 +228,24 @@ end
     return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * $x_e))
 end
 
-# left linear map action via adjoint: tensorcontract(env', x) (kind of...)
-# TODO: if we want multiplication action env' * x, we need additional twists
+# left linear map action via adjoint: env' * x
 function full_infinite_environment(
         x::AbstractTensor{T, S, N}, env::AbstractTensorMap{T, S, N, N},
     ) where {T, S, N}
     return half_infinite_environment(x, env)
 end
 function full_infinite_environment(
+        x::AbstractTensor{T, S, N},
+        C_1, C_2, C_3, C_4,
+        E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+        A_1, A_2, A_3, A_4,
+    ) where {T, S, N}
+    xt = twistdual(x, 1:N)
+    return _full_infinite_environment(
+        xt, C_1, C_2, C_3, C_4, E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8, A_1, A_2, A_3, A_4
+    )
+end
+function _full_infinite_environment(
         x::AbstractTensor{T, S, 3},
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
@@ -242,7 +262,7 @@ function full_infinite_environment(
         conj(ket(A_4)[d4; D_inabove D17 D19 D21]) * bra(A_4)[d4; D_inbelow D18 D20 D22] *
         conj(E_7[χ9 D19 D20; χ10]) * conj(C_4[χ10; χ11]) * conj(E_8[χ11 D21 D22; χ_in])
 end
-function full_infinite_environment(
+function _full_infinite_environment(
         x::AbstractTensor{T, S, 2},
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
@@ -259,7 +279,7 @@ function full_infinite_environment(
         conj(A_4[D21 D19; D_in D17]) *
         conj(E_7[χ9 D19; χ10]) * conj(C_4[χ10; χ11]) * conj(E_8[χ11 D21; χ_in])
 end
-@generated function full_infinite_environment(
+@generated function _full_infinite_environment(
         x::AbstractTensor{T, S, N},
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,

--- a/src/algorithms/contractions/ctmrg/fullinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/fullinf_env.jl
@@ -165,12 +165,6 @@ function full_infinite_environment(
     return half_infinite_environment(env, x)
 end
 function full_infinite_environment(
-        henv1::AbstractTensorMap{T, S, N, N}, henv2::AbstractTensorMap{T, S, N, N},
-        x::AbstractTensor{T, S, N}
-    ) where {T, S, N}
-    return half_infinite_environment(henv1, henv2, x)
-end
-function full_infinite_environment(
         C_1, C_2, C_3, C_4,
         E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
         x::AbstractTensor{T, S, 3},
@@ -230,12 +224,6 @@ function full_infinite_environment(
         x::AbstractTensor{T, S, N}, env::AbstractTensorMap{T, S, N, N},
     ) where {T, S, N}
     return half_infinite_environment(x, env)
-end
-function full_infinite_environment(
-        x::AbstractTensor{T, S, N},
-        henv1::AbstractTensorMap{T, S, N, N}, henv2::AbstractTensorMap{T, S, N, N},
-    ) where {T, S, N}
-    return half_infinite_environment(x, henv1, henv2)
 end
 function full_infinite_environment(
         x::AbstractTensor{T, S, 3},

--- a/src/algorithms/contractions/ctmrg/halfinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/halfinf_env.jl
@@ -49,7 +49,47 @@ function half_infinite_environment(
         E_1[χ_out D1 D2; χ1] * C_1[χ1; χ2] * E_2[χ2 D3 D4; χ3] *
         ket(A_1)[d1; D3 D9 D_outabove D1] * conj(bra(A_1)[d1; D4 D10 D_outbelow D2]) *
         ket(A_2)[d2; D5 D7 D_inabove D9] * conj(bra(A_2)[d2; D6 D8 D_inbelow D10]) *
-        E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ_out]
+        E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ_in]
+end
+function half_infinite_environment(
+        C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
+    ) where {P <: PFTensor}
+    return @autoopt @tensor env[χ_out D_out; χ_in D_in] :=
+        E_1[χ_out D1; χ1] * C_1[χ1; χ2] * E_2[χ2 D3; χ3] *
+        A_1[D1 D_out; D3 D9] *
+        A_2[D9 D_in; D5 D7] *
+        E_3[χ3 D5; χ4] * C_2[χ4; χ5] * E_4[χ5 D7; χ_in]
+end
+@generated function half_infinite_environment(
+        C_1, C_2, E_1, E_2, E_3, E_4, A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}
+    ) where {H}
+    # return projector expression
+    env_e = _pepo_env_expr(:env, :SW, :SE, :S, :S, 1, 2, H)
+
+    # reuse partial multiplication expression
+    proj_expr = _half_infinite_environment_expr(H)
+
+    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
+end
+
+# right linear map action: tensorcontract(env, x)
+# TODO: if we want multiplication action env * x, we need additional twists
+function half_infinite_environment(
+        env::AbstractTensorMap{T, S, N, N}, x::AbstractTensor{T, S, N}
+    ) where {T, S, N}
+    envi = (codomainind(env), domainind(env))
+    xi = (codomainind(x), domainind(x))
+    return tensorcontract(env, envi, false, x, xi, false, xi)
+end
+function half_infinite_environment(
+        quadrant1::AbstractTensorMap{T, S, N, N}, quadrant2::AbstractTensorMap{T, S, N, N},
+        x::AbstractTensor{T, S, N}
+    ) where {T, S, N}
+    qi = (codomainind(quadrant1), domainind(quadrant1))
+    xi = (codomainind(x), domainind(x))
+    q2x = tensorcontract(quadrant2, qi, false, x, xi, false, xi)
+    q1q2x = tensorcontract(quadrant1, qi, false, q2x, xi, false, xi)
+    return q1q2x
 end
 function half_infinite_environment(
         C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 3}, A_1::P, A_2::P
@@ -62,26 +102,7 @@ function half_infinite_environment(
         x[χ6 D11 D12]
 end
 function half_infinite_environment(
-        x::AbstractTensor{T, S, 3}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
-    ) where {T, S, P <: PEPSSandwich}
-    return @autoopt @tensor x_env[χ_in D_inabove D_inbelow] :=
-        x[χ1 D1 D2] *
-        conj(E_1[χ1 D3 D4; χ2]) * conj(C_1[χ2; χ3]) * conj(E_2[χ3 D5 D6; χ4]) *
-        conj(ket(A_1)[d1; D5 D11 D1 D3]) * bra(A_1)[d1; D6 D12 D2 D4] *
-        conj(ket(A_2)[d2; D7 D9 D_inabove D11]) * bra(A_2)[d2; D8 D10 D_inbelow D12] *
-        conj(E_3[χ4 D7 D8; χ5]) * conj(C_2[χ5; χ6]) * conj(E_4[χ6 D9 D10; χ_in])
-end
-function half_infinite_environment(
-        C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
-    ) where {P <: PFTensor}
-    return @autoopt @tensor env[χ_out D_out; χ_in D_in] :=
-        E_1[χ_out D1; χ1] * C_1[χ1; χ2] * E_2[χ2 D3; χ3] *
-        A_1[D1 D_out; D3 D9] *
-        A_2[D9 D_in; D5 D7] *
-        E_3[χ3 D5; χ4] * C_2[χ4; χ5] * E_4[χ5 D7; χ_in]
-end
-function half_infinite_environment(
-        C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 2}, A_1::P, A::P
+        C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 2}, A_1::P, A_2::P
     ) where {T, S, P <: PFTensor}
     return @autoopt @tensor env_x[χ_out D_out] :=
         E_1[χ_out D1; χ1] * C_1[χ1; χ2] * E_2[χ2 D3; χ3] *
@@ -89,57 +110,6 @@ function half_infinite_environment(
         A_2[D9 D11; D5 D7] *
         E_3[χ3 D5; χ4] * C_2[χ4; χ5] * E_4[χ5 D7; χ6] *
         x[χ6 D11]
-end
-function half_infinite_environment(
-        x::AbstractTensor{T, S, 2}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
-    ) where {T, S, P <: PFTensor}
-    return @autoopt @tensor env_x[χ_in D_in] :=
-        x[χ1 D1 D2] *
-        conj(E_1[χ1 D3; χ2]) * conj(C_1[χ2; χ3]) * conj(E_2[χ3 D5; χ4]) *
-        conj(A_1[D3 D1; D5 D11]) *
-        conj(A_2[D11 D_in; D7 D9]) *
-        conj(E_3[χ4 D7; χ5]) * conj(C_2[χ5; χ6]) * conj(E_4[χ6 D9; χ_in])
-end
-
-## HalfInfiniteEnvironment contractions
-
-# reuse partial multiplication expression; TODO: return quadrants separately?
-function _half_infinite_environnment_expr(H)
-    # site 1 (codomain)
-    C1_e = _corner_expr(:C_1, :WNW, :NNW)
-    E1_e = _pepo_edge_expr(:E_1, :SW, :WNW, :W, H, 1)
-    E2_e = _pepo_edge_expr(:E_2, :NNW, :NC, :N, H, 1)
-    ket1_e, bra1_e, pepo1_es = _pepo_sandwich_expr(:A_1, H, 1; contract_east = :NC)
-
-    # site 2 (domain)
-    C2_e = _corner_expr(:C_2, :NNE, :ENE)
-    E3_e = _pepo_edge_expr(:E_3, :NC, :NNE, :N, H, 2)
-    E4_e = _pepo_edge_expr(:E_4, :ENE, :SE, :E, H, 2)
-    ket2_e, bra2_e, pepo2_es = _pepo_sandwich_expr(:A_2, H, 2; contract_west = :NC)
-
-    partial_expr = Expr(
-        :call, :*,
-        E1_e, C1_e, E2_e,
-        ket1_e, Expr(:call, :conj, bra1_e),
-        pepo1_es...,
-        E3_e, C2_e, E4_e,
-        ket2_e, Expr(:call, :conj, bra2_e),
-        pepo2_es...,
-    )
-
-    return partial_expr
-end
-
-@generated function half_infinite_environment(
-        C_1, C_2, E_1, E_2, E_3, E_4, A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}
-    ) where {H}
-    # return projector expression
-    env_e = _pepo_env_expr(:env, :SW, :SE, :S, :S, 1, 2, H)
-
-    # reuse partial multiplication expression
-    proj_expr = _half_infinite_environnment_expr(H)
-
-    return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $rhs))
 end
 @generated function half_infinite_environment(
         C_1, C_2,
@@ -153,7 +123,7 @@ end
     env_x_e = _pepo_env_arg_expr(:env_x, :SW, :S, 1, H)
 
     # reuse partial multiplication expression
-    proj_expr = _half_infinite_environnment_expr(H)
+    proj_expr = _half_infinite_environment_expr(H)
 
     # domain vector (input)
     x_e = _pepo_env_arg_expr(:x, :SE, :S, 2, H)
@@ -161,6 +131,46 @@ end
     return macroexpand(
         @__MODULE__, :(return @autoopt @tensor $env_x_e := $proj_expr * $x_e)
     )
+end
+
+# left linear map action via adjoint: tensorcontract(env', x) (kind of...)
+# TODO: if we want multiplication action env' * x, we need additional twists
+function half_infinite_environment(
+        x::AbstractTensor{T, S, N}, env::AbstractTensorMap{T, S, N, N},
+    ) where {T, S, N}
+    envi = (domainind(env), codomainind(env))
+    xi = (codomainind(x), domainind(x))
+    return tensorcontract(env, envi, true, x, xi, false, xi)
+end
+function half_infinite_environment(
+        x::AbstractTensor{T, S, N},
+        quadrant1::AbstractTensorMap{T, S, N, N}, quadrant2::AbstractTensorMap{T, S, N, N},
+    ) where {T, S, N}
+    qi = (domainind(quadrant1), codomainind(quadrant1))
+    xi = (codomainind(x), domainind(x))
+    xq1 = tensorcontract(quadrant1, qi, true, x, xi, false, xi)
+    xq1q2 = tensorcontract(quadrant2, qi, true, xq1, xi, false, xi)
+    return xq1q2
+end
+function half_infinite_environment(
+        x::AbstractTensor{T, S, 3}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
+    ) where {T, S, P <: PEPSSandwich}
+    return @autoopt @tensor x_env[χ_in D_inabove D_inbelow] :=
+        x[χ1 D1 D2] *
+        conj(E_1[χ1 D3 D4; χ2]) * conj(C_1[χ2; χ3]) * conj(E_2[χ3 D5 D6; χ4]) *
+        conj(ket(A_1)[d1; D5 D11 D1 D3]) * bra(A_1)[d1; D6 D12 D2 D4] *
+        conj(ket(A_2)[d2; D7 D9 D_inabove D11]) * bra(A_2)[d2; D8 D10 D_inbelow D12] *
+        conj(E_3[χ4 D7 D8; χ5]) * conj(C_2[χ5; χ6]) * conj(E_4[χ6 D9 D10; χ_in])
+end
+function half_infinite_environment(
+        x::AbstractTensor{T, S, 2}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
+    ) where {T, S, P <: PFTensor}
+    return @autoopt @tensor env_x[χ_in D_in] :=
+        x[χ_SW D_S1] *
+        conj(E_1[χ_SW D_W1; χ_WNW]) * conj(C_1[χ_WNW; χ_NNW]) * conj(E_2[χ_NNW D_N1; χ_N]) *
+        conj(A_1[D_W1 D_S1; D_N1 D_C]) *
+        conj(A_2[D_C D_in; D_N2 D_E2]) *
+        conj(E_3[χ_N D_N2; χ_NNE]) * conj(C_2[χ_NNE; χ_ENE]) * conj(E_4[χ_ENE D_E2; χ_in])
 end
 @generated function half_infinite_environment(
         x::AbstractTensor{T, S, N},
@@ -173,7 +183,7 @@ end
     x_e = _pepo_env_arg_expr(:x, :SW, :S, 1, H)
 
     # reuse partial multiplication expression
-    proj_expr = _half_infinite_environnment_expr(H)
+    proj_expr = _half_infinite_environment_conj_expr(H)
 
     # domain vector (output)
     x_env_e = _pepo_env_arg_expr(:env_x, :SE, :S, 2, H)

--- a/src/algorithms/contractions/ctmrg/halfinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/halfinf_env.jl
@@ -72,16 +72,19 @@ end
     return macroexpand(@__MODULE__, :(return @autoopt @tensor $env_e := $proj_expr))
 end
 
-# right linear map action: tensorcontract(env, x)
-# TODO: if we want multiplication action env * x, we need additional twists
+# right linear map action: env * x
 function half_infinite_environment(
         env::AbstractTensorMap{T, S, N, N}, x::AbstractTensor{T, S, N}
     ) where {T, S, N}
-    envi = (codomainind(env), domainind(env))
-    xi = (codomainind(x), domainind(x))
-    return tensorcontract(env, envi, false, x, xi, false, xi)
+    return env * x
 end
 function half_infinite_environment(
+        C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, N}, A_1, A_2
+    ) where {T, S, N}
+    xt = twistdual(x, 1:N)
+    return _half_infinite_environment(C_1, C_2, E_1, E_2, E_3, E_4, xt, A_1, A_2)
+end
+function _half_infinite_environment(
         C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 3}, A_1::P, A_2::P
     ) where {T, S, P <: PEPSSandwich}
     return @autoopt @tensor env_x[χ_out D_outabove D_outbelow] :=
@@ -91,7 +94,7 @@ function half_infinite_environment(
         E_3[χ3 D5 D6; χ4] * C_2[χ4; χ5] * E_4[χ5 D7 D8; χ6] *
         x[χ6 D11 D12]
 end
-function half_infinite_environment(
+function _half_infinite_environment(
         C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 2}, A_1::P, A_2::P
     ) where {T, S, P <: PFTensor}
     return @autoopt @tensor env_x[χ_out D_out] :=
@@ -101,7 +104,7 @@ function half_infinite_environment(
         E_3[χ3 D5; χ4] * C_2[χ4; χ5] * E_4[χ5 D7; χ6] *
         x[χ6 D11]
 end
-@generated function half_infinite_environment(
+@generated function _half_infinite_environment(
         C_1, C_2,
         E_1, E_2, E_3, E_4,
         x::AbstractTensor{T, S, N},
@@ -123,16 +126,19 @@ end
     )
 end
 
-# left linear map action via adjoint: tensorcontract(env', x) (kind of...)
-# TODO: if we want multiplication action env' * x, we need additional twists
+# left linear map action via adjoint: env' * x
 function half_infinite_environment(
         x::AbstractTensor{T, S, N}, env::AbstractTensorMap{T, S, N, N},
     ) where {T, S, N}
-    envi = (domainind(env), codomainind(env))
-    xi = (codomainind(x), domainind(x))
-    return tensorcontract(env, envi, true, x, xi, false, xi)
+    return env' * x
 end
 function half_infinite_environment(
+        x::AbstractTensor{T, S, N}, C_1, C_2, E_1, E_2, E_3, E_4, A_1, A_2
+    ) where {T, S, N}
+    xt = twistdual(x, 1:N)
+    return _half_infinite_environment(xt, C_1, C_2, E_1, E_2, E_3, E_4, A_1, A_2)
+end
+function _half_infinite_environment(
         x::AbstractTensor{T, S, 3}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
     ) where {T, S, P <: PEPSSandwich}
     return @autoopt @tensor x_env[χ_in D_inabove D_inbelow] :=
@@ -142,7 +148,7 @@ function half_infinite_environment(
         conj(ket(A_2)[d2; D7 D9 D_inabove D11]) * bra(A_2)[d2; D8 D10 D_inbelow D12] *
         conj(E_3[χ4 D7 D8; χ5]) * conj(C_2[χ5; χ6]) * conj(E_4[χ6 D9 D10; χ_in])
 end
-function half_infinite_environment(
+function _half_infinite_environment(
         x::AbstractTensor{T, S, 2}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P
     ) where {T, S, P <: PFTensor}
     return @autoopt @tensor env_x[χ_in D_in] :=
@@ -152,7 +158,7 @@ function half_infinite_environment(
         conj(A_2[D_C D_in; D_N2 D_E2]) *
         conj(E_3[χ_N D_N2; χ_NNE]) * conj(C_2[χ_NNE; χ_ENE]) * conj(E_4[χ_ENE D_E2; χ_in])
 end
-@generated function half_infinite_environment(
+@generated function _half_infinite_environment(
         x::AbstractTensor{T, S, N},
         C_1, C_2,
         E_1, E_2, E_3, E_4,

--- a/src/algorithms/contractions/ctmrg/halfinf_env.jl
+++ b/src/algorithms/contractions/ctmrg/halfinf_env.jl
@@ -82,16 +82,6 @@ function half_infinite_environment(
     return tensorcontract(env, envi, false, x, xi, false, xi)
 end
 function half_infinite_environment(
-        quadrant1::AbstractTensorMap{T, S, N, N}, quadrant2::AbstractTensorMap{T, S, N, N},
-        x::AbstractTensor{T, S, N}
-    ) where {T, S, N}
-    qi = (codomainind(quadrant1), domainind(quadrant1))
-    xi = (codomainind(x), domainind(x))
-    q2x = tensorcontract(quadrant2, qi, false, x, xi, false, xi)
-    q1q2x = tensorcontract(quadrant1, qi, false, q2x, xi, false, xi)
-    return q1q2x
-end
-function half_infinite_environment(
         C_1, C_2, E_1, E_2, E_3, E_4, x::AbstractTensor{T, S, 3}, A_1::P, A_2::P
     ) where {T, S, P <: PEPSSandwich}
     return @autoopt @tensor env_x[χ_out D_outabove D_outbelow] :=
@@ -141,16 +131,6 @@ function half_infinite_environment(
     envi = (domainind(env), codomainind(env))
     xi = (codomainind(x), domainind(x))
     return tensorcontract(env, envi, true, x, xi, false, xi)
-end
-function half_infinite_environment(
-        x::AbstractTensor{T, S, N},
-        quadrant1::AbstractTensorMap{T, S, N, N}, quadrant2::AbstractTensorMap{T, S, N, N},
-    ) where {T, S, N}
-    qi = (domainind(quadrant1), codomainind(quadrant1))
-    xi = (codomainind(x), domainind(x))
-    xq1 = tensorcontract(quadrant1, qi, true, x, xi, false, xi)
-    xq1q2 = tensorcontract(quadrant2, qi, true, xq1, xi, false, xi)
-    return xq1q2
 end
 function half_infinite_environment(
         x::AbstractTensor{T, S, 3}, C_1, C_2, E_1, E_2, E_3, E_4, A_1::P, A_2::P

--- a/src/algorithms/contractions/ctmrg/projector.jl
+++ b/src/algorithms/contractions/ctmrg/projector.jl
@@ -14,16 +14,99 @@ Contract the CTMRG left projector with the higher-dimensional subspace facing to
     out
 ```
 """
-function left_projector(E_1, C, E_2, V, isqS, A::PEPSSandwich)
+function left_projector(E_1, C, E_2, V, isqS, A)
+    Vdt_isqS = twistdual(V', 1:(numind(V) - 1)) * isqS
+    return _left_projector(E_1, C, E_2, Vdt_isqS, A)
+end
+function _left_projector(E_1, C, E_2, Vd, A::PEPSSandwich)
     return @autoopt @tensor P_left[χ_out D_outabove D_outbelow; χ_in] :=
         E_1[χ_out D1 D2; χ1] * C[χ1; χ2] * E_2[χ2 D3 D4; χ3] *
         ket(A)[d; D3 D5 D_outabove D1] * conj(bra(A)[d; D4 D6 D_outbelow D2]) *
-        conj(V[χ4; χ3 D5 D6]) * isqS[χ4; χ_in]
+        Vd[χ3 D5 D6; χ_in]
 end
-function left_projector(E_1, C, E_2, V, isqS, A::PFTensor)
+function _left_projector(E_1, C, E_2, Vd, A::PFTensor)
     return @autoopt @tensor P_left[χ_out D_out; χ_in] :=
         E_1[χ_out D1; χ1] * C[χ1; χ2] * E_2[χ2 D2; χ3] *
-        A[D1 D_out; D2 D3] * conj(V[χ4; χ3 D3]) * isqS[χ4; χ_in]
+        A[D1 D_out; D2 D3] * Vd[χ3 D3; χ_in]
+end
+@generated function _left_projector(
+        E_1, C, E_2, Vd, A::PEPOSandwich{H}
+    ) where {H}
+
+    E_west_e = _pepo_edge_expr(:E_1, :out, :WNW, :W, H)
+    E_north_e = _pepo_edge_expr(:E_2, :NNW, :NE, :N, H)
+    C_northwest_e = _corner_expr(:C, :WNW, :NNW)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+
+    Vd_e = _pepo_domain_projector_expr(:Vd, :NE, :E, :in, H)
+
+    P_left_e = _pepo_domain_projector_expr(:P_left, :out, :S, :in, H)
+
+    rhs = Expr(
+        :call, :*,
+        E_west_e, C_northwest_e, E_north_e,
+        ket_e, Expr(:call, :conj, bra_e),
+        pepo_es...,
+        Vd_e
+    )
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $P_left_e := $rhs)
+    )
+end
+
+"""
+$(SIGNATURES)
+
+Contract the CTMRG left projector with the higher-dimensional subspace facing to the left.
+
+```
+    C_1 -- E_2 -- E_3 -- C_2
+     |      |      |      |
+    E_1 -- A_1 -- A_2 -- E_4
+     |      |      |      |
+    out            [~~~V'~]
+                       |
+                     isqS
+                       |
+                       in
+```
+"""
+function left_projector(E_1, C_1, E_2, E_3, C_2, E_4, V, isqS, A_1, A_2)
+    Vdt_isqS = twistdual(V', 1:(numind(V) - 1)) * isqS
+    return _left_projector(E_1, C_1, E_2, E_3, C_2, E_4, Vdt_isqS, A_1, A_2)
+end
+function _left_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Vd, A_1::PEPSSandwich, A_2::PEPSSandwich
+    )
+    return @autoopt @tensor P_left[χ_out D_outa D_outb; χ_in] :=
+        E_1[χ_out D_W1a D_W1b; χ_WNW] * C_1[χ_WNW; χ_NNW] * E_2[χ_NNW D_N1a D_N1b; χ_N] *
+        ket(A_1)[d1; D_N1a D_Ca D_outa D_W1a] * conj(bra(A_1)[d1; D_N1b D_Cb D_outb D_W1b]) *
+        E_3[χ_N D_N2a D_N2b; χ_NNE] * C_2[χ_NNE; χ_ENE] * E_4[χ_ENE D_E2a D_E2b; χ_SE] *
+        ket(A_2)[d2; D_N2a D_E2a D_S2a D_Ca] * conj(bra(A_2)[d2; D_N2b D_E2b D_S2b D_Cb]) *
+        Vd[χ_SE D_S2a D_S2b; χ_in]
+end
+function _left_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Vd, A_1::PFTensor, A_2::PFTensor
+    )
+    return @autoopt @tensor P_left[χ_out D_out; χ_in] :=
+        E_1[χ_out D_W1; χ_WNW] * C_1[χ_WNW; χ_NNW] * E_2[χ_NNW D_N1; χ_N] *
+        A_1[D_W1 D_out; D_N1 D_C] *
+        E_3[χ_N D_N2; χ_NNE] * C_2[χ_NNE; χ_ENE] * E_4[χ_ENE D_E2; χ_SE] *
+        A_2[D_C D_S2; D_N2 D_E2] *
+        Vd[χ_SE D_S2; χ_in]
+end
+@generated function _left_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Vd, A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}
+    ) where {H}
+
+    Vd_e = _pepo_domain_projector_expr(:Vd, :SE, :S, :in, H, 2)
+    proj_expr = _half_infinite_environment_expr(H)
+    P_left_e = _pepo_domain_projector_expr(:P_left, :SW, :S, :in, H, 1)
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $P_left_e := $proj_expr * $Vd_e)
+    )
 end
 
 """
@@ -32,24 +115,107 @@ $(SIGNATURES)
 Contract the CTMRG right projector with the higher-dimensional subspace facing to the right.
 
 ```
-                  |~~| --   E_2   --  C
+                  |~~| --   E_1   --  C
     out-- isqS -- |U'|      |         |
-                  |~~| --   A     -- E_1
+                  |~~| --   A     -- E_2
                             |         |
                                       in
 ```
 """
-function right_projector(E_1, C, E_2, U, isqS, A::PEPSSandwich)
-    return @autoopt @tensor P_right[χ_out; χ_in D_inabove D_inbelow] :=
-        isqS[χ_out; χ1] * conj(U[χ1; χ2 D1 D2]) *
-        ket(A)[d; D3 D5 D_inabove D1] * conj(bra(A)[d; D4 D6 D_inbelow D2]) *
-        E_2[χ2 D3 D4; χ3] * C[χ3; χ4] * E_1[χ4 D5 D6; χ_in]
+function right_projector(E_1, C, E_2, U, isqS, A)
+    isqS_Udt = isqS * twistnondual(U', 2:numind(U))
+    return _right_projector(E_1, C, E_2, isqS_Udt, A)
 end
-function right_projector(E_1, C, E_2, U, isqS, A::PFTensor)
+function _right_projector(E_1, C, E_2, Ud, A::PEPSSandwich)
+    return @autoopt @tensor P_right[χ_out; χ_in D_inabove D_inbelow] :=
+        Ud[χ_out; χ2 D1 D2] *
+        ket(A)[d; D3 D5 D_inabove D1] * conj(bra(A)[d; D4 D6 D_inbelow D2]) *
+        E_1[χ2 D3 D4; χ3] * C[χ3; χ4] * E_2[χ4 D5 D6; χ_in]
+end
+function _right_projector(E_1, C, E_2, Ud, A::PFTensor)
     return @autoopt @tensor P_right[χ_out; χ_in D_in] :=
-        isqS[χ_out; χ1] * conj(U[χ1; χ2 D1]) *
+        Ud[χ_out; χ2 D1] *
         A[D1 D_in; D2 D3] *
-        E_2[χ2 D2; χ3] * C[χ3; χ4] * E_1[χ4 D3; χ_in]
+        E_1[χ2 D2; χ3] * C[χ3; χ4] * E_2[χ4 D3; χ_in]
+end
+@generated function _right_projector(
+        E_1, C, E_2, Ud, A::PEPOSandwich{H}
+    ) where {H}
+
+    E_north_e = _pepo_edge_expr(:E_1, :NW, :NNE, :N, H)
+    E_east_e = _pepo_edge_expr(:E_2, :ENE, :in, :E, H)
+    C_northeast_e = _corner_expr(:C, :NNE, :ENE)
+    ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)
+
+    Ud_e = _pepo_codomain_projector_expr(:Ud, :out, :NW, :W, H)
+
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :in, :S, H)
+
+    rhs = Expr(
+        :call, :*,
+        E_north_e, C_northeast_e, E_east_e,
+        ket_e, Expr(:call, :conj, bra_e),
+        pepo_es...,
+        Ud_e
+    )
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $P_right_e := $rhs)
+    )
+end
+
+"""
+$(SIGNATURES)
+
+Contract the CTMRG left projector with the higher-dimensional subspace facing to the left.
+
+```
+    C_1 -- E_2 -- E_3 -- C_2
+     |      |      |      |
+    E_1 -- A_1 -- A_2 -- E_4
+     |      |      |      |
+     [~~~U'~]             in            
+         |
+        isqS
+         |
+        out
+```
+"""
+function right_projector(E_1, C_1, E_2, E_3, C_2, E_4, U, isqS, A_1, A_2)
+    isqS_Udt = isqS * twistnondual(U', 2:numind(U))
+    return _right_projector(E_1, C_1, E_2, E_3, C_2, E_4, isqS_Udt, A_1, A_2)
+end
+function _right_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Ud, A_1::PEPSSandwich, A_2::PEPSSandwich
+    )
+    return @autoopt @tensor P_right[χ_out; χ_in D_ina D_inb] :=
+        E_1[χ_SW D_W1a D_W1b; χ_WNW] * C_1[χ_WNW; χ_NNW] * E_2[χ_NNW D_N1a D_N1b; χ_N] *
+        ket(A_1)[d1; D_N1a D_Ca D_S1a D_W1a] * conj(bra(A_1)[d1; D_N1b D_Cb D_S1b D_W1b]) *
+        E_3[χ_N D_N2a D_N2b; χ_NNE] * C_2[χ_NNE; χ_ENE] * E_4[χ_ENE D_E2a D_E2b; χ_in] *
+        ket(A_2)[d2; D_N2a D_E2a D_ina D_Ca] * conj(bra(A_2)[d2; D_N2b D_E2b D_inb D_Cb]) *
+        Ud[χ_out; χ_SW D_S1a D_S1b]
+end
+function _right_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Ud, A_1::PFTensor, A_2::PFTensor
+    )
+    return @autoopt @tensor P_right[χ_out; χ_in D_in] :=
+        E_1[χ_SW D_W1; χ_WNW] * C_1[χ_WNW; χ_NNW] * E_2[χ_NNW D_N1; χ_N] *
+        A_1[D_W1 D_S1; D_N1 D_C] *
+        E_3[χ_N D_N2; χ_NNE] * C_2[χ_NNE; χ_ENE] * E_4[χ_ENE D_E2; χ_in] *
+        A_2[D_C D_in; D_N2 D_E2] *
+        Ud[χ_out; χ_SW D_S1]
+end
+@generated function _right_projector(
+        E_1, C_1, E_2, E_3, C_2, E_4, Ud, A_1::PEPOSandwich{H}, A_2::PEPOSandwich{H}
+    ) where {H}
+
+    Ud_e = _pepo_codomain_projector_expr(:Ud, :out, :SW, :S, H, 1)
+    proj_expr = _half_infinite_environment_expr(H)
+    P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :SE, :S, H, 2)
+
+    return macroexpand(
+        @__MODULE__, :(return @autoopt @tensor $P_right_e := $Ud_e * $proj_expr)
+    )
 end
 
 """

--- a/src/algorithms/contractions/ctmrg/renormalize_corner.jl
+++ b/src/algorithms/contractions/ctmrg/renormalize_corner.jl
@@ -285,7 +285,7 @@ end
     C_out_e = _corner_expr(:corner, :out, :in)
 
     P_right_e = _pepo_codomain_projector_expr(:P_right, :out, :N, :N, H)
-    E_east_e = _pepo_edge_expr(:E_east, :N, :EWE, :E, H)
+    E_east_e = _pepo_edge_expr(:E_east, :N, :ESE, :E, H)
     C_southeast_e = _corner_expr(:C_southeast, :ESE, :SSE)
     E_south_e = _pepo_edge_expr(:E_south, :SSE, :W, :S, H)
     ket_e, bra_e, pepo_es = _pepo_sandwich_expr(:A, H)

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -99,7 +99,7 @@ function half_infinite_environment(ec_1::EnlargedCorner, ec_2::EnlargedCorner)
 end
 
 # Compute left and right projectors sparsely without constructing enlarged corners explicitly
-function left_and_right_projector(U, S, V, Q::EnlargedCorner, Q_next::EnlargedCorner)
+function contract_projectors(U, S, V, Q::EnlargedCorner, Q_next::EnlargedCorner)
     isqS = sdiag_pow(S, -0.5)
     P_left = left_projector(Q.E_1, Q.C, Q.E_2, V, isqS, Q.A)
     P_right = right_projector(Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.A)

--- a/src/algorithms/ctmrg/sparse_environments.jl
+++ b/src/algorithms/ctmrg/sparse_environments.jl
@@ -100,9 +100,11 @@ end
 
 # Compute left and right projectors sparsely without constructing enlarged corners explicitly
 function contract_projectors(U, S, V, Q::EnlargedCorner, Q_next::EnlargedCorner)
+    Ar = _rotate_north_localsandwich(Q.A, _prev(Q.dir, 4))
+    Ar_next = _rotate_north_localsandwich(Q_next.A, Q_next.dir)
     isqS = sdiag_pow(S, -0.5)
-    P_left = left_projector(Q.E_1, Q.C, Q.E_2, V, isqS, Q.A)
-    P_right = right_projector(Q_next.E_1, Q_next.C, Q_next.E_2, U, isqS, Q_next.A)
+    P_left = left_projector(Q_next.E_1, Q_next.C, Q_next.E_2, V, isqS, Ar_next)
+    P_right = right_projector(Q.E_1, Q.C, Q.E_2, U, isqS, Ar)
     return P_left, P_right
 end
 
@@ -134,12 +136,23 @@ struct HalfInfiniteEnv{TC, TE, TA}  # TODO: subtype as AbstractTensorMap once Te
     E_4::TE
     A_1::TA
     A_2::TA
+    A_1r::TA # prerotate
+    A_2r::TA
+    dir::Int
+    function HalfInfiniteEnv(
+            C_1::TC, C_2::TC, E_1::TE, E_2::TE, E_3::TE, E_4::TE, A_1::TA, A_2::TA, dir::Int
+        ) where {TC, TE, TA}
+        A_1r = _rotate_north_localsandwich(A_1, dir)
+        A_2r = _rotate_north_localsandwich(A_2, dir)
+        return new{TC, TE, TA}(C_1, C_2, E_1, E_2, E_3, E_4, A_1, A_2, A_1r, A_2r, dir)
+    end
 end
 function HalfInfiniteEnv(quadrant1::EnlargedCorner, quadrant2::EnlargedCorner)
     return HalfInfiniteEnv(
         quadrant1.C, quadrant2.C,
         quadrant1.E_1, quadrant1.E_2, quadrant2.E_1, quadrant2.E_2,
-        quadrant1.A_1, quadrant2.A_2,
+        quadrant1.A, quadrant2.A,
+        quadrant1.dir,
     )
 end
 
@@ -150,7 +163,7 @@ Instantiate half-infinite environment as `TensorMap` explicitly.
 """
 function TensorKit.TensorMap(env::HalfInfiniteEnv)  # Dense operator
     return half_infinite_environment(
-        env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, env.A_1, env.A_2
+        env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, env.A_1r, env.A_2r
     )
 end
 
@@ -163,29 +176,58 @@ linear map or adjoint linear map on `x` if `Val(true)` or `Val(false)` is passed
 """
 function (env::HalfInfiniteEnv)(x, ::Val{false})  # Linear map: env() * x
     return half_infinite_environment(
-        env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, x, env.A_1, env.A_2
+        env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, x, env.A_1r, env.A_2r
     )
 end
 function (env::HalfInfiniteEnv)(x, ::Val{true})  # Adjoint linear map: env()' * x
     return half_infinite_environment(
-        x, env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, env.A_1, env.A_2
+        x, env.C_1, env.C_2, env.E_1, env.E_2, env.E_3, env.E_4, env.A_1r, env.A_2r
     )
+end
+
+function contract_projectors(U, S, V, env::HalfInfiniteEnv)
+    Q = EnlargedCorner(env.C_1, env.E_1, env.E_2, env.A_1, env.dir)
+    Q_next = EnlargedCorner(env.C_2, env.E_3, env.E_4, env.A_2, _next(env.dir, 4))
+    return contract_projectors(U, S, V, Q, Q_next)
+end
+
+function contract_projectors(U, S, V, henv::HalfInfiniteEnv, henv_next::HalfInfiniteEnv)
+    isqS = sdiag_pow(S, -0.5)
+    P_left = left_projector(
+        henv_next.E_1, henv_next.C_1, henv_next.E_2, henv_next.E_3, henv_next.C_2, henv_next.E_4,
+        V, isqS,
+        henv_next.A_1r, henv_next.A_2r
+    )
+    P_right = right_projector(
+        henv.E_1, henv.C_1, henv.E_2, henv.E_3, henv.C_2, henv.E_4,
+        U, isqS,
+        henv.A_1r, henv.A_2r
+    )
+    return P_left, P_right
 end
 
 # -----------------------------------------------------
 # AbstractTensorMap subtyping and IterSVD compatibility
 # -----------------------------------------------------
 
+function TensorKit.storagetype(::Type{HalfInfiniteEnv{TC, TE, TA}}) where {TC, TE, TA}
+    return TensorKit.promote_storagetype(TC, TE, storagetype(TA))
+end
+
+function TensorKit.spacetype(::Type{HalfInfiniteEnv{TC, TE, TA}}) where {TC, TE, TA}
+    return spacetype(TC)
+end
+
 function TensorKit.domain(env::HalfInfiniteEnv)
-    return domain(env.E_4) * _elementwise_dual(south_virtualspace(env.A_2))
+    return domain(env.E_4) * _elementwise_dual(south_virtualspace(env.A_2r))
 end
 
 function TensorKit.codomain(env::HalfInfiniteEnv)
-    return first(codomain(env.E_1)) * south_virtualspace(env.A_1)
+    return first(codomain(env.E_1)) * south_virtualspace(env.A_1r)
 end
 
 function random_start_vector(env::HalfInfiniteEnv)
-    return randn(domain(env))
+    return randn(storagetype(env), domain(env))
 end
 
 # --------------------------------
@@ -225,6 +267,28 @@ struct FullInfiniteEnv{TC, TE, TA}  # TODO: subtype as AbstractTensorMap once Te
     A_2::TA
     A_3::TA
     A_4::TA
+    A_1r::TA
+    A_2r::TA
+    A_3r::TA
+    A_4r::TA
+    dir::Int
+    function FullInfiniteEnv(
+            C_1::TC, C_2::TC, C_3::TC, C_4::TC,
+            E_1::TE, E_2::TE, E_3::TE, E_4::TE, E_5::TE, E_6::TE, E_7::TE, E_8::TE,
+            A_1::TA, A_2::TA, A_3::TA, A_4::TA, dir::Int
+        ) where {TC, TE, TA}
+        A_1r = _rotate_north_localsandwich(A_1, dir)
+        A_2r = _rotate_north_localsandwich(A_2, dir)
+        A_3r = _rotate_north_localsandwich(A_3, dir)
+        A_4r = _rotate_north_localsandwich(A_4, dir)
+        return new{TC, TE, TA}(
+            C_1, C_2, C_3, C_4,
+            E_1, E_2, E_3, E_4, E_5, E_6, E_7, E_8,
+            A_1, A_2, A_3, A_4,
+            A_1r, A_2r, A_3r, A_4r,
+            dir,
+        )
+    end
 end
 function FullInfiniteEnv(
         quadrant1::E, quadrant2::E, quadrant3::E, quadrant4::E
@@ -234,6 +298,7 @@ function FullInfiniteEnv(
         quadrant1.E_1, quadrant1.E_2, quadrant2.E_1, quadrant2.E_2,
         quadrant3.E_1, quadrant3.E_2, quadrant4.E_1, quadrant4.E_2,
         quadrant1.A, quadrant2.A, quadrant3.A, quadrant4.A,
+        quadrant1.dir,
     )
 end
 
@@ -245,8 +310,8 @@ Instantiate full-infinite environment as `TensorMap` explicitly.
 function TensorKit.TensorMap(env::FullInfiniteEnv)  # Dense operator
     return full_infinite_environment(
         env.C_1, env.C_2, env.C_3, env.C_4,
-        env.E_1, env.E_2, env.E_3, env.E_4, env.E_2, env.E_3, env.E_4, env.E_5,
-        env.A_1, env.A_2, env.A_3, env.A_4,
+        env.E_1, env.E_2, env.E_3, env.E_4, env.E_5, env.E_6, env.E_7, env.E_8,
+        env.A_1r, env.A_2r, env.A_3r, env.A_4r,
     )
 end
 
@@ -262,7 +327,7 @@ function (env::FullInfiniteEnv)(x, ::Val{false})  # Linear map: env() * x
         env.C_1, env.C_2, env.C_3, env.C_4,
         env.E_1, env.E_2, env.E_3, env.E_4, env.E_5, env.E_6, env.E_7, env.E_8,
         x,
-        env.A_1, env.A_2, env.A_3, env.A_4,
+        env.A_1r, env.A_2r, env.A_3r, env.A_4r,
     )
 end
 function (env::FullInfiniteEnv)(x, ::Val{true})  # Adjoint linear map: env()' * x
@@ -270,7 +335,7 @@ function (env::FullInfiniteEnv)(x, ::Val{true})  # Adjoint linear map: env()' * 
         x,
         env.C_1, env.C_2, env.C_3, env.C_4,
         env.E_1, env.E_2, env.E_3, env.E_4, env.E_5, env.E_6, env.E_7, env.E_8,
-        env.A_1, env.A_2, env.A_3, env.A_4,
+        env.A_1r, env.A_2r, env.A_3r, env.A_4r,
     )
 end
 
@@ -281,17 +346,45 @@ function full_infinite_environment(
     return FullInfiniteEnv(ec_1, ec_2, ec_3, ec_4)
 end
 
+function contract_projectors(U, S, V, env::FullInfiniteEnv)
+    ndir = _next(env.dir, 4)
+    nndir = _next(ndir, 4)
+    henv = HalfInfiniteEnv(
+        env.C_1, env.C_2,
+        env.E_1, env.E_2, env.E_3, env.E_4,
+        env.A_1, env.A_2, env.dir,
+    )
+    henv_next = HalfInfiniteEnv(
+        env.C_3, env.C_4,
+        env.E_5, env.E_6, env.E_7, env.E_8,
+        env.A_3, env.A_4, nndir,
+    )
+    return contract_projectors(U, S, V, henv, henv_next)
+end
+
+
+# -----------------------------------------------------
 # AbstractTensorMap subtyping and IterSVD compatibility
+# -----------------------------------------------------
+
+function TensorKit.storagetype(::Type{FullInfiniteEnv{TC, TE, TA}}) where {TC, TE, TA}
+    return TensorKit.promote_storagetype(TC, TE, storagetype(TA))
+end
+
+function TensorKit.spacetype(::Type{FullInfiniteEnv{TC, TE, TA}}) where {TC, TE, TA}
+    return spacetype(TC)
+end
+
 function TensorKit.domain(env::FullInfiniteEnv)
-    return domain(env.E_8) * _elementwise_dual(north_virtualspace(env.A_4))
+    return domain(env.E_8) * _elementwise_dual(north_virtualspace(env.A_4r))
 end
 
 function TensorKit.codomain(env::FullInfiniteEnv)
-    return first(codomain(env.E_1)) * south_virtualspace(env.A_1)
+    return first(codomain(env.E_1)) * south_virtualspace(env.A_1r)
 end
 
 function random_start_vector(env::FullInfiniteEnv)
-    return randn(domain(env))
+    return randn(storagetype(env), domain(env))
 end
 
 # -----------------------------

--- a/src/networks/local_sandwich.jl
+++ b/src/networks/local_sandwich.jl
@@ -26,6 +26,10 @@ _rotl90_localsandwich(O) = rotl90.(O)
 _rotr90_localsandwich(O) = rotr90.(O)
 _rot180_localsandwich(O) = rot180.(O)
 
+function _rotate_north_localsandwich(t, dir)
+    return mod1(dir, 4) == NORTH ? t : _rotate_north_localsandwich(_rotl90_localsandwich(t), dir - 1)
+end
+
 ## Math (for Zygote accumulation)
 
 # generic local interface
@@ -67,6 +71,7 @@ flip_physicalspace(O::PEPSSandwich) = flip_physicalspace.(O)
 herm_depth(O::PEPSSandwich) = herm_depth.(O)
 
 TensorKit.spacetype(::Type{P}) where {P <: PEPSSandwich} = spacetype(eltype(P))
+TensorKit.storagetype(::Type{P}) where {P <: PEPSSandwich} = storagetype(eltype(P))
 
 # not overloading MPOTensor because that defines AbstractTensorMap{<:Any,S,2,2}(::PEPSTensor, ::PEPSTensor)
 # ie type piracy
@@ -129,3 +134,6 @@ flip_physicalspace(O::PEPOSandwich) = flip_physicalspace.(O)
 herm_depth(O::PEPOSandwich) = herm_depth.(O)
 
 TensorKit.spacetype(::Type{P}) where {P <: PEPOSandwich} = spacetype(eltype(P))
+function TensorKit.storagetype(::Type{PEPOSandwich{N, T, P}}) where {N, T, P}
+    return TensorKit.promote_storagetype(T, P)
+end

--- a/src/operators/infinitepepo.jl
+++ b/src/operators/infinitepepo.jl
@@ -56,9 +56,9 @@ function InfinitePEPO(
     size(Pspaces) == size(Nspaces) == size(Espaces) ||
         throw(ArgumentError("Input spaces should have equal sizes."))
 
-    Sspaces = adjoint.(circshift(Nspaces, (1, 0, 0)))
-    Wspaces = adjoint.(circshift(Espaces, (0, -1, 0)))
-    Ppspaces = adjoint.(circshift(Pspaces, (0, 0, -1)))
+    Sspaces = adjoint.(circshift(Nspaces, (-1, 0, 0)))
+    Wspaces = adjoint.(circshift(Espaces, (0, 1, 0)))
+    Ppspaces = adjoint.(circshift(Pspaces, (0, 0, 1)))
 
     P = map(Pspaces, Ppspaces, Nspaces, Espaces, Sspaces, Wspaces) do P, Pp, N, E, S, W
         return f(T, P * Pp ← N * E * S * W)

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -135,36 +135,6 @@ function twistnondual!(t::AbstractTensorMap, is)
 end
 twistnondual(t::AbstractTensorMap, is) = twistnondual!(copy(t), is)
 
-# make twistdual and twistnondual differentiable via dummy out-of-place functions
-function _twistdual(t::AbstractTensorMap, i::Int)
-    isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function _twistdual(t::AbstractTensorMap, is)
-    is′ = filter(i -> isdual(space(t, i)), is)
-    return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
-    )
-    tout, twistdual_pullback = rrule_via_ad(config, _twistdual, t, i)
-    return tout, twistdual_pullback
-end
-function _twistnondual(t::AbstractTensorMap, i::Int)
-    !isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function _twistnondual(t::AbstractTensorMap, is)
-    is′ = filter(i -> !isdual(space(t, i)), is)
-    return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
-    )
-    tout, twistnondual_pullback = rrule_via_ad(config, _twistnondual, t, i)
-    return tout, twistnondual_pullback
-end
-
 """
     str(t)
 

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -118,6 +118,53 @@ function twistdual!(t::AbstractTensorMap, is)
 end
 twistdual(t::AbstractTensorMap, is) = twistdual!(copy(t), is)
 
+# lifted from #311, to be removed once that's merged
+"""
+    twistnondual(t::AbstractTensorMap, i)
+    twistnondual!(t::AbstractTensorMap, i)
+
+Twist the i-th leg of a tensor `t` if it represents a non-dual space.
+"""
+function twistnondual!(t::AbstractTensorMap, i::Int)
+    !isdual(space(t, i)) || return t
+    return twist!(t, i)
+end
+function twistnondual!(t::AbstractTensorMap, is)
+    is′ = filter(i -> !isdual(space(t, i)), is)
+    return twist!(t, is′)
+end
+twistnondual(t::AbstractTensorMap, is) = twistnondual!(copy(t), is)
+
+# make twistdual and twistnondual differentiable via dummy out-of-place functions
+function _twistdual(t::AbstractTensorMap, i::Int)
+    isdual(space(t, i)) || return t
+    return twist(t, i)
+end
+function _twistdual(t::AbstractTensorMap, is)
+    is′ = filter(i -> isdual(space(t, i)), is)
+    return twist(t, is′)
+end
+function ChainRulesCore.rrule(
+        config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
+    )
+    tout, twistdual_pullback = rrule_via_ad(config, _twistdual, t, i)
+    return tout, twistdual_pullback
+end
+function _twistnondual(t::AbstractTensorMap, i::Int)
+    !isdual(space(t, i)) || return t
+    return twist(t, i)
+end
+function _twistnondual(t::AbstractTensorMap, is)
+    is′ = filter(i -> !isdual(space(t, i)), is)
+    return twist(t, is′)
+end
+function ChainRulesCore.rrule(
+        config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
+    )
+    tout, twistnondual_pullback = rrule_via_ad(config, _twistnondual, t, i)
+    return tout, twistnondual_pullback
+end
+
 """
     str(t)
 

--- a/test/ctmrg/contractions.jl
+++ b/test/ctmrg/contractions.jl
@@ -13,7 +13,7 @@ using PEPSKit: renormalize_northwest_corner, renormalize_northeast_corner,
 using PEPSKit: random_start_vector
 
 # settings
-Random.seed!(91283219347)
+Random.seed!(91283219348)
 stype = ComplexF64
 
 renormalize_corner_fns = (

--- a/test/ctmrg/contractions.jl
+++ b/test/ctmrg/contractions.jl
@@ -12,13 +12,39 @@ Random.seed!(91283219347)
 stype = ComplexF64
 ctm_alg = SimultaneousCTMRG(; projector_alg = :halfinfinite)
 
-function test_contractions(
+function test_peps_contractions(
         Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
     )
     peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
     env = CTMRGEnv(randn, stype, peps, chis_north, chis_east, chis_south, chis_west)
 
     n = InfiniteSquareNetwork(peps)
+
+    return test_contractions(n, env)
+end
+
+function test_pf_contractions(
+        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    pf = InfinitePartitionFunction(randn, stype, Nspaces, Espaces)
+    env = CTMRGEnv(randn, stype, pf, chis_north, chis_east, chis_south, chis_west)
+    n = InfiniteSquareNetwork(pf)
+
+    return test_contractions(n, env)
+end
+
+function test_pepo_contractions(
+        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    pepo = InfinitePEPO(randn, stype, Pspaces, Pspaces, Pspaces)
+    peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
+    n = InfiniteSquareNetwork(peps, pepo)
+    env = CTMRGEnv(randn, stype, n, chis_north, chis_east, chis_south, chis_west)
+
+    return test_contractions(n, env)
+end
+
+function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
     coordinates = eachcoordinate(n)
     dirs_and_coordinates = eachcoordinate(n, 1:4)
 
@@ -59,7 +85,13 @@ end
     chis_south = ComplexSpace.(rand(5:10, unitcell...))
     chis_west = ComplexSpace.(rand(5:10, unitcell...))
 
-    test_contractions(
+    test_peps_contractions(
+        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    test_pf_contractions(
+        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    test_pepo_contractions(
         Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
     )
 end
@@ -76,7 +108,9 @@ end
     Nspaces = [Vpeps Vpeps'; Vpeps' Vpeps]
     chis = [Venv Venv; Venv Venv]
 
-    test_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_peps_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_pf_contractions(Nspaces, Nspaces, chis, chis, chis, chis)
+    test_pepo_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
 
     # 4x4 unit cell with all 32 inequivalent bonds
     #
@@ -119,5 +153,41 @@ end
     Pspaces = fill(phys_space, (4, 4))
     chis = fill(corner_space, (4, 4))
 
-    test_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_peps_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_pf_contractions(Nspaces, Nspaces, chis, chis, chis, chis)
+    test_pepo_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+end
+
+@testset "Random fermionic spaces" begin
+    unitcell = (3, 3)
+
+    S = Vect[FermionParity]
+    pdims = rand(2:3, unitcell..., 2)
+    vdims = rand(2:4, unitcell..., 2)
+    edims = rand(5:10, unitcell..., 2)
+
+    function _construct_space(ds::Array{<:Int, 3})
+        V = map(Iterators.product(axes(ds)[1:2]...)) do (r, c)
+            return S(0 => ds[r, c, 1], 1 => ds[r, c, 2])
+        end
+        return V
+    end
+
+    Pspaces = _construct_space(pdims)
+    Nspaces = _construct_space(vdims)
+    Espaces = _construct_space(vdims)
+    chis_north = _construct_space(edims)
+    chis_east = _construct_space(edims)
+    chis_south = _construct_space(edims)
+    chis_west = _construct_space(edims)
+
+    test_peps_contractions(
+        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    test_pf_contractions(
+        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
+    test_pepo_contractions(
+        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
+    )
 end

--- a/test/ctmrg/contractions.jl
+++ b/test/ctmrg/contractions.jl
@@ -119,7 +119,7 @@ function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
 
     # check projector computation for both types of environments,
     # comparing dense and sparse implementations
-    return foreach(dirs_and_coordinates) do co
+    foreach(dirs_and_coordinates) do co
         dir, r, c = co
 
         co2 = _next_coordinate(co, size(env)[2:3]...)
@@ -185,19 +185,21 @@ function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
         @test P_right_sparse ≈ P_right_full[dir, r, c]
     end
 
-    return foreach(dirs_and_coordinates) do co
+    foreach(dirs_and_coordinates) do co
         dir, r, c = co
 
         ## Corner renormalization
 
         C_sparse = renormalize_corner_fns[dir](
-            (r, c), sparse_enlarged_corners, P_left, P_right
+            (r, c), sparse_enlarged_corners, P_left_half, P_right_half
         )
         C_dense = renormalize_corner_fns[dir](
-            (r, c), dense_enlarged_corners, P_left, P_right
+            (r, c), dense_enlarged_corners, P_left_half, P_right_half
         )
         @test C_sparse ≈ C_dense
     end
+
+    return nothing
 end
 
 @testset "Random Cartesian spaces" begin

--- a/test/ctmrg/contractions.jl
+++ b/test/ctmrg/contractions.jl
@@ -2,50 +2,59 @@ using Test
 using Random
 using PEPSKit
 using TensorKit
+using TensorOperations: tensorcontract
 
-using PEPSKit: eachcoordinate
-using PEPSKit: EnlargedCorner, simultaneous_projectors
-using PEPSKit: renormalize_northwest_corner, renormalize_northeast_corner, renormalize_southeast_corner, renormalize_southwest_corner
+using PEPSKit: eachcoordinate, _next_coordinate
+using PEPSKit: EnlargedCorner, HalfInfiniteEnv, FullInfiniteEnv
+using PEPSKit: half_infinite_environment, full_infinite_environment
+using PEPSKit: simultaneous_projectors, contract_projectors
+using PEPSKit: renormalize_northwest_corner, renormalize_northeast_corner,
+    renormalize_southeast_corner, renormalize_southwest_corner
+using PEPSKit: random_start_vector
 
 # settings
 Random.seed!(91283219347)
 stype = ComplexF64
-ctm_alg = SimultaneousCTMRG(; projector_alg = :halfinfinite)
 
-function test_peps_contractions(
+renormalize_corner_fns = (
+    renormalize_northwest_corner, renormalize_northeast_corner,
+    renormalize_southeast_corner, renormalize_southwest_corner,
+)
+
+function test_ctmrg_contractions(
         Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
     )
-    peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
-    env = CTMRGEnv(randn, stype, peps, chis_north, chis_east, chis_south, chis_west)
 
-    n = InfiniteSquareNetwork(peps)
+    @testset "CTMRG PEPS contractions" begin
+        peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
+        env = CTMRGEnv(randn, stype, peps, chis_north, chis_east, chis_south, chis_west)
 
-    return test_contractions(n, env)
-end
+        n = InfiniteSquareNetwork(peps)
 
-function test_pf_contractions(
-        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    pf = InfinitePartitionFunction(randn, stype, Nspaces, Espaces)
-    env = CTMRGEnv(randn, stype, pf, chis_north, chis_east, chis_south, chis_west)
-    n = InfiniteSquareNetwork(pf)
+        test_contractions(n, env)
+    end
 
-    return test_contractions(n, env)
-end
+    @testset "CTMRG PartitionFunction contractions" begin
+        pf = InfinitePartitionFunction(randn, stype, Nspaces, Espaces)
+        env = CTMRGEnv(randn, stype, pf, chis_north, chis_east, chis_south, chis_west)
+        n = InfiniteSquareNetwork(pf)
 
-function test_pepo_contractions(
-        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    pepo = InfinitePEPO(randn, stype, Pspaces, Pspaces, Pspaces)
-    peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
-    n = InfiniteSquareNetwork(peps, pepo)
-    env = CTMRGEnv(randn, stype, n, chis_north, chis_east, chis_south, chis_west)
+        test_contractions(n, env)
+    end
 
-    return test_contractions(n, env)
+    @testset "CTMRG PEPO contractions" begin
+        pepo = InfinitePEPO(randn, stype, Pspaces, Pspaces, Pspaces)
+        peps = InfinitePEPS(randn, stype, Pspaces, Nspaces, Espaces)
+        n = InfiniteSquareNetwork(peps, pepo)
+        env = CTMRGEnv(randn, stype, n, chis_north, chis_east, chis_south, chis_west)
+
+        test_contractions(n, env)
+    end
+
+    return nothing
 end
 
 function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
-    coordinates = eachcoordinate(n)
     dirs_and_coordinates = eachcoordinate(n, 1:4)
 
     # initialize dense and sparse enlarged corners
@@ -54,24 +63,141 @@ function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
     end
     dense_enlarged_corners = map(TensorMap, sparse_enlarged_corners)
 
-    # compute projectors (doesn't matter how)
-    (P_left, P_right), info = simultaneous_projectors(
-        dense_enlarged_corners, env, ctm_alg.projector_alg
-    )
-
-    # test corner renormalization
-    return foreach(coordinates) do (r, c)
-        for renormalize_f in (
-                renormalize_northwest_corner, renormalize_northeast_corner,
-                renormalize_southeast_corner, renormalize_southwest_corner,
-            )
-            C_sparse = renormalize_f((r, c), sparse_enlarged_corners, P_left, P_right)
-            C_dense = renormalize_f((r, c), dense_enlarged_corners, P_left, P_right)
-            @test C_sparse ≈ C_dense
-        end
+    # initialize sparse and dense half-inifite environments
+    sparse_halfinf_envs = map(dirs_and_coordinates) do co
+        co´ = _next_coordinate(co, size(env)[2:3]...)
+        return HalfInfiniteEnv(
+            sparse_enlarged_corners[co...], sparse_enlarged_corners[co´...]
+        )
+    end
+    dense_halfinf_envs = map(TensorMap, sparse_halfinf_envs)
+    # also compute directly from dense enlarged corners, for consistency with current implementation
+    dense_halfinf_envs_bis = map(dirs_and_coordinates) do co
+        co´ = _next_coordinate(co, size(env)[2:3]...)
+        return half_infinite_environment(
+            dense_enlarged_corners[co...], dense_enlarged_corners[co´...]
+        )
     end
 
-    # TODO: test all other uncovered contracitions
+    # initialize sparse and dense full-inifite environments
+    sparse_fullinf_envs = map(dirs_and_coordinates) do co
+        rowsize, colsize = size(env)[2:3]
+        co2 = _next_coordinate(co, rowsize, colsize)
+        co3 = _next_coordinate(co2, rowsize, colsize)
+        co4 = _next_coordinate(co3, rowsize, colsize)
+        return FullInfiniteEnv(
+            sparse_enlarged_corners[co4...],
+            sparse_enlarged_corners[co...],
+            sparse_enlarged_corners[co2...],
+            sparse_enlarged_corners[co3...],
+        )
+    end
+    dense_fullinf_envs = map(TensorMap, sparse_fullinf_envs)
+    # also compute directly from dense enlarged corners, for consistency with current implementation
+    dense_fullinf_envs_bis = map(dirs_and_coordinates) do co
+        rowsize, colsize = size(env)[2:3]
+        co2 = _next_coordinate(co, rowsize, colsize)
+        co3 = _next_coordinate(co2, rowsize, colsize)
+        co4 = _next_coordinate(co3, rowsize, colsize)
+        return full_infinite_environment(
+            dense_enlarged_corners[co4...],
+            dense_enlarged_corners[co...],
+            dense_enlarged_corners[co2...],
+            dense_enlarged_corners[co3...],
+        )
+    end
+
+    # SVD half and full infinite environments
+    (P_left_half, P_right_half), info_half = simultaneous_projectors(
+        dense_enlarged_corners, env, HalfInfiniteProjector()
+    )
+    U_half, S_half, V_half = info_half.U, info_half.S, info_half.V
+    (P_left_full, P_right_full), info_full = simultaneous_projectors(
+        dense_enlarged_corners, env, FullInfiniteProjector()
+    )
+    U_full, S_full, V_full = info_full.U, info_full.S, info_full.V
+
+    # check projector computation for both types of environments,
+    # comparing dense and sparse implementations
+    return foreach(dirs_and_coordinates) do co
+        dir, r, c = co
+
+        co2 = _next_coordinate(co, size(env)[2:3]...)
+        co3 = _next_coordinate(co2, size(env)[2:3]...)
+        co4 = _next_coordinate(co3, size(env)[2:3]...)
+
+        ## HalfInfiniteEnv
+
+        shenv = sparse_halfinf_envs[dir, r, c]
+        dhenv = dense_halfinf_envs[dir, r, c]
+        dhenv_bis = dense_halfinf_envs_bis[dir, r, c]
+        @test dhenv ≈ dhenv_bis
+
+        # application
+        xr = random_start_vector(shenv)
+        xl = randn(storagetype(shenv), codomain(shenv))
+        @test shenv(xr, Val(false)) ≈ half_infinite_environment(dhenv, xr)
+        @test shenv(xl, Val(true)) ≈ half_infinite_environment(xl, dhenv)
+
+        # projector computation
+        P_left_sparse, P_right_sparse = contract_projectors(
+            U_half[dir, r, c], S_half[dir, r, c], V_half[dir, r, c], shenv
+        )
+        P_left_dense, P_right_dense = contract_projectors(
+            U_half[dir, r, c], S_half[dir, r, c], V_half[dir, r, c],
+            dense_enlarged_corners[co...], dense_enlarged_corners[co2...],
+        )
+        @test P_left_sparse ≈ P_left_dense
+        @test P_right_sparse ≈ P_right_dense
+        @test P_left_sparse ≈ P_left_half[dir, r, c]
+        @test P_right_sparse ≈ P_right_half[dir, r, c]
+
+
+        ## FullInfiniteEnv
+
+        sfenv = sparse_fullinf_envs[dir, r, c]
+        dfenv = dense_fullinf_envs[dir, r, c]
+        dfenv_bis = dense_fullinf_envs_bis[dir, r, c]
+        @test dfenv ≈ dfenv_bis
+
+        # application
+        xl = randn(storagetype(sfenv), codomain(sfenv))
+        xr = random_start_vector(sfenv)
+        @test sfenv(xr, Val(false)) ≈ full_infinite_environment(dfenv, xr)
+        @test sfenv(xl, Val(true)) ≈ full_infinite_environment(xl, dfenv)
+
+        # projector computation
+        P_left_sparse, P_right_sparse = contract_projectors(
+            U_full[dir, r, c], S_full[dir, r, c], V_full[dir, r, c], sfenv
+        )
+        P_left_dense, P_right_dense = contract_projectors(
+            U_full[dir, r, c], S_full[dir, r, c], V_full[dir, r, c],
+            half_infinite_environment(
+                dense_enlarged_corners[co4...], dense_enlarged_corners[co...]
+            ),
+            half_infinite_environment(
+                dense_enlarged_corners[co2...], dense_enlarged_corners[co3...]
+            ),
+        )
+        @test P_left_sparse ≈ P_left_dense
+        @test P_right_sparse ≈ P_right_dense
+        @test P_left_sparse ≈ P_left_full[dir, r, c]
+        @test P_right_sparse ≈ P_right_full[dir, r, c]
+    end
+
+    return foreach(dirs_and_coordinates) do co
+        dir, r, c = co
+
+        ## Corner renormalization
+
+        C_sparse = renormalize_corner_fns[dir](
+            (r, c), sparse_enlarged_corners, P_left, P_right
+        )
+        C_dense = renormalize_corner_fns[dir](
+            (r, c), dense_enlarged_corners, P_left, P_right
+        )
+        @test C_sparse ≈ C_dense
+    end
 end
 
 @testset "Random Cartesian spaces" begin
@@ -85,13 +211,7 @@ end
     chis_south = ComplexSpace.(rand(5:10, unitcell...))
     chis_west = ComplexSpace.(rand(5:10, unitcell...))
 
-    test_peps_contractions(
-        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    test_pf_contractions(
-        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    test_pepo_contractions(
+    test_ctmrg_contractions(
         Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
     )
 end
@@ -108,9 +228,7 @@ end
     Nspaces = [Vpeps Vpeps'; Vpeps' Vpeps]
     chis = [Venv Venv; Venv Venv]
 
-    test_peps_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
-    test_pf_contractions(Nspaces, Nspaces, chis, chis, chis, chis)
-    test_pepo_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_ctmrg_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
 
     # 4x4 unit cell with all 32 inequivalent bonds
     #
@@ -153,18 +271,16 @@ end
     Pspaces = fill(phys_space, (4, 4))
     chis = fill(corner_space, (4, 4))
 
-    test_peps_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
-    test_pf_contractions(Nspaces, Nspaces, chis, chis, chis, chis)
-    test_pepo_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
+    test_ctmrg_contractions(Pspaces, Nspaces, Nspaces, chis, chis, chis, chis)
 end
 
 @testset "Random fermionic spaces" begin
     unitcell = (3, 3)
 
     S = Vect[FermionParity]
-    pdims = rand(2:3, unitcell..., 2)
+    pdims = rand(1:2, unitcell..., 2)
     vdims = rand(2:4, unitcell..., 2)
-    edims = rand(5:10, unitcell..., 2)
+    edims = rand(3:6, unitcell..., 2)
 
     function _construct_space(ds::Array{<:Int, 3})
         V = map(Iterators.product(axes(ds)[1:2]...)) do (r, c)
@@ -181,13 +297,7 @@ end
     chis_south = _construct_space(edims)
     chis_west = _construct_space(edims)
 
-    test_peps_contractions(
-        Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    test_pf_contractions(
-        Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
-    )
-    test_pepo_contractions(
+    test_ctmrg_contractions(
         Pspaces, Nspaces, Espaces, chis_north, chis_east, chis_south, chis_west,
     )
 end

--- a/test/ctmrg/contractions.jl
+++ b/test/ctmrg/contractions.jl
@@ -136,8 +136,8 @@ function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
         # application
         xr = random_start_vector(shenv)
         xl = randn(storagetype(shenv), codomain(shenv))
-        @test shenv(xr, Val(false)) ≈ half_infinite_environment(dhenv, xr)
-        @test shenv(xl, Val(true)) ≈ half_infinite_environment(xl, dhenv)
+        @test shenv(xr, Val(false)) ≈ dhenv * xr
+        @test shenv(xl, Val(true)) ≈ dhenv' * xl
 
         # projector computation
         P_left_sparse, P_right_sparse = contract_projectors(
@@ -163,8 +163,8 @@ function test_contractions(n::InfiniteSquareNetwork, env::CTMRGEnv)
         # application
         xl = randn(storagetype(sfenv), codomain(sfenv))
         xr = random_start_vector(sfenv)
-        @test sfenv(xr, Val(false)) ≈ full_infinite_environment(dfenv, xr)
-        @test sfenv(xl, Val(true)) ≈ full_infinite_environment(xl, dfenv)
+        @test sfenv(xr, Val(false)) ≈ dfenv * xr
+        @test sfenv(xl, Val(true)) ≈ dfenv' * xl
 
         # projector computation
         P_left_sparse, P_right_sparse = contract_projectors(


### PR DESCRIPTION
Adds coverage for all of the sparse CTMRG contractions that were previously untested, by directly comparing their results to the dense equivalents. Quite a few of these were broken or even missing, so I fixed things up where necessary and added the missing parts so that we can actually do everything we would need using sparse environments.

There's one part that's a bit unclear to me, in the application of a (half or full infinite) environment to a vector, which I think we plan to use for fully matrix-free sparse SVDs in the future. There I'm not sure if for the "right" action we need the contraction `tensorcontract(env, x)` or the multiplication `env * x` instead, and the same for the "left" action. ~~I chose contraction for now since that was the easiest and there is currently no use case to check this on. But if we need multiplication we'll have to add some additional twists.~~ If we want the use of `svdsolve` to correspond to an `svd_trunc` on the dense environment, then application should correspond to proper tensor composition, so `env * x`. I updated the implementation and test accordingly.