### PR TITLE
Don't compute diff unnecessarily in simple update

### DIFF
--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -215,12 +215,12 @@ function MPSKit.time_evolve(
         env0, time0 = it.state.env, time()
         for (psi, env, info) in it
             iter = it.state.iter
-            diff = compare_weights(env0, env)
             stop = (iter == it.nstep)
             showinfo = (check_interval > 0) &&
                 ((iter % check_interval == 0) || (iter == 1) || stop)
             time1 = time()
             if showinfo
+                diff = compare_weights(env0, env)
                 @infov 2 "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
                 @infov 2 @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, diff, time1 - time0)
             end

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -220,9 +220,8 @@ function MPSKit.time_evolve(
                 ((iter % check_interval == 0) || (iter == 1) || stop)
             time1 = time()
             if showinfo
-                diff = compare_weights(env0, env)
-                @infov 2 "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
-                @infov 2 @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, diff, time1 - time0)
+@infov 2 "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
+@infov 2 @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, compare_weights(env0, env), time1 - time0)
             end
             if stop
                 time_end = time()

--- a/src/algorithms/time_evolution/simpleupdate.jl
+++ b/src/algorithms/time_evolution/simpleupdate.jl
@@ -220,8 +220,8 @@ function MPSKit.time_evolve(
                 ((iter % check_interval == 0) || (iter == 1) || stop)
             time1 = time()
             if showinfo
-@infov 2 "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
-@infov 2 @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, compare_weights(env0, env), time1 - time0)
+                @infov 2 "Space of x-weight at [1, 1] = $(space(env[1, 1, 1], 1))"
+                @infov 2 @sprintf("SU iter %-7d: |Δλ| = %.3e. Time = %.3f s/it", iter, compare_weights(env0, env), time1 - time0)
             end
             if stop
                 time_end = time()


### PR DESCRIPTION
Right now this `compare_weights` is being run every iteration, even when completely unused. We can move it down into the `showinfo` block to avoid wasting some time.