### PR TITLE
Reduce C4v breaking in time evolution (again)

### DIFF
--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -126,7 +126,7 @@ function _trotterize_nnn2site!(gates::Vector, H::LocalOperator, dt::Number)
         (origin, CartesianIndex(1, 0), CartesianIndex(1, 1))
     ]
     Nr = size(H, 1)
-    for x in CartesianIndices(size(H)), (dir, v) in enumerate(vs)
+    for (dir, v) in enumerate(vs), x in CartesianIndices(size(H))
         x′ = if dir == NORTHEAST || dir == SOUTHWEST
             x
         else

--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -19,14 +19,14 @@ function gate_to_mpo(
     Os = map(MPSKit.decompose_localmpo(MPSKit.add_util_leg(gate), trunc)) do O
         return permute(O, ((1, 2, 3), (4,)))
     end
+    # convert to Vidal gauge
+    _cluster_truncate!(Os, fill(notrunc(), N - 1))
     # evenly distribute the (Inf) norm
     nrms = norm.(Os, Inf)
     fac = prod(nrms)^(1 / N)
     for (i, nrm) in enumerate(nrms)
         Os[i] *= fac / nrm
     end
-    # convert to Vidal gauge
-    _cluster_truncate!(Os, fill(notrunc(), N - 1))
     # remove trivial legs in first/last tensor, and restore MPO convention
     return map(enumerate(Os)) do (i, O)
         if i == 1

--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -15,14 +15,26 @@ function gate_to_mpo(
         trunc = trunctol(; atol = MPSKit.Defaults.tol)
     ) where {N}
     @assert N >= 2
-    Os = MPSKit.decompose_localmpo(MPSKit.add_util_leg(gate), trunc)
-    return map(1:N) do i
+    # use MPS convention of domain/codomain
+    Os = map(MPSKit.decompose_localmpo(MPSKit.add_util_leg(gate), trunc)) do O
+        return permute(O, ((1, 2, 3), (4,)))
+    end
+    # evenly distribute the (Inf) norm
+    nrms = norm.(Os, Inf)
+    fac = prod(nrms)^(1 / N)
+    for (i, nrm) in enumerate(nrms)
+        Os[i] *= fac / nrm
+    end
+    # convert to Vidal gauge
+    _cluster_truncate!(Os, fill(notrunc(), N - 1))
+    # remove trivial legs in first/last tensor, and restore MPO convention
+    return map(enumerate(Os)) do (i, O)
         if i == 1
-            return removeunit(Os[1], 1)
+            return permute(removeunit(O, 1), ((1,), (2, 3)))
         elseif i == N
-            return removeunit(Os[N], 4)
+            return permute(removeunit(O, 4), ((1, 2), (3,)))
         else
-            return Os[i]
+            return permute(O, ((1, 2), (3, 4)))
         end
     end
 end
@@ -89,11 +101,11 @@ end
 """
 Trotterize next-nearest neighbor terms in a Hamiltonian,
 converting them to 3-site MPO gates. 
-For each gate, the order of sites is
+For each gate, the sites are in counter-clockwise order
 ```
-    2---3   1---2
+    2---1   3---2
     |           |
-    1           3
+    3           1
 
     1           3
     |           |
@@ -102,21 +114,34 @@ For each gate, the order of sites is
 """
 function _trotterize_nnn2site!(gates::Vector, H::LocalOperator, dt::Number)
     T = scalartype(H)
+    origin = CartesianIndex(0, 0)
     vs = [
-        # ⌞ next-nearest-neighbour
-        (CartesianIndex(1, 0), CartesianIndex(1, 1)),
-        # ⌜ next-nearest-neighbour
-        (CartesianIndex(-1, 0), CartesianIndex(-1, 1)),
-        # ⌝ next-nearest-neighbour
-        (CartesianIndex(0, 1), CartesianIndex(1, 1)),
-        # ⌟ next-nearest-neighbour
-        (CartesianIndex(0, 1), CartesianIndex(-1, 1)),
+        # ⌜ northwest next-nearest-neighbour
+        (CartesianIndex(-1, 1), CartesianIndex(-1, 0), origin)
+        # ⌝ northeast next-nearest-neighbour
+        (CartesianIndex(1, 1), CartesianIndex(0, 1), origin)
+        # ⌟ southeast next-nearest-neighbour
+        (origin, CartesianIndex(0, 1), CartesianIndex(-1, 1))
+        # ⌞ southwest next-nearest-neighbour
+        (origin, CartesianIndex(1, 0), CartesianIndex(1, 1))
     ]
-    for x1 in CartesianIndices(size(H)), v in vs
-        x2, x3 = x1 + v[1], x1 + v[2]
+    Nr = size(H, 1)
+    for x in CartesianIndices(size(H)), (dir, v) in enumerate(vs)
+        x′ = if dir == NORTHEAST || dir == SOUTHWEST
+            x
+        else
+            CartesianIndex(mod1(x[1] + 1, Nr), x[2])
+        end
+        x1, x2, x3 = x′ + v[1], x′ + v[2], x′ + v[3]
         coord = [x1, x3]
-        haskey(H.terms, coord) || continue
-        gate = gate_to_mpo(exp(H.terms[coord] * -dt / 2))
+        rev = !issorted(coord)
+        coord′ = rev ? reverse!(coord) : coord
+        haskey(H.terms, coord′) || continue
+        term = H.terms[coord′]
+        if rev
+            term = permute(term, ((2, 1), (4, 3)))
+        end
+        gate = gate_to_mpo(exp(term * -dt / 2))
         b = TensorKit.BraidingTensor{T}(physicalspace(H, x2), left_virtualspace(gate[2]))
         insert!(gate, 2, TensorMap(b))
         push!(gates, [x1, x2, x3] => gate)

--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -87,7 +87,7 @@ function _trotterize_nn2site!(
         gates::Vector, H::LocalOperator, dt::Number; force_mpo::Bool = false
     )
     vs = [CartesianIndex(0, 1), CartesianIndex(1, 0)]
-    for x in CartesianIndices(size(H)), v in vs
+    for v in vs, x in CartesianIndices(size(H))
         y = x + v
         coord = [x, y]
         haskey(H.terms, coord) || continue

--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -57,6 +57,7 @@ On the square lattice, the neighbor distances are
 """
 function _check_hamiltonian_for_trotter(H::LocalOperator)
     dist = 0
+    all(size(H) .>= 2) || error("Unit cell size of the Hamiltonian cannot be smaller than (2, 2).")
     for (sites, op) in H.terms
         @assert numin(op) <= 2 "Hamiltonians containing multi-site (> 2) terms are not currently supported."
         if numin(op) == 2
@@ -86,10 +87,26 @@ Trotterize nearest neighbor terms in the Hamiltonian `H`.
 function _trotterize_nn2site!(
         gates::Vector, H::LocalOperator, dt::Number; force_mpo::Bool = false
     )
-    vs = [CartesianIndex(0, 1), CartesianIndex(1, 0)]
-    for v in vs, x in CartesianIndices(size(H))
-        y = x + v
-        coord = [x, y]
+    Nr, Nc = size(H)
+    # horizontal bonds, column by column
+    # within group `g`, all gates commute
+    period = iseven(Nc) ? 2 : 3
+    for g in 1:period, c in 1:Nc, r in 1:Nr
+        mod1(c, period) == g || continue
+        x = CartesianIndex(r, c)
+        coord = [x, x + CartesianIndex(0, 1)]
+        haskey(H.terms, coord) || continue
+        gate = exp(H.terms[coord] * -dt)
+        force_mpo && (gate = gate_to_mpo(gate))
+        push!(gates, coord => gate)
+    end
+    # vertical bonds, row by row
+    # within group `g`, all gates commute
+    period = iseven(Nr) ? 2 : 3
+    for g in 1:period, r in 1:Nr, c in 1:Nc
+        mod1(r, period) == g || continue
+        x = CartesianIndex(r, c)
+        coord = [x, x + CartesianIndex(1, 0)]
         haskey(H.terms, coord) || continue
         gate = exp(H.terms[coord] * -dt)
         force_mpo && (gate = gate_to_mpo(gate))
@@ -115,16 +132,16 @@ For each gate, the sites are in counter-clockwise order
 function _trotterize_nnn2site!(gates::Vector, H::LocalOperator, dt::Number)
     T = scalartype(H)
     origin = CartesianIndex(0, 0)
-    vs = [
+    vs = (
         # ⌜ northwest next-nearest-neighbour
-        (CartesianIndex(-1, 1), CartesianIndex(-1, 0), origin)
+        (CartesianIndex(-1, 1), CartesianIndex(-1, 0), origin),
         # ⌝ northeast next-nearest-neighbour
-        (CartesianIndex(1, 1), CartesianIndex(0, 1), origin)
+        (CartesianIndex(1, 1), CartesianIndex(0, 1), origin),
         # ⌟ southeast next-nearest-neighbour
-        (origin, CartesianIndex(0, 1), CartesianIndex(-1, 1))
+        (origin, CartesianIndex(0, 1), CartesianIndex(-1, 1)),
         # ⌞ southwest next-nearest-neighbour
-        (origin, CartesianIndex(1, 0), CartesianIndex(1, 1))
-    ]
+        (origin, CartesianIndex(1, 0), CartesianIndex(1, 1)),
+    )
     Nr = size(H, 1)
     for (dir, v) in enumerate(vs), x in CartesianIndices(size(H))
         x′ = if dir == NORTHEAST || dir == SOUTHWEST

--- a/src/algorithms/time_evolution/trotter_gate.jl
+++ b/src/algorithms/time_evolution/trotter_gate.jl
@@ -24,9 +24,7 @@ function gate_to_mpo(
     # evenly distribute the (Inf) norm
     nrms = norm.(Os, Inf)
     fac = prod(nrms)^(1 / N)
-    for (i, nrm) in enumerate(nrms)
-        Os[i] *= fac / nrm
-    end
+    scale!.(Os, fac ./ nrms)
     # remove trivial legs in first/last tensor, and restore MPO convention
     return map(enumerate(Os)) do (i, O)
         if i == 1

--- a/src/operators/localcircuit.jl
+++ b/src/operators/localcircuit.jl
@@ -11,7 +11,8 @@ struct LocalCircuit{O, S}
     "lattice of physical spaces on which the gates act"
     lattice::Matrix{S}
 
-    "list of `sites => gate` pairs that make up the circuit"
+    "list of `sites => gate` pairs that make up the circuit.
+    `sites` is not required to be sorted."
     gates::Vector{Pair{Vector{CartesianIndex{2}}, O}}
 
     LocalCircuit{O, S}(lattice::Matrix{S}) where {O, S} =
@@ -45,12 +46,6 @@ function add_factor!(operator::LocalCircuit, inds::Vector{CartesianIndex{2}}, te
         physicalspace(operator, ind_translated) == domain(term)[i] == codomain(term)[i] ||
             throw(SpaceMismatch("Incompatible physical spaces at $(ind)."))
     end
-    # permute input
-    if !issorted(inds)
-        I = sortperm(inds)
-        inds = inds[I]
-        term = permute(term, (Tuple(I), Tuple(I) .+ numout(term)))
-    end
     # translate coordinates
     I1 = first(inds)
     I1_mod = CartesianIndex(mod1.(Tuple(I1), size(operator)))
@@ -78,7 +73,6 @@ function add_factor!(
             sum(Tuple(ind - ind_prev) .^ 2) == 1 || throw(ArgumentError("Two consecutive sites in `inds` must be nearest neighbours for MPO terms."))
         end
     end
-    # for MPO term, `inds` should not be sorted
     push!(operator.gates, inds => term)
     return operator
 end

--- a/src/operators/localcircuit.jl
+++ b/src/operators/localcircuit.jl
@@ -46,10 +46,6 @@ function add_factor!(operator::LocalCircuit, inds::Vector{CartesianIndex{2}}, te
         physicalspace(operator, ind_translated) == domain(term)[i] == codomain(term)[i] ||
             throw(SpaceMismatch("Incompatible physical spaces at $(ind)."))
     end
-    # translate coordinates
-    I1 = first(inds)
-    I1_mod = CartesianIndex(mod1.(Tuple(I1), size(operator)))
-    inds .-= (I1 - I1_mod)
     push!(operator.gates, inds => term)
     return operator
 end


### PR DESCRIPTION
This PR improves how NNN terms in the Hamiltonian are trotterized to reduce artificial C4v symmetry breaking in time evolution. Depends on #387.

- The sites in an NNN 3-site gate MPO are now always put in counter clockwise order. This is equivalent to the old approach (#219) of rotating the PEPS/PEPO so that the gate can always act on the (say) southeast 3-site corner.
- The order of the NNN 3-site gate MPO is changed: first act on the same corner of all plaquettes in the unitcell, and then change to gates on other corners.
- In `gate_to_mpo`, the resulting MPO is put in Vidal gauge, and the norm of the gate is evenly distributed among the MPO tensors.

@GlebFedorovich You can try this out on J1-J2 (together with `symmetrize_gates = true`).