### PR TITLE
Add adaptive tolerance scaling for boundary and gradient algorithms in variational optimization

### DIFF
--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -12,7 +12,7 @@ Module containing default algorithm parameter values and arguments.
     - `:SimultaneousCTMRG` : Simultaneous expansion and renormalization of all sides.
     - `:SequentialCTMRG` : Sequential application of left moves and rotations.
 * `ctmrg_verbosity=$(Defaults.ctmrg_verbosity)` : CTMRG output information verbosity
-* `ctmrg_dynamic_tols=$(Defaults.ctmrg_dynamic_tols)` : If `true`, wrap the CTMRG algorithm used during variational optimization in a `MPSKit.DynamicTol` that rescales its tolerance based on the current PEPS optimization gradient norm, see [`PEPSOptimize`](@ref).
+* `ctmrg_dynamic_tols=$(Defaults.ctmrg_dynamic_tols)` : If `true`, wrap the CTMRG algorithm used during variational optimization in an `MPSKit.DynamicTols.DynamicTol` that rescales its tolerance based on the current PEPS optimization gradient norm, see [`PEPSKit.PEPSOptimize`](@ref).
 * `ctmrg_tol_min=$(Defaults.ctmrg_tol_min)` : Minimal CTMRG tolerance used by `ctmrg_dynamic_tols`.
 * `ctmrg_tol_max=$(Defaults.ctmrg_tol_max)` : Maximal CTMRG tolerance used by `ctmrg_dynamic_tols`.
 * `ctmrg_tol_factor=$(Defaults.ctmrg_tol_factor)` : Tolerance scaling factor used by `ctmrg_dynamic_tols`.
@@ -89,7 +89,7 @@ Module containing default algorithm parameter values and arguments.
     - `:GeomSum` : Geometric sum approximation of the Neumann series of the inverse Jacobian, see [`PEPSKit.GeomSum`](@ref) for details
     - `:ManualIter` : Manual fixed-point iteration, see [`PEPSKit.ManualIter`](@ref) for details
 * `gradient_fixedpoint_solver_eager=$(Defaults.gradient_fixedpoint_solver_eager)` : Enables `:Arnoldi` solver algorithm to finish before the full Krylov dimension is reached.
-* `gradient_dynamic_tols=$(Defaults.gradient_dynamic_tols)` : If `true`, wrap the gradient algorithm used during variational optimization in a `MPSKit.DynamicTol` that rescales its tolerance based on the effective (possibly dynamically-scaled) tolerance of the boundary algorithm, see [`PEPSOptimize`](@ref).
+* `gradient_dynamic_tols=$(Defaults.gradient_dynamic_tols)` : If `true`, wrap the gradient algorithm used during variational optimization in an `MPSKit.DynamicTols.DynamicTol` that rescales its tolerance based on the effective (possibly dynamically-scaled) tolerance of the boundary algorithm, see [`PEPSKit.PEPSOptimize`](@ref).
 * `gradient_tol_min=$(Defaults.gradient_tol_min)` : Minimal gradient algorithm tolerance used by `gradient_dynamic_tols`.
 * `gradient_tol_max=$(Defaults.gradient_tol_max)` : Maximal gradient algorithm tolerance used by `gradient_dynamic_tols`.
 * `gradient_tol_factor=$(Defaults.gradient_tol_factor)` : Tolerance scaling factor relative to the boundary algorithm's tolerance, used by `gradient_dynamic_tols` (e.g. `10` makes the gradient tolerance ~10x looser than the boundary tolerance).

--- a/src/Defaults.jl
+++ b/src/Defaults.jl
@@ -12,6 +12,10 @@ Module containing default algorithm parameter values and arguments.
     - `:SimultaneousCTMRG` : Simultaneous expansion and renormalization of all sides.
     - `:SequentialCTMRG` : Sequential application of left moves and rotations.
 * `ctmrg_verbosity=$(Defaults.ctmrg_verbosity)` : CTMRG output information verbosity
+* `ctmrg_dynamic_tols=$(Defaults.ctmrg_dynamic_tols)` : If `true`, wrap the CTMRG algorithm used during variational optimization in a `MPSKit.DynamicTol` that rescales its tolerance based on the current PEPS optimization gradient norm, see [`PEPSOptimize`](@ref).
+* `ctmrg_tol_min=$(Defaults.ctmrg_tol_min)` : Minimal CTMRG tolerance used by `ctmrg_dynamic_tols`.
+* `ctmrg_tol_max=$(Defaults.ctmrg_tol_max)` : Maximal CTMRG tolerance used by `ctmrg_dynamic_tols`.
+* `ctmrg_tol_factor=$(Defaults.ctmrg_tol_factor)` : Tolerance scaling factor used by `ctmrg_dynamic_tols`.
 
 ## SVD forward & reverse
 
@@ -85,6 +89,10 @@ Module containing default algorithm parameter values and arguments.
     - `:GeomSum` : Geometric sum approximation of the Neumann series of the inverse Jacobian, see [`PEPSKit.GeomSum`](@ref) for details
     - `:ManualIter` : Manual fixed-point iteration, see [`PEPSKit.ManualIter`](@ref) for details
 * `gradient_fixedpoint_solver_eager=$(Defaults.gradient_fixedpoint_solver_eager)` : Enables `:Arnoldi` solver algorithm to finish before the full Krylov dimension is reached.
+* `gradient_dynamic_tols=$(Defaults.gradient_dynamic_tols)` : If `true`, wrap the gradient algorithm used during variational optimization in a `MPSKit.DynamicTol` that rescales its tolerance based on the effective (possibly dynamically-scaled) tolerance of the boundary algorithm, see [`PEPSOptimize`](@ref).
+* `gradient_tol_min=$(Defaults.gradient_tol_min)` : Minimal gradient algorithm tolerance used by `gradient_dynamic_tols`.
+* `gradient_tol_max=$(Defaults.gradient_tol_max)` : Maximal gradient algorithm tolerance used by `gradient_dynamic_tols`.
+* `gradient_tol_factor=$(Defaults.gradient_tol_factor)` : Tolerance scaling factor relative to the boundary algorithm's tolerance, used by `gradient_dynamic_tols` (e.g. `10` makes the gradient tolerance ~10x looser than the boundary tolerance).
 
 ## Optimization
 
@@ -117,6 +125,10 @@ const ctmrg_miniter = 4
 const ctmrg_alg = :SimultaneousCTMRG # ∈ {:SimultaneousCTMRG, :SequentialCTMRG}
 const ctmrg_verbosity = 2
 const sparse = false # TODO: implement sparse CTMRG
+const ctmrg_dynamic_tols = true
+const ctmrg_tol_min = 1.0e-12
+const ctmrg_tol_max = 1.0e-4
+const ctmrg_tol_factor = 1.0e-3
 
 # SVD forward & reverse
 const trunc = :FixedSpaceTruncation # ∈ {:FixedSpaceTruncation, :notrunc, :truncerror, :truncspace, :trunctol}
@@ -151,6 +163,10 @@ const gradient_verbosity = -1
 const gradient_alg = :FixedPointGradient
 const gradient_fixedpoint_solver_alg = :Arnoldi # ∈ {:GMRES, :BiCGStab, :Arnoldi, :GeomSum, :ManualIter}
 const gradient_fixedpoint_solver_eager = true
+const gradient_dynamic_tols = true
+const gradient_tol_min = 1.0e-10
+const gradient_tol_max = 1.0e-1
+const gradient_tol_factor = 1.0e1
 
 # Optimization
 const reuse_env = true

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -30,6 +30,8 @@ import TupleTools
 using MPSKit
 using MPSKit: MPSTensor, MPOTensor, GenericMPSTensor, MPSBondTensor, ProductTransferMatrix
 using MPSKit: InfiniteEnvironments
+using MPSKit: DynamicTol, updatetol
+import MPSKit.DynamicTols: _updatetol
 import MPSKit: tensorexpr, leading_boundary, loginit!, logiter!, logfinish!, logcancel!, physicalspace
 import MPSKit: infinite_temperature_density_matrix
 

--- a/src/algorithms/optimization/fixed_point_differentiation.jl
+++ b/src/algorithms/optimization/fixed_point_differentiation.jl
@@ -93,6 +93,10 @@ end
 FixedPointGradient(; kwargs...) = GradientAlgorithm(; alg = :FixedPointGradient, kwargs...)
 GRADIENT_ALGORITHM_SYMBOLS[:FixedPointGradient] = FixedPointGradient
 
+# `FixedPointGradient` has no top-level `tol` field (it lives on `solver_alg`), so the
+# default `MPSKit.DynamicTols._updatetol` (which sets `alg.tol`) doesn't apply
+_updatetol(alg::FixedPointGradient, tol::Real) = @set alg.solver_alg.tol = tol
+
 const FIXEDPOINT_SOLVER_SYMBOLS = IdDict{Symbol, Type{<:Any}}(
     :GMRES => GMRES, :BiCGStab => BiCGStab, :Arnoldi => Arnoldi,
 )

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -155,6 +155,22 @@ keyword arguments are:
 * `ls_maxfg::Int=$(Defaults.ls_maxfg)` : Maximal number of function-gradient evaluations during linesearch.
 * `lbfgs_memory::Int=$(Defaults.lbfgs_memory)` : Size of limited memory representation of BFGS Hessian matrix.
 
+### Dynamic tolerances
+
+The boundary and gradient algorithms each additionally accept the keyword arguments below,
+which wrap the corresponding algorithm in an `MPSKit.DynamicTols.DynamicTol` that
+rescales its tolerance over the course of the optimization. This allows the intermediate
+problems to be solved only as accurately as the current optimization step requires, which
+can significantly reduce the total runtime. The boundary tolerance is scaled relative to the
+current gradient norm, while the gradient tolerance is in turn scaled relative to the
+effective boundary tolerance. These settings are only available within a
+variational optimization, not for standalone [`leading_boundary`](@ref) calls.
+
+* `dynamic_tols::Bool` : Enable dynamic tolerance scaling for this algorithm. Defaults to `$(Defaults.ctmrg_dynamic_tols)` and `$(Defaults.gradient_dynamic_tols)` for the boundary and gradient algorithm respectively.
+* `tol_min::Real` : Lower clamp on the dynamically scaled tolerance.
+* `tol_max::Real` : Upper clamp on the dynamically scaled tolerance.
+* `tol_factor::Real` : Prefactor of the dynamically scaled tolerance.
+
 ## Return values
 
 The function returns the final PEPS, CTMRG environment and cost value, as well as an

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -137,6 +137,22 @@ keyword arguments are:
     - `:FixedPointGradient` : Compute the gradient via fixed-point differentiation, see [`FixedPointGradient`](@ref)
 * `solver_alg::Union{Algorithm,NamedTuple}`: Solver algorithm for computing the implicit gradient; see [`FixedPointGradient`](@ref) for supported algorithms.
 
+### Dynamic tolerances
+
+The boundary and gradient algorithms each additionally accept the keyword arguments below,
+which wrap the corresponding algorithm in an `MPSKit.DynamicTols.DynamicTol` that
+rescales its tolerance over the course of the optimization. This allows the intermediate
+problems to be solved only as accurately as the current optimization step requires, which
+can significantly reduce the total runtime. The boundary tolerance is scaled relative to the
+current gradient norm, while the gradient tolerance is in turn scaled relative to the
+effective boundary tolerance. These settings are only available within a
+variational optimization, not for standalone [`leading_boundary`](@ref) calls.
+
+* `dynamic_tols::Bool` : Enable dynamic tolerance scaling for this algorithm. Defaults to `$(Defaults.ctmrg_dynamic_tols)` and `$(Defaults.gradient_dynamic_tols)` for the boundary and gradient algorithm respectively.
+* `tol_min::Real` : Lower clamp on the dynamically scaled tolerance.
+* `tol_max::Real` : Upper clamp on the dynamically scaled tolerance.
+* `tol_factor::Real` : Prefactor of the dynamically scaled tolerance.
+
 ### Optimizer settings
 
 Supply the optimizer algorithm via `optimizer_alg::Union{NamedTuple,<:OptimKit.OptimizationAlgorithm}`
@@ -154,22 +170,6 @@ keyword arguments are:
 * `ls_maxiter::Int=$(Defaults.ls_maxiter)` : Maximal number of linesearch iterations.
 * `ls_maxfg::Int=$(Defaults.ls_maxfg)` : Maximal number of function-gradient evaluations during linesearch.
 * `lbfgs_memory::Int=$(Defaults.lbfgs_memory)` : Size of limited memory representation of BFGS Hessian matrix.
-
-### Dynamic tolerances
-
-The boundary and gradient algorithms each additionally accept the keyword arguments below,
-which wrap the corresponding algorithm in an `MPSKit.DynamicTols.DynamicTol` that
-rescales its tolerance over the course of the optimization. This allows the intermediate
-problems to be solved only as accurately as the current optimization step requires, which
-can significantly reduce the total runtime. The boundary tolerance is scaled relative to the
-current gradient norm, while the gradient tolerance is in turn scaled relative to the
-effective boundary tolerance. These settings are only available within a
-variational optimization, not for standalone [`leading_boundary`](@ref) calls.
-
-* `dynamic_tols::Bool` : Enable dynamic tolerance scaling for this algorithm. Defaults to `$(Defaults.ctmrg_dynamic_tols)` and `$(Defaults.gradient_dynamic_tols)` for the boundary and gradient algorithm respectively.
-* `tol_min::Real` : Lower clamp on the dynamically scaled tolerance.
-* `tol_max::Real` : Upper clamp on the dynamically scaled tolerance.
-* `tol_factor::Real` : Prefactor of the dynamically scaled tolerance.
 
 ## Return values
 

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -31,7 +31,9 @@ struct PEPSOptimize{B, G}
             boundary_alg::B, gradient_alg::G, optimizer_alg,
             reuse_env, symmetrization,
         ) where {B, G}
-        _check_algorithm_combination(boundary_alg, gradient_alg, symmetrization)
+        _check_algorithm_combination(
+            parent_alg(boundary_alg), parent_alg(gradient_alg), symmetrization
+        )
         return new{B, G}(boundary_alg, gradient_alg, optimizer_alg, reuse_env, symmetrization)
     end
 end
@@ -189,11 +191,26 @@ function fixedpoint(
         )
     end
 
-    # initialize info collection vectors
     T = promote_type(real(scalartype(peps₀)), real(scalartype(env₀)))
+
+    # `tol_state` tracks (iter, gradnorm) of the last accepted optimization step
+    # (updated only in `finalize!`), used to adjust `alg.boundary_alg`/`alg.gradient_alg`
+    # via `MPSKit.updatetol` if they are wrapped in a `MPSKit.DynamicTol`. `latest_*`
+    # hold the values produced by the current `fg` call, and are only recorded into
+    # their respective history vectors once a step is accepted.
+    tol_state = Ref((iter = 0, gradnorm = one(T)))
+    latest_metrics = Ref{NamedTuple}()
+    latest_gradnorms = Ref{Matrix{T}}()
+    latest_time = Ref(0.0)
+
+    # initialize info collection vectors
     contraction_metrics = Vector{NamedTuple}()
     gradnorms_unitcell = Vector{Matrix{T}}()
     times = Vector{Float64}()
+    finalize! = track_state_and_finalize!(
+        tol_state, latest_metrics, latest_gradnorms, latest_time,
+        contraction_metrics, gradnorms_unitcell, times, finalize!,
+    )
 
     # normalize the initial guess
     peps₀ = peps_normalize(peps₀)
@@ -205,20 +222,24 @@ function fixedpoint(
         hasconverged, shouldstop, finalize!,
     ) do (peps, env)
         start_time = time_ns()
+        boundary_alg = updatetol(alg.boundary_alg, tol_state[].iter, tol_state[].gradnorm)
+        # gradient tolerance is scaled relative to the boundary algorithm's own
+        # (just-updated) effective tolerance, not directly to the gradient norm
+        gradient_alg = updatetol(alg.gradient_alg, tol_state[].iter, boundary_alg.tol)
         E, gs = withgradient(peps) do ψ
             env′, info = hook_pullback(
-                leading_boundary, env, ψ, alg.boundary_alg;
-                alg_rrule = alg.gradient_alg,
+                leading_boundary, env, ψ, boundary_alg;
+                alg_rrule = gradient_alg,
             )
             ignore_derivatives() do
                 alg.reuse_env && update!(env, env′)
-                push!(contraction_metrics, info.contraction_metrics)
+                latest_metrics[] = info.contraction_metrics
             end
             return cost_function(ψ, env′, operator)
         end
         g = only(gs)  # `withgradient` returns tuple of gradients `gs`
-        push!(gradnorms_unitcell, norm.(g.A))
-        push!(times, (time_ns() - start_time) * 1.0e-9)
+        latest_gradnorms[] = norm.(g.A)
+        latest_time[] = (time_ns() - start_time) * 1.0e-9
         return E, g
     end
 
@@ -235,13 +256,14 @@ function fixedpoint(
 end
 
 """
-    check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize{<:SimultaneousCTMRG})
+    check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize)
 
 Check compatibility of an initial PEPS and environment with a specified PEPS optimization algorithm.
 """
-function check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize) end
-function check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize{<:SimultaneousCTMRG, <:FixedPointGradient})
-    if scalartype(env₀) <: Real # :fixed mode gauge fixing is incompatible with real environments
+function check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize)
+    if parent_alg(alg.boundary_alg) isa SimultaneousCTMRG &&
+            parent_alg(alg.gradient_alg) isa FixedPointGradient &&
+            scalartype(env₀) <: Real # :fixed mode gauge fixing is incompatible with real environments
         msg = "the provided real environment is incompatible with :fixed mode \
         since :fixed mode generally produces complex gauges"
         throw(ArgumentError(msg))
@@ -337,4 +359,37 @@ function symmetrize_retract_and_finalize!(
         return (peps´_symm, env´), ξ_symm
     end
     return retract_then_symmetrize, symmetrize_then_finalize!
+end
+
+"""
+    track_state_and_finalize!(
+        tol_state::Base.RefValue, latest_metrics::Base.RefValue, latest_gradnorms::Base.RefValue,
+        latest_time::Base.RefValue, contraction_metrics::Vector, gradnorms_unitcell::Vector,
+        times::Vector, [finalize!],
+    )
+
+Return a `finalize!` function that, after calling `finalize!` (defaulting to
+`OptimKit._finalize!`):
+* updates `tol_state[]` to the `(iter, gradnorm)` of the now-accepted optimization step,
+  used to drive `MPSKit.updatetol` for any `alg.boundary_alg`/`alg.gradient_alg` wrapped
+  in a `MPSKit.DynamicTol`
+* records `latest_metrics[]`/`latest_gradnorms[]`/`latest_time[]`, i.e. the values
+  produced by the `fg` call corresponding to the accepted step, into
+  `contraction_metrics`/`gradnorms_unitcell`/`times`
+"""
+function track_state_and_finalize!(
+        tol_state::Base.RefValue, latest_metrics::Base.RefValue, latest_gradnorms::Base.RefValue,
+        latest_time::Base.RefValue, contraction_metrics::Vector, gradnorms_unitcell::Vector,
+        times::Vector, (finalize!) = OptimKit._finalize!,
+    )
+    function commit_state_and_finalize!((peps, env), E, grad, numiter)
+        (peps, env), E, grad = finalize!((peps, env), E, grad, numiter)
+        gradnorm = sqrt(real_inner((peps, env), grad, grad))
+        tol_state[] = (; iter = numiter, gradnorm)
+        push!(contraction_metrics, latest_metrics[])
+        push!(gradnorms_unitcell, latest_gradnorms[])
+        push!(times, latest_time[])
+        return (peps, env), E, grad
+    end
+    return commit_state_and_finalize!
 end

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -209,23 +209,19 @@ function fixedpoint(
 
     T = promote_type(real(scalartype(peps₀)), real(scalartype(env₀)))
 
-    # `tol_state` tracks (iter, gradnorm) of the last accepted optimization step
-    # (updated only in `finalize!`), used to adjust `alg.boundary_alg`/`alg.gradient_alg`
-    # via `MPSKit.updatetol` if they are wrapped in a `MPSKit.DynamicTol`. `latest_*`
-    # hold the values produced by the current `fg` call, and are only recorded into
-    # their respective history vectors once a step is accepted.
-    tol_state = Ref((iter = 0, gradnorm = one(T)))
-    latest_metrics = Ref{NamedTuple}()
-    latest_gradnorms = Ref{Matrix{T}}()
-    latest_time = Ref(0.0)
-
     # initialize info collection vectors
-    contraction_metrics = Vector{NamedTuple}()
-    gradnorms_unitcell = Vector{Matrix{T}}()
-    times = Vector{Float64}()
-    finalize! = track_state_and_finalize!(
-        tol_state, latest_metrics, latest_gradnorms, latest_time,
-        contraction_metrics, gradnorms_unitcell, times, finalize!,
+    contraction_metrics = Vector{NamedTuple}(undef, 1)
+    gradnorms_unitcell = Vector{Matrix{T}}(undef, 1)
+    times = Vector{Float64}(undef, 1)
+
+    # `tol_state` tracks (iter, gradnorm) of the last accepted optimization step, used to
+    # adjust `alg.boundary_alg`/`alg.gradient_alg` via `MPSKit.updatetol` if they are
+    # wrapped in a `MPSKit.DynamicTol`.
+    tol_state = (iter = 0, gradnorm = one(T))
+
+    # set up finalizer to update `tol_state` and record info after each accepted optimization step
+    tracked_finalizer = TrackedFinalizer(
+        tol_state, contraction_metrics, gradnorms_unitcell, times, finalize!,
     )
 
     # normalize the initial guess
@@ -235,13 +231,19 @@ function fixedpoint(
     (peps_final, env_final), cost_final, ∂cost, numfg, convergence_history = optimize(
         (peps₀, env₀), alg.optimizer_alg;
         retract, inner = real_inner, (transport!) = (peps_transport!),
-        hasconverged, shouldstop, finalize!,
+        hasconverged, shouldstop, (finalize!) = tracked_finalizer,
     ) do (peps, env)
-        start_time = time_ns()
-        boundary_alg = updatetol(alg.boundary_alg, tol_state[].iter, tol_state[].gradnorm)
+        start_time = time()
+        boundary_alg = updatetol(
+            alg.boundary_alg,
+            tracked_finalizer.tol_state.iter,
+            tracked_finalizer.tol_state.gradnorm
+        )
         # gradient tolerance is scaled relative to the boundary algorithm's own
         # (just-updated) effective tolerance, not directly to the gradient norm
-        gradient_alg = updatetol(alg.gradient_alg, tol_state[].iter, boundary_alg.tol)
+        gradient_alg = updatetol(
+            alg.gradient_alg, tracked_finalizer.tol_state.iter, boundary_alg.tol
+        )
         E, gs = withgradient(peps) do ψ
             env′, info = hook_pullback(
                 leading_boundary, env, ψ, boundary_alg;
@@ -249,24 +251,29 @@ function fixedpoint(
             )
             ignore_derivatives() do
                 alg.reuse_env && update!(env, env′)
-                latest_metrics[] = info.contraction_metrics
+                tracked_finalizer.contraction_metrics[end] = info.contraction_metrics
             end
             return cost_function(ψ, env′, operator)
         end
         g = only(gs)  # `withgradient` returns tuple of gradients `gs`
-        latest_gradnorms[] = norm.(unitcell(g))
-        latest_time[] = (time_ns() - start_time) * 1.0e-9
+        tracked_finalizer.gradnorms_unitcell[end] = norm.(unitcell(g))
+        tracked_finalizer.times[end] = time() - start_time
         return E, g
     end
+
+    # remove potential undefined placeholders from end of info collection vectors
+    resize!(tracked_finalizer.contraction_metrics, tracked_finalizer.tol_state.iter)
+    resize!(tracked_finalizer.gradnorms_unitcell, tracked_finalizer.tol_state.iter)
+    resize!(tracked_finalizer.times, tracked_finalizer.tol_state.iter)
 
     info = (;
         last_gradient = ∂cost,
         fg_evaluations = numfg,
         costs = convergence_history[:, 1],
         gradnorms = convergence_history[:, 2],
-        contraction_metrics,
-        gradnorms_unitcell,
-        times,
+        contraction_metrics = tracked_finalizer.contraction_metrics,
+        gradnorms_unitcell = tracked_finalizer.gradnorms_unitcell,
+        times = tracked_finalizer.times,
     )
     return peps_final, env_final, cost_final, info
 end
@@ -277,7 +284,8 @@ end
 Check compatibility of an initial PEPS and environment with a specified PEPS optimization algorithm.
 """
 function check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize)
-    if parent_alg(alg.gradient_alg) isa FixedPointGradient &&
+    if typeof(parent_alg(alg.boundary_alg)) <: Union{SimultaneousCTMRG, SequentialCTMRG} &&
+            parent_alg(alg.gradient_alg) isa FixedPointGradient &&
             scalartype(env₀) <: Real # :fixed mode gauge fixing is incompatible with real environments
         msg = "the provided real environment is incompatible with :fixed mode \
         since :fixed mode generally produces complex gauges"
@@ -377,34 +385,39 @@ function symmetrize_retract_and_finalize!(
 end
 
 """
-    track_state_and_finalize!(
-        tol_state::Base.RefValue, latest_metrics::Base.RefValue, latest_gradnorms::Base.RefValue,
-        latest_time::Base.RefValue, contraction_metrics::Vector, gradnorms_unitcell::Vector,
-        times::Vector, [finalize!],
-    )
+$(TYPEDEF)
 
-Return a `finalize!` function that, after calling `finalize!` (defaulting to
-`OptimKit._finalize!`):
-* updates `tol_state[]` to the `(iter, gradnorm)` of the now-accepted optimization step,
-  used to drive `MPSKit.updatetol` for any `alg.boundary_alg`/`alg.gradient_alg` wrapped
-  in a `MPSKit.DynamicTol`
-* records `latest_metrics[]`/`latest_gradnorms[]`/`latest_time[]`, i.e. the values
-  produced by the `fg` call corresponding to the accepted step, into
-  `contraction_metrics`/`gradnorms_unitcell`/`times`
+Callable that acts as the `finalize!` function passed to `OptimKit.optimize`.
+Keeps track of the optimization iteration number and gradient norm of the last accepted
+optimization step, and records the contraction metrics, gradient norms and execution times
+of each optimization step.
+
+## Fields
+
+$(TYPEDFIELDS)
 """
-function track_state_and_finalize!(
-        tol_state::Base.RefValue, latest_metrics::Base.RefValue, latest_gradnorms::Base.RefValue,
-        latest_time::Base.RefValue, contraction_metrics::Vector, gradnorms_unitcell::Vector,
-        times::Vector, (finalize!) = OptimKit._finalize!,
-    )
-    function commit_state_and_finalize!((peps, env), E, grad, numiter)
-        (peps, env), E, grad = finalize!((peps, env), E, grad, numiter)
-        gradnorm = sqrt(real_inner((peps, env), grad, grad))
-        tol_state[] = (; iter = numiter, gradnorm)
-        push!(contraction_metrics, latest_metrics[])
-        push!(gradnorms_unitcell, latest_gradnorms[])
-        push!(times, latest_time[])
-        return (peps, env), E, grad
-    end
-    return commit_state_and_finalize!
+mutable struct TrackedFinalizer{A, B, C}
+    tol_state::A
+    const contraction_metrics::Vector{B}
+    const gradnorms_unitcell::Vector{C}
+    const times::Vector{Float64}
+    const finalize!
+end
+
+"""
+    (tf::TrackedFinalizer)((peps, env), E, grad, numiter)
+
+Finalize the accepted optimization step. This calls `tf.finalize!`, updates `tf.tol_state`
+to the (; iter, gradnorm) of the last accepted optimization step, and extends
+`tf.contraction_metrics`, `tf.gradnorms_unitcell` and `tf.times` to make room for the next
+step.
+"""
+function (tf::TrackedFinalizer)((peps, env), E, grad, numiter)
+    (peps, env), E, grad = tf.finalize!((peps, env), E, grad, numiter)
+    gradnorm = sqrt(real_inner((peps, env), grad, grad))
+    tf.tol_state = (; iter = numiter, gradnorm)
+    resize!(tf.contraction_metrics, numiter + 1)
+    resize!(tf.gradnorms_unitcell, numiter + 1)
+    resize!(tf.times, numiter + 1)
+    return (peps, env), E, grad
 end

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -277,8 +277,7 @@ end
 Check compatibility of an initial PEPS and environment with a specified PEPS optimization algorithm.
 """
 function check_input(::typeof(fixedpoint), peps₀, env₀, alg::PEPSOptimize)
-    if parent_alg(alg.boundary_alg) isa SimultaneousCTMRG &&
-            parent_alg(alg.gradient_alg) isa FixedPointGradient &&
+    if parent_alg(alg.gradient_alg) isa FixedPointGradient &&
             scalartype(env₀) <: Real # :fixed mode gauge fixing is incompatible with real environments
         msg = "the provided real environment is incompatible with :fixed mode \
         since :fixed mode generally produces complex gauges"

--- a/src/algorithms/optimization/peps_optimization.jl
+++ b/src/algorithms/optimization/peps_optimization.jl
@@ -238,7 +238,7 @@ function fixedpoint(
             return cost_function(ψ, env′, operator)
         end
         g = only(gs)  # `withgradient` returns tuple of gradients `gs`
-        latest_gradnorms[] = norm.(g.A)
+        latest_gradnorms[] = norm.(unitcell(g))
         latest_time[] = (time_ns() - start_time) * 1.0e-9
         return E, g
     end

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -6,9 +6,9 @@ _alg_or_nt(T, alg) = throw(ArgumentError("unkown $T: $alg"))
 """
     parent_alg(alg)
 
-Unwrap an algorithm from a `MPSKit.DynamicTol` wrapper, if present, returning the
-algorithm it wraps. Falls back to returning `alg` unchanged for any other input,
-including `nothing`.
+Unwrap an algorithm from a `MPSKit.DynamicTols.DynamicTol` wrapper, if
+present, returning the algorithm it wraps. Falls back to returning `alg` unchanged for any
+other input, including `nothing`.
 """
 parent_alg(alg) = alg
 parent_alg(alg::DynamicTol) = parent_alg(alg.alg)
@@ -16,8 +16,8 @@ parent_alg(alg::DynamicTol) = parent_alg(alg.alg)
 """
     _dynamic_tol_or_alg(alg; dynamic_tols::Bool, tol_min::Real, tol_max::Real, tol_factor::Real)
 
-Wrap `alg` in a `MPSKit.DynamicTol` with the given tolerance-scaling settings if
-`dynamic_tols` is `true`, otherwise return `alg` unchanged.
+Wrap `alg` in a `MPSKit.DynamicTols.DynamicTol` with the given
+tolerance-scaling settings if `dynamic_tols` is `true`, otherwise return `alg` unchanged.
 """
 function _dynamic_tol_or_alg(alg; dynamic_tols::Bool, tol_min::Real, tol_max::Real, tol_factor::Real)
     return dynamic_tols ? DynamicTol(alg, tol_min, tol_max, tol_factor) : alg

--- a/src/algorithms/select_algorithm.jl
+++ b/src/algorithms/select_algorithm.jl
@@ -1,6 +1,46 @@
 _alg_or_nt(::Type{T}, alg::NamedTuple) where {T} = T(; alg...)
 _alg_or_nt(::Type{T}, alg::A) where {T, A <: T} = alg
+_alg_or_nt(::Type{T}, alg::DynamicTol{<:T}) where {T} = alg
 _alg_or_nt(T, alg) = throw(ArgumentError("unkown $T: $alg"))
+
+"""
+    parent_alg(alg)
+
+Unwrap an algorithm from a `MPSKit.DynamicTol` wrapper, if present, returning the
+algorithm it wraps. Falls back to returning `alg` unchanged for any other input,
+including `nothing`.
+"""
+parent_alg(alg) = alg
+parent_alg(alg::DynamicTol) = parent_alg(alg.alg)
+
+"""
+    _dynamic_tol_or_alg(alg; dynamic_tols::Bool, tol_min::Real, tol_max::Real, tol_factor::Real)
+
+Wrap `alg` in a `MPSKit.DynamicTol` with the given tolerance-scaling settings if
+`dynamic_tols` is `true`, otherwise return `alg` unchanged.
+"""
+function _dynamic_tol_or_alg(alg; dynamic_tols::Bool, tol_min::Real, tol_max::Real, tol_factor::Real)
+    return dynamic_tols ? DynamicTol(alg, tol_min, tol_max, tol_factor) : alg
+end
+
+const DYNAMIC_TOL_KWARGS = (; dynamic_tols = nothing, tol_min = nothing, tol_max = nothing, tol_factor = nothing)
+
+"""
+    _pop_dynamic_tol_kwargs(kwargs::NamedTuple) -> dynamic_tol_kwargs, remaining_kwargs
+
+Split off the `dynamic_tols`/`tol_min`/`tol_max`/`tol_factor` entries from `kwargs`,
+returning them separately (to be passed on to [`_dynamic_tol_or_alg`](@ref)) from the
+remaining keyword arguments (to be passed on to the algorithm constructor).
+"""
+function _pop_dynamic_tol_kwargs(kwargs::NamedTuple)
+    dynamic_tol_kwargs = (;
+        dynamic_tols = kwargs.dynamic_tols,
+        tol_min = kwargs.tol_min,
+        tol_max = kwargs.tol_max,
+        tol_factor = kwargs.tol_factor,
+    )
+    return dynamic_tol_kwargs, Base.structdiff(kwargs, DYNAMIC_TOL_KWARGS)
+end
 
 """
     select_algorithm(func_or_alg, args...; kwargs...) -> Algorithm
@@ -27,24 +67,41 @@ function select_algorithm(
     )
     # adjust CTMRG tols and verbosity
     if boundary_alg isa NamedTuple
-        defaults = (; verbosity = verbosity ≤ 3 ? -1 : 3, tol = 1.0e-4tol)
+        defaults = (;
+            verbosity = verbosity ≤ 3 ? -1 : 3, tol = 1.0e-4tol,
+            dynamic_tols = Defaults.ctmrg_dynamic_tols,
+            tol_min = Defaults.ctmrg_tol_min,
+            tol_max = Defaults.ctmrg_tol_max,
+            tol_factor = Defaults.ctmrg_tol_factor,
+        )
         boundary_kwargs = merge(defaults, boundary_alg)
+        dynamic_tol_kwargs, boundary_kwargs = _pop_dynamic_tol_kwargs(boundary_kwargs)
         boundary_alg = select_algorithm(leading_boundary, env₀; boundary_kwargs...)
+        boundary_alg = _dynamic_tol_or_alg(boundary_alg; dynamic_tol_kwargs...)
     end
 
     # C4vCTMRG-specific defaults
-    if boundary_alg isa C4vCTMRG
+    if parent_alg(boundary_alg) isa C4vCTMRG
         # symmetrize state and gradient
         if isnothing(symmetrization)
             symmetrization = RotateReflect()
         end
     end
 
-    # adjust gradient verbosity
+    # adjust gradient verbosity and construct the gradient algorithm
     if gradient_alg isa NamedTuple
         # TODO: check this:
-        defaults = (; verbosity = verbosity ≤ 3 ? -1 : 3, tol = 1.0e-2tol)
-        gradient_alg = merge(defaults, gradient_alg)
+        defaults = (;
+            verbosity = verbosity ≤ 3 ? -1 : 3, tol = 1.0e-2tol,
+            dynamic_tols = Defaults.gradient_dynamic_tols,
+            tol_min = Defaults.gradient_tol_min,
+            tol_max = Defaults.gradient_tol_max,
+            tol_factor = Defaults.gradient_tol_factor,
+        )
+        gradient_kwargs = merge(defaults, gradient_alg)
+        dynamic_tol_kwargs, gradient_kwargs = _pop_dynamic_tol_kwargs(gradient_kwargs)
+        gradient_alg = GradientAlgorithm(; gradient_kwargs...)
+        gradient_alg = _dynamic_tol_or_alg(gradient_alg; dynamic_tol_kwargs...)
     end
 
     # adjust optimizer tol and verbosity


### PR DESCRIPTION
Adds adaptive tolerance scaling, where the tolerance of the contraction algorithm is set based on the current norm of the gradient (default scaling factor of `1.0e-3`). The tolerance of the gradient algorithm in turn is set based on the contraction tolerance (default scaling factor `1.0e1`).

On the README example, these default settings give a 1.5x speedup in walltime needed to reach a given energy value starting from the same initial guess. I'll see what the tests say for now, and do some more trials in the meantime.

At the same time, this reworks the way the per-iteration info metrics are stored and added. Previously, the `contraction_metrics` and `gradnorms_unitcell` got a new entry every time cost function was called. These function evaluations don't necessarily match the iterations of the optimization loop. In particular, entries were added for every rejected step during the line search, which just seemed needlessly confusing. I changed to workflow to record the current values in the cost function, but only add entries in the `finalize!` routine, which is actually called after every iteration (i.e. every accepted step).

This is also in anticipation of adding preconditioning, which naturally requires access to the current gradient norm.