### PR TITLE
Do not sort `sites` for all LocalCircuit gates

### DIFF
--- a/src/operators/localcircuit.jl
+++ b/src/operators/localcircuit.jl
@@ -46,6 +46,7 @@ function add_factor!(operator::LocalCircuit, inds::Vector{CartesianIndex{2}}, te
         physicalspace(operator, ind_translated) == domain(term)[i] == codomain(term)[i] ||
             throw(SpaceMismatch("Incompatible physical spaces at $(ind)."))
     end
+    _shift_into_unitcell!(inds, size(operator))
     push!(operator.gates, inds => term)
     return operator
 end
@@ -69,6 +70,7 @@ function add_factor!(
             sum(Tuple(ind - ind_prev) .^ 2) == 1 || throw(ArgumentError("Two consecutive sites in `inds` must be nearest neighbours for MPO terms."))
         end
     end
+    _shift_into_unitcell!(inds, size(operator))
     push!(operator.gates, inds => term)
     return operator
 end

--- a/src/operators/localcircuit.jl
+++ b/src/operators/localcircuit.jl
@@ -11,7 +11,8 @@ struct LocalCircuit{O, S}
     "lattice of physical spaces on which the gates act"
     lattice::Matrix{S}
 
-    "list of `sites => gate` pairs that make up the circuit"
+    "list of `sites => gate` pairs that make up the circuit.
+    `sites` is not required to be sorted."
     gates::Vector{Pair{Vector{CartesianIndex{2}}, O}}
 
     LocalCircuit{O, S}(lattice::Matrix{S}) where {O, S} =
@@ -45,12 +46,6 @@ function add_factor!(operator::LocalCircuit, inds::Vector{CartesianIndex{2}}, te
         physicalspace(operator, ind_translated) == domain(term)[i] == codomain(term)[i] ||
             throw(SpaceMismatch("Incompatible physical spaces at $(ind)."))
     end
-    # permute input
-    if !issorted(inds)
-        I = sortperm(inds)
-        inds = inds[I]
-        term = permute(term, (Tuple(I), Tuple(I) .+ numout(term)))
-    end
     # translate coordinates
     I1 = first(inds)
     I1_mod = CartesianIndex(mod1.(Tuple(I1), size(operator)))
@@ -78,7 +73,6 @@ function add_factor!(
             sum(Tuple(ind - ind_prev) .^ 2) == 1 || throw(ArgumentError("Two consecutive sites in `inds` must be nearest neighbours for MPO terms."))
         end
     end
-    # for MPO term, `inds` should not be sorted
     push!(operator.gates, inds => term)
     return operator
 end

--- a/src/operators/localcircuit.jl
+++ b/src/operators/localcircuit.jl
@@ -46,10 +46,6 @@ function add_factor!(operator::LocalCircuit, inds::Vector{CartesianIndex{2}}, te
         physicalspace(operator, ind_translated) == domain(term)[i] == codomain(term)[i] ||
             throw(SpaceMismatch("Incompatible physical spaces at $(ind)."))
     end
-    # translate coordinates
-    I1 = first(inds)
-    I1_mod = CartesianIndex(mod1.(Tuple(I1), size(operator)))
-    inds .-= (I1 - I1_mod)
     push!(operator.gates, inds => term)
     return operator
 end

--- a/src/operators/localoperator.jl
+++ b/src/operators/localoperator.jl
@@ -76,9 +76,7 @@ function add_term!(
     end
 
     # translate coordinates
-    I1 = first(inds)
-    I1_mod = CartesianIndex(mod1.(Tuple(I1), size(operator)))
-    inds .-= (I1 - I1_mod)
+    _shift_into_unitcell!(inds, size(operator))
 
     if haskey(operator.terms, inds)
         operator.terms[inds] = VI.add!!(operator.terms[inds], term)

--- a/src/utility/indexing.jl
+++ b/src/utility/indexing.jl
@@ -2,6 +2,19 @@
 _next(i, total) = mod1(i + 1, total)
 _prev(i, total) = mod1(i - 1, total)
 
+"""
+Shift the first of `inds` into the unit cell
+(with size `unitcell`) by a lattice translation.
+"""
+function _shift_into_unitcell!(
+        inds::Vector{CartesianIndex{N}}, unitcell::NTuple{N, Int}
+    ) where {N}
+    I1 = first(inds)
+    I1_mod = CartesianIndex(mod1.(Tuple(I1), unitcell))
+    inds .-= (I1 - I1_mod)
+    return inds
+end
+
 @inline _periodic_inds(data, J::NTuple{N, Int}) where {N} =
     ntuple(i -> mod1(J[i], size(data, i)), Val(N))
 


### PR DESCRIPTION
I feel that there is no reason to sort the sites to be acted on by a gate in `LocalCircuit`. ~Also, with periodic indexing (#377), there is also no need to move the `AbstractTensorMap` gates inside the unit cell, to be more consistent with how MPO gates are handled.~