### PR TITLE
Bump version to v0.8.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
     given-names: "Lukas"
     orcid: "https://orcid.org/0000-0002-0256-4200"
 title: "PEPSKit"
-version: 0.8.0
+version: 0.8.1
 identifiers:
   - type: doi
     value: 10.5281/zenodo.13938737
-date-released: 2026-05-08
+date-released: 2026-07-30

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PEPSKit"
 uuid = "52969e89-939e-4361-9b68-9bc7cde4bdeb"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Paul Brehmer", "Lander Burgelman", "Zhengyuan Yue", "Lukas Devos <ldevos98@gmail.com>"]
 
 [workspace]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,13 +18,11 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/quantumkithub/pepskit.jl/compare/v0.8.0...HEAD)
+## [Unreleased](https://github.com/quantumkithub/pepskit.jl/compare/v0.8.1...HEAD)
 
 ### Added
 
 ### Changed
-
-- In `correlator`, sites `js` are allowed on either side of the reference site `i` by adding right-to-left contractions (#399)
 
 ### Deprecated
 
@@ -33,6 +31,21 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 ### Fixed
 
 ### Performance
+
+## [0.8.1](https://github.com/quantumkithub/pepskit.jl/compare/v0.8.0...v0.8.1) - 2026-07-30
+
+### Added
+
+- Basic support for `MatrixAlgebraKit.svd_trunc_no_error` with custom adjoints (#390)
+- Dedicated environment initialization for CTMRG (`initialize_ctmrg_environment) with several initialization styles (#264)
+- `ProductStateEnv` type representing product state environments of generic square contractible networks (#264)
+- Compression of a 2-layer `InfinitePEPO` to a single-layer network using local truncation (#311)
+
+### Changed
+
+- TensorKit.jl compat bumped to include v0.17 (#393)
+- In `correlator`, sites `js` are allowed on either side of the reference site `i` by adding right-to-left contractions (#399)
+- Added additional keyword arguments `hasconverged` and `shouldstop` to `fixedpoint`, in line with OptimKit.jl conventions (#397)
 
 ## [0.8.0](https://github.com/quantumkithub/pepskit.jl/compare/v0.7.0...v0.8.0) - 2026-06-05
 


### PR DESCRIPTION
Patch version bump, mainly to allow using TensorKit v0.17.

Release notes:

Patch release containing a small amount of additions, along with compatibility with TensorKit v0.17.

### Highlights

- Basic support for truncated SVD without computing truncation error
- Dedicated routines for CTMRG environment initialization and representing product state environments
- Compression of 2-layer iPEPOs using local truncation
- Increased control over stopping criterion in `fixedpoint`
- Compatibility with TensorKit.jl v0.17

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/PEPSKit.jl/blob/main/docs/src/changelog.md#081---2026-07-30) for the complete list of changes.