### PR TITLE
Add keyword arguments to `fixedpoint` for `hasconverged` and `shouldstop` stopping criteria

### DIFF
--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -166,19 +166,10 @@ information `NamedTuple` which contains the following entries:
 * `gradnorms_unitcell` : History of gradient norms for each respective unit cell entry.
 * `times` : History of optimization step execution times.
 """
-function fixedpoint(
-        operator, peps₀::InfinitePEPS, env₀;
-        (finalize!) = OptimKit._finalize!,
-        hasconverged = nothing, shouldstop = nothing, kwargs...,
-    )
-    # select OptimizationAlgorithm from kwargs
-    alg = select_algorithm(fixedpoint, env₀; kwargs...)
-
-    # default stopping criteria initialized on alg parameters that have to be select first
-    isnothing(hasconverged) && (hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.gradtol))
-    isnothing(shouldstop) && (shouldstop = OptimKit.DefaultShouldStop(alg.optimizer_alg.maxiter))
-
-    return fixedpoint(operator, peps₀, env₀, alg; finalize!, hasconverged, shouldstop)
+function fixedpoint(operator, peps₀::InfinitePEPS, env₀; kwargs...)
+    extra_kwarg_keys = (:finalize!, :hasconverged, :shouldstop) # these will not be passed to `select_algorithm`, only to the 2nd `fixedpoint` call
+    alg = select_algorithm(fixedpoint, env₀; filter(kw -> !(first(kw) in extra_kwarg_keys), kwargs)...)
+    return fixedpoint(operator, peps₀, env₀, alg; filter(kw -> first(kw) in extra_kwarg_keys, kwargs)...)
 end
 function fixedpoint(
         operator, peps₀::InfinitePEPS, env₀, alg::PEPSOptimize;

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -109,7 +109,9 @@ The optimization parameters can be supplied via the keyword arguments or directl
     4. Debug info including AD outputs
 * `reuse_env::Bool=$(Defaults.reuse_env)` : If `true`, the current optimization step is initialized on the previous environment, otherwise a random environment is used.
 * `symmetrization::Union{Nothing,SymmetrizationStyle}=nothing` : Accepts `nothing` or a `SymmetrizationStyle`, in which case the PEPS and PEPS gradient are symmetrized after each optimization iteration.
-* `(finalize!)=OptimKit._finalize!` : Inserts a `finalize!` function call after each optimization step by utilizing the `finalize!` kwarg of `OptimKit.optimize`. The function maps `(peps, env), f, g = finalize!((peps, env), f, g, numiter)`.
+* `hasconverged=OptimKit.DefaultHasConverged(optimizer_alg.tol)` : Function specifying the convergence criterion with signature `bool = hasconverged(state, cost, grad, gradnorm)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
+* `shouldstop=OptimKit.DefaultShouldStop(optimizer_alg.maxiter)` : Function specifying the stopping criterion with signature `bool = shouldstop(state, cost, grad, numfg, iter, timespent)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
+* `(finalize!)=OptimKit._finalize!` : Inserts a `finalize!` function call after each optimization step by utilizing the `finalize!` kwarg of `OptimKit.optimize`. The function maps `(state, env), f, g = finalize!((state, env), cost, grad, numiter)`.
 
 ### Boundary algorithm
 
@@ -131,7 +133,7 @@ keyword arguments are:
 * `verbosity::Int` : Gradient output verbosity, ≤0 by default to disable too verbose printing. Should only be >0 for debug purposes.
 * `alg::Symbol=:$(Defaults.gradient_alg)` : Implicit gradient algorithm variant, can be one of the following:
     - `:FixedPointGradient` : Compute the gradient via fixed-point differentiation, see [`FixedPointGradient`](@ref)
-* `solver_alg::`Union{Algorithm,NamedTuple}`: Solver algorithm for computing the implicit gradient; see [`FixedPointGradient`](@ref) for supported algorithms.
+* `solver_alg::Union{Algorithm,NamedTuple}`: Solver algorithm for computing the implicit gradient; see [`FixedPointGradient`](@ref) for supported algorithms.
 
 ### Optimizer settings
 
@@ -165,13 +167,24 @@ information `NamedTuple` which contains the following entries:
 * `times` : History of optimization step execution times.
 """
 function fixedpoint(
-        operator, peps₀::InfinitePEPS, env₀; (finalize!) = OptimKit._finalize!, kwargs...,
+        operator, peps₀::InfinitePEPS, env₀;
+        (finalize!) = OptimKit._finalize!,
+        hasconverged = nothing, shouldstop = nothing, kwargs...,
     )
+    # select OptimizationAlgorithm from kwargs
     alg = select_algorithm(fixedpoint, env₀; kwargs...)
-    return fixedpoint(operator, peps₀, env₀, alg; finalize!)
+
+    # default stopping criteria initialized on alg parameters that have to be select first
+    isnothing(hasconverged) && (hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.tol))
+    isnothing(shouldstop) && (shouldstop = OptimKit.DefaultShouldStop(alg.optimizer_alg.maxiter))
+
+    return fixedpoint(operator, peps₀, env₀, alg; finalize!, hasconverged, shouldstop)
 end
 function fixedpoint(
-        operator, peps₀::InfinitePEPS, env₀, alg::PEPSOptimize; (finalize!) = OptimKit._finalize!,
+        operator, peps₀::InfinitePEPS, env₀, alg::PEPSOptimize;
+        (finalize!) = OptimKit._finalize!,
+        hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.tol),
+        shouldstop = OptimKit.DefaultShouldStop(alg.optimizer_alg.maxiter),
     )
     # validate inputs
     check_input(fixedpoint, peps₀, env₀, alg)
@@ -197,7 +210,8 @@ function fixedpoint(
     # optimize operator cost function
     (peps_final, env_final), cost_final, ∂cost, numfg, convergence_history = optimize(
         (peps₀, env₀), alg.optimizer_alg;
-        retract, inner = real_inner, finalize!, (transport!) = (peps_transport!),
+        retract, inner = real_inner, (transport!) = (peps_transport!),
+        hasconverged, shouldstop, finalize!,
     ) do (peps, env)
         start_time = time_ns()
         E, gs = withgradient(peps) do ψ

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -175,7 +175,7 @@ function fixedpoint(
     alg = select_algorithm(fixedpoint, env₀; kwargs...)
 
     # default stopping criteria initialized on alg parameters that have to be select first
-    isnothing(hasconverged) && (hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.tol))
+    isnothing(hasconverged) && (hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.gradtol))
     isnothing(shouldstop) && (shouldstop = OptimKit.DefaultShouldStop(alg.optimizer_alg.maxiter))
 
     return fixedpoint(operator, peps₀, env₀, alg; finalize!, hasconverged, shouldstop)
@@ -183,7 +183,7 @@ end
 function fixedpoint(
         operator, peps₀::InfinitePEPS, env₀, alg::PEPSOptimize;
         (finalize!) = OptimKit._finalize!,
-        hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.tol),
+        hasconverged = OptimKit.DefaultHasConverged(alg.optimizer_alg.gradtol),
         shouldstop = OptimKit.DefaultShouldStop(alg.optimizer_alg.maxiter),
     )
     # validate inputs

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -109,7 +109,7 @@ The optimization parameters can be supplied via the keyword arguments or directl
     4. Debug info including AD outputs
 * `reuse_env::Bool=$(Defaults.reuse_env)` : If `true`, the current optimization step is initialized on the previous environment, otherwise a random environment is used.
 * `symmetrization::Union{Nothing,SymmetrizationStyle}=nothing` : Accepts `nothing` or a `SymmetrizationStyle`, in which case the PEPS and PEPS gradient are symmetrized after each optimization iteration.
-* `hasconverged=OptimKit.DefaultHasConverged(optimizer_alg.tol)` : Function specifying the convergence criterion with signature `bool = hasconverged(state, cost, grad, gradnorm)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
+* `hasconverged=OptimKit.DefaultHasConverged(optimizer_alg.gradtol)` : Function specifying the convergence criterion with signature `bool = hasconverged(state, cost, grad, gradnorm)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
 * `shouldstop=OptimKit.DefaultShouldStop(optimizer_alg.maxiter)` : Function specifying the stopping criterion with signature `bool = shouldstop(state, cost, grad, numfg, iter, timespent)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
 * `(finalize!)=OptimKit._finalize!` : Inserts a `finalize!` function call after each optimization step by utilizing the `finalize!` kwarg of `OptimKit.optimize`. The function maps `(state, env), f, g = finalize!((state, env), cost, grad, numiter)`.
 

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -109,8 +109,8 @@ The optimization parameters can be supplied via the keyword arguments or directl
     4. Debug info including AD outputs
 * `reuse_env::Bool=$(Defaults.reuse_env)` : If `true`, the current optimization step is initialized on the previous environment, otherwise a random environment is used.
 * `symmetrization::Union{Nothing,SymmetrizationStyle}=nothing` : Accepts `nothing` or a `SymmetrizationStyle`, in which case the PEPS and PEPS gradient are symmetrized after each optimization iteration.
-* `hasconverged=OptimKit.DefaultHasConverged(optimizer_alg.gradtol)` : Function specifying the convergence criterion with signature `bool = hasconverged(state, cost, grad, gradnorm)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
-* `shouldstop=OptimKit.DefaultShouldStop(optimizer_alg.maxiter)` : Function specifying the stopping criterion with signature `bool = shouldstop(state, cost, grad, numfg, iter, timespent)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics.
+* `hasconverged=OptimKit.DefaultHasConverged(optimizer_alg.gradtol)` : Function specifying the convergence criterion with signature `bool = hasconverged(state, cost, grad, gradnorm)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics. Note that this overrides the default convergence criterion.
+* `shouldstop=OptimKit.DefaultShouldStop(optimizer_alg.maxiter)` : Function specifying the stopping criterion with signature `bool = shouldstop(state, cost, grad, numfg, iter, timespent)`, see [OptimKit.optimize](https://github.com/Jutho/OptimKit.jl/blob/master/src/OptimKit.jl) for specifics. Note that this overrides the default stopping criterion.
 * `(finalize!)=OptimKit._finalize!` : Inserts a `finalize!` function call after each optimization step by utilizing the `finalize!` kwarg of `OptimKit.optimize`. The function maps `(state, env), f, g = finalize!((state, env), cost, grad, numiter)`.
 
 ### Boundary algorithm

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -23,7 +23,7 @@ function select_algorithm(
         tol = Defaults.optimizer_tol, # top-level tolerance
         verbosity = 3, # top-level verbosity
         boundary_alg = (;), gradient_alg = (;), optimizer_alg = (;),
-        symmetrization = nothing, hasconverged = nothing, shouldstop = nothing, kwargs...,
+        symmetrization = nothing, kwargs...,
     )
     # adjust CTMRG tols and verbosity
     if boundary_alg isa NamedTuple

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -23,7 +23,7 @@ function select_algorithm(
         tol = Defaults.optimizer_tol, # top-level tolerance
         verbosity = 3, # top-level verbosity
         boundary_alg = (;), gradient_alg = (;), optimizer_alg = (;),
-        symmetrization = nothing, kwargs...,
+        symmetrization = nothing, hasconverged = nothing, shouldstop = nothing, kwargs...,
     )
     # adjust CTMRG tols and verbosity
     if boundary_alg isa NamedTuple

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -150,3 +150,51 @@ end
     @test e_site2 ≈ E_ref atol = 1.0e-2
     @test all(@. ξ_h > 0 && ξ_v > 0)
 end
+
+@kwdef mutable struct ΔEnergyShouldStop{T <: Real}
+    E_last::T = 0.0
+    tol::T = 1.0e-12
+end
+function (es::ΔEnergyShouldStop)(x, f, g, numfg, numiter, t)
+    Δenergy = f - es.E_last
+    es.E_last = f
+    return abs(Δenergy) <= es.tol
+end
+
+@kwdef mutable struct ΔEnergyHasConverged{T <: Real}
+    E_last::T = 0.0
+    tol::T = 1.0e-12
+end
+function (es::ΔEnergyHasConverged)(x, f, g, normgrad)
+    Δenergy = f - es.E_last
+    es.E_last = f
+    return abs(Δenergy) <= es.tol
+end
+
+@testset "Early stopping with hasconverged and shouldstop" begin
+    maxiter = 100
+    Random.seed!(123)
+    H = heisenberg_XYZ(InfiniteSquare())
+    peps₀ = InfinitePEPS(ComplexSpace(2), ComplexSpace(Dbond))
+
+    # should converge when energy difference becomes small enough
+    env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenv)), peps₀)
+    ΔEconverged = ΔEnergyHasConverged(; tol = 1.0e-4)
+    peps, env, E, info = fixedpoint(
+        H, peps₀, env₀;
+        optimizer_alg = (; maxiter, tol = 0),
+        hasconverged = ΔEconverged,
+    )
+    @test length(info.costs) < maxiter
+
+    # should stop when linesearching fails and returns α = 0 (i.e. ΔE = 0)
+    χenvsmall = 2
+    env₀, = leading_boundary(CTMRGEnv(peps₀, ComplexSpace(χenvsmall)), peps₀)
+    ΔEstop = ΔEnergyShouldStop(; tol = 1.0e-8)
+    peps, env, E, info = fixedpoint(
+        H, peps₀, env₀;
+        optimizer_alg = (; maxiter, ls_maxfg = 2, ls_maxiter = 2),
+        shouldstop = ΔEstop,
+    )
+    @test length(info.costs) < maxiter
+end

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -154,11 +154,12 @@ end
 @kwdef mutable struct ΔEnergyShouldStop{T <: Real}
     E_last::T = 0.0
     tol::T = 1.0e-12
+    maxiter::Int = 100
 end
 function (es::ΔEnergyShouldStop)(x, f, g, numfg, numiter, t)
     Δenergy = f - es.E_last
     es.E_last = f
-    return abs(Δenergy) <= es.tol
+    return (abs(Δenergy) <= es.tol) || numiter >= es.maxiter
 end
 
 @kwdef mutable struct ΔEnergyHasConverged{T <: Real}

--- a/test/examples/heisenberg.jl
+++ b/test/examples/heisenberg.jl
@@ -151,9 +151,9 @@ end
     @test all(@. ξ_h > 0 && ξ_v > 0)
 end
 
-@kwdef mutable struct ΔEnergyShouldStop{T <: Real}
-    E_last::T = 0.0
-    tol::T = 1.0e-12
+@kwdef mutable struct ΔEnergyShouldStop
+    E_last::Float64 = 0.0
+    tol::Float64 = 1.0e-12
     maxiter::Int = 100
 end
 function (es::ΔEnergyShouldStop)(x, f, g, numfg, numiter, t)
@@ -162,9 +162,9 @@ function (es::ΔEnergyShouldStop)(x, f, g, numfg, numiter, t)
     return (abs(Δenergy) <= es.tol) || numiter >= es.maxiter
 end
 
-@kwdef mutable struct ΔEnergyHasConverged{T <: Real}
-    E_last::T = 0.0
-    tol::T = 1.0e-12
+@kwdef mutable struct ΔEnergyHasConverged
+    E_last::Float64 = 0.0
+    tol::Float64 = 1.0e-12
 end
 function (es::ΔEnergyHasConverged)(x, f, g, normgrad)
     Δenergy = f - es.E_last


### PR DESCRIPTION
This PR adds the possibility for customized converging and stopping criteria through OptimKit's `hasconverged` and `shouldstop` keyword arguments. This can be very usefu e.g.l if one would like to do early stopping of an optimization based on converging energies or if the optimization gets stuck in linesearching and thereby produces vanishing energy differences.