### PR TITLE
Update `info` in `leading_boundary` output for CTMRG

### DIFF
--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -88,10 +88,11 @@ supplied via the keyword arguments or directly as an [`CTMRGAlgorithm`](@ref) st
 
 ## Return values
 
-The `leading_boundary` routine returns the final environment as well as an information `NamedTuple`
-that generally contains a `contraction_metrics` `NamedTuple` storing different contents depending
-on the chosen `alg`. Depending on the contraction method, the information tuple may also contain
-the final tensor decomposition (used in the projectors) including its truncation indices.
+* `env` : The final environment.
+* `info` : A `NamedTuple` containing information about the `leading_boundary` convergence, which has the following fields:
+    - `info.converged::Bool` : Convergence flag indicating whether the contraction converged within `maxiter` and `tol`.
+    - `info.convergence_error::Real` : The final convergence error at the end of the contraction procedure.
+    - `info.contraction_metrics::NamedTuple` : A `NamedTuple` containing metrics which characterize the contraction. The precise contents depend on `alg`.
 """
 function leading_boundary(env₀::CTMRGEnv, network::InfiniteSquareNetwork; kwargs...)
     alg = select_algorithm(leading_boundary, env₀; kwargs...)
@@ -109,13 +110,15 @@ function leading_boundary(
         end
         η = one(real(scalartype(network)))
         ctmrg_loginit!(log, η, network, env₀)
-        local info
+        local info_iter
+        converged = false
         for iter in 1:(alg.maxiter)
-            env, info = ctmrg_iteration(network, env, alg)
+            env, info_iter = ctmrg_iteration(network, env, alg)
             η, CS, TS = calc_convergence(env, CS, TS)
 
             if η ≤ alg.tol && iter ≥ alg.miniter
                 ctmrg_logfinish!(log, iter, η, network, env)
+                converged = true
                 break
             end
             if iter == alg.maxiter
@@ -124,6 +127,11 @@ function leading_boundary(
                 ctmrg_logiter!(log, iter, η, network, env)
             end
         end
+        info = (;
+            converged,
+            convergence_error = η,
+            contraction_metrics = info_iter.contraction_metrics,
+        )
         return env, info
     end
 end


### PR DESCRIPTION
Addresses #354. Changes the contents of the `info` named tuple returned by the CTMRG `leading_boundary` to now include:
- `info.converged::Bool`: Boolean flag indicating whether or not the `leading_boundary` run converged to the requested `tol` within the specified `maxiter`.
- `info.convergence_error::Real`: Convergence error after the final iteration of the `leading_boundary` run.

In addition, I would suggest we remove the intermediate objects used in the contraction algorithm (`U`/`S`/`V` for asymmetric CTMRG, `V`/`D` for eigh-C4vCTMRG, `Q`/`R` for QR-C4vCTMRG from the output `info`. This is all extremely specific to the algorithm being used, and as far as I can tell this output is never actually used. I left in the `contraction_metrics` field, since these metrics do seem useful.

The only place where this output is used is in the `info` returned by a single `ctmrg_iteration` (specifically for gauge fixing). That makes much more sense to me, since these decompositions are really intermediate objects in a single iteration. So it makes sense to keep them there. Let me know what you think about removing the decompositions from the `info` output of `leading_boundary` @pbrehmer.