### PR TITLE
Move `trunc` out of bond truncation algorithm

### DIFF
--- a/src/algorithms/truncation/bond_truncation.jl
+++ b/src/algorithms/truncation/bond_truncation.jl
@@ -13,13 +13,11 @@ $(TYPEDFIELDS)
 
 The truncation algorithm can be constructed from the following keyword arguments:
 
-* `trunc::TruncationStrategy`: SVD truncation strategy when initilizing the truncated tensors connected by the bond.
 * `maxiter::Int=50` : Maximal number of ALS iterations.
 * `tol::Float64=1e-9` : ALS converges when the relative change in bond SVD spectrum between two iterations is smaller than `tol`.
 * `check_interval::Int=0` : Set number of iterations to print information. Output is suppressed when `check_interval <= 0`. 
 """
 @kwdef struct ALSTruncation
-    trunc::TruncationStrategy
     maxiter::Int = 50
     tol::Float64 = 1.0e-9
     check_interval::Int = 0
@@ -35,7 +33,10 @@ function _als_message(
 end
 
 """
-    bond_truncate(a::AbstractTensorMap{T,S,2,1}, b::AbstractTensorMap{T,S,1,2}, benv::BondEnv{T,S}, alg) -> U, S, V, info
+    bond_truncate(
+        a::AbstractTensorMap{T,S,2,1}, b::AbstractTensorMap{T,S,1,2},
+        benv::BondEnv{T,S}, trunc::TruncationStrategy, alg
+    ) -> U, S, V, info
 
 After time-evolving the reduced tensors `a` and `b` connected by a bond, 
 truncate the bond dimension using the bond environment tensor `benv`.
@@ -60,7 +61,7 @@ function bond_truncate(
         a::AbstractTensorMap{T, S, 2, 1},
         b::AbstractTensorMap{T, S, 1, 2},
         benv::BondEnv{T, S},
-        alg::ALSTruncation,
+        trunc::TruncationStrategy, alg::ALSTruncation,
     ) where {T <: Number, S <: ElementarySpace}
     # dual check of physical index
     @assert !isdual(space(a, 2))
@@ -72,7 +73,7 @@ function bond_truncate(
     a2b2 = _combine_ab(a, b)
     # initialize truncated a, b
     perm_ab = ((1, 3), (4, 2))
-    a, s0, b = svd_trunc(permute(a2b2, perm_ab); trunc = alg.trunc)
+    a, s0, b = svd_trunc(permute(a2b2, perm_ab); trunc)
     a, b = absorb_s(a, s0, b)
     # put b in MPS axis order
     b = permute(b, ((1, 2), (3,)))
@@ -102,7 +103,7 @@ function bond_truncate(
         ab = _combine_ab(a, b)
         cost, fid = cost_function_als(benv, ab, a2b2)
         # TODO: replace with truncated svdvals (without calculating u, vh)
-        _, s, _ = svd_trunc!(permute(ab, perm_ab); trunc = alg.trunc)
+        _, s, _ = svd_trunc!(permute(ab, perm_ab); trunc)
         # fidelity, cost and normalized bond-s change
         s_nrm = norm(s0, Inf)
         Δs = _singular_value_distance(s, s0) / s_nrm
@@ -129,7 +130,7 @@ function bond_truncate(
         end
         converge && break
     end
-    a, s, b = svd_trunc!(permute(_combine_ab(a, b), perm_ab); trunc = alg.trunc)
+    a, s, b = svd_trunc!(permute(_combine_ab(a, b), perm_ab); trunc)
     a, b = absorb_s(a, s, b)
     if need_flip
         a, s, b = flip(a, numind(a)), _fliptwist_s(s), flip(b, 1)
@@ -141,7 +142,7 @@ function bond_truncate(
         a::AbstractTensorMap{T, S, 2, 1},
         b::AbstractTensorMap{T, S, 1, 2},
         benv::BondEnv{T, S},
-        alg::FullEnvTruncation,
+        trunc::TruncationStrategy, alg::FullEnvTruncation,
     ) where {T <: Number, S <: ElementarySpace}
     # dual check of physical index
     @assert !isdual(space(a, 2))
@@ -173,7 +174,7 @@ function bond_truncate(
         benv[1 2; 3 4] * conj(Qa[1 5 -1]) * conj(Qb[-2 6 2]) * Qa[3 5 -3] * Qb[-4 6 4]
     )
     # optimize bond matrix
-    u, s, vh, info = fullenv_truncate(b0, benv2, alg)
+    u, s, vh, info = fullenv_truncate(b0, benv2, trunc, alg)
     u, vh = absorb_s(u, s, vh)
     # truncate a, b tensors with u, s, vh
     @tensor a[-1 -2; -3] := Qa[-1 -2 3] * u[3 -3]

--- a/src/algorithms/truncation/fullenv_truncation.jl
+++ b/src/algorithms/truncation/fullenv_truncation.jl
@@ -13,7 +13,6 @@ $(TYPEDFIELDS)
 
 The truncation algorithm can be constructed from the following keyword arguments:
 
-* `trunc::TruncationStrategy` : SVD truncation strategy when optimizing the new bond matrix.
 * `maxiter::Int=50` : Maximal number of FET iterations.
 * `tol::Float64=1e-9` : FET converges when the relative change in bond SVD spectrum between two FET iterations is smaller than `tol`.
 * `trunc_init::Bool=true` : Controls whether the initialization of the new bond matrix is obtained from truncated SVD of the old bond matrix. 
@@ -24,7 +23,6 @@ The truncation algorithm can be constructed from the following keyword arguments
 * [Glen Evenbly, Phys. Rev. B 98, 085155 (2018)](@cite evenbly_gauge_2018). 
 """
 @kwdef struct FullEnvTruncation
-    trunc::TruncationStrategy
     maxiter::Int = 50
     tol::Float64 = 1.0e-9
     trunc_init::Bool = true
@@ -75,7 +73,10 @@ function _fet_message(
 end
 
 """
-    fullenv_truncate(benv::BondEnv{T,S}, b0::AbstractTensorMap{T,S,1,1}, alg::FullEnvTruncation) -> U, S, V, info
+    fullenv_truncate(
+        benv::BondEnv{T,S}, b0::AbstractTensorMap{T,S,1,1},
+        trunc::TruncationStrategy, alg::FullEnvTruncation
+    ) -> U, S, V, info
 
 Perform full environment truncation algorithm from
 [Phys. Rev. B 98, 085155 (2018)](@cite evenbly_gauge_2018) on `benv`.
@@ -204,14 +205,15 @@ Returns the SVD result of the new bond matrix `U`, `S`, `V`, as well as an infor
 * `Δs` : Last singular value difference.
 """
 function fullenv_truncate(
-        b0::AbstractTensorMap{T, S, 1, 1}, benv::BondEnv{T, S}, alg::FullEnvTruncation
+        b0::AbstractTensorMap{T, S, 1, 1}, benv::BondEnv{T, S},
+        trunc::TruncationStrategy, alg::FullEnvTruncation
     ) where {T <: Number, S <: ElementarySpace}
     verbose = (alg.check_interval > 0)
     # `benv` is assumed to be positive; here we only check codomain(benv) == domain(benv).
     @assert codomain(benv) == domain(benv)
     time00 = time()
     # initialize u, s, vh with truncated or untruncated SVD
-    u, s, vh = svd_trunc(b0; trunc = (alg.trunc_init ? alg.trunc : notrunc()))
+    u, s, vh = svd_trunc(b0; trunc = (alg.trunc_init ? trunc : notrunc()))
     b1 = similar(b0)
     s0 = deepcopy(s)
     Δfid, Δs, fid, fid0 = NaN, NaN, 0.0, 0.0
@@ -225,7 +227,7 @@ function fullenv_truncate(
         _linearmap_twist!(B)
         r, info_r = linsolve(Base.Fix1(*, B), p, r, 0, 1)
         @tensor b1[-1; -2] = u[-1; 1] * r[1 -2]
-        u, s, vh = svd_trunc(b1; trunc = alg.trunc)
+        u, s, vh = svd_trunc(b1; trunc)
         # update `- l ←  =  - u ← s ←`
         @tensor l[-1 -2] := u[-1; 1] * s[1; -2]
         @tensor p[-1 -2] := conj(vh[-2; 2]) * benv[-1 2; 3 4] * b0[3; 4]
@@ -236,7 +238,7 @@ function fullenv_truncate(
         @debug "Bond truncation info" info_l info_r
         @tensor b1[-1; -2] = l[-1 1] * vh[1; -2]
         _, fid = cost_function_als(benv, b0, b1)
-        u, s, vh = svd_trunc!(b1; trunc = alg.trunc)
+        u, s, vh = svd_trunc!(b1; trunc)
         # determine convergence
         s_nrm = norm(s0, Inf)
         Δs = _singular_value_distance(s, s0) / s_nrm

--- a/test/bondenv/bond_truncate.jl
+++ b/test/bondenv/bond_truncate.jl
@@ -26,16 +26,16 @@ for Vbondl in (Vint, Vint'), Vbondr in (Vint, Vint')
     a2, s, b2 = svd_compact(permute(a2b2, perm_ab))
     a2, b2 = PEPSKit.absorb_s(a2, s, b2)
     # bond tensor (truncated SVD initialization)
-    a0, s, b0 = svd_trunc(permute(a2b2, perm_ab); trunc = trunc)
+    a0, s, b0 = svd_trunc(permute(a2b2, perm_ab); trunc)
     a0, b0 = PEPSKit.absorb_s(a0, s, b0)
     fid0 = cost_function_als(benv, PEPSKit._combine_ab(a0, b0), a2b2)[2]
     @info "Fidelity of simple SVD truncation = $fid0.\n"
     ss = Dict{String, DiagonalTensorMap}()
     for (label, alg) in (
-            ("ALS", ALSTruncation(; trunc, maxiter, check_interval)),
-            ("FET", FullEnvTruncation(; trunc, maxiter, check_interval, trunc_init = false)),
+            ("ALS", ALSTruncation(; maxiter, check_interval)),
+            ("FET", FullEnvTruncation(; maxiter, check_interval, trunc_init = false)),
         )
-        a1, ss[label], b1, info = PEPSKit.bond_truncate(a2, b2, benv, alg)
+        a1, ss[label], b1, info = PEPSKit.bond_truncate(a2, b2, benv, trunc, alg)
         @info "$label improved fidelity = $(info.fid)."
         # display(ss[label])
         @test info.fid ≈ cost_function_als(benv, PEPSKit._combine_ab(a1, b1), a2b2)[2]


### PR DESCRIPTION
This PR moves `trunc::TruncationStrategy` out of bond truncation algorithms `ALSTruncation` and `FullEnvTruncation`. 

The motivation is to make supporting `FixedSpaceTruncation` and `SiteDependentTruncation` in NTU (#144) easier, so I don't need to reconstruct the bond truncation algorithm struct every time I switch the bond to be truncated (since each bond have a different `trunc`).