### PR TITLE
Avoid needlessly recomputing svd_vals for c4v

### DIFF
--- a/src/algorithms/ctmrg/c4v.jl
+++ b/src/algorithms/ctmrg/c4v.jl
@@ -135,9 +135,24 @@ function check_input(
     return nothing
 end
 
-#
-## C4v-symmetric CTMRG iteration (called through `leading_boundary`)
-#
+# The corners in C₄ᵥ CTMRG are identical and the four edges are related by
+# rotation, so all edges produce the same singular values. `eigh_vals` is about
+# as expensive as `svd_vals` on CPU but much cheaper on GPU, and gives effectively
+# the same information. For the QR projector, off-diagonal elements are still
+# present until CTMRG converges, so we need a fallback for the non-diagonal case.
+corner_spectrum(C::AbstractTensorMap, ::C4vCTMRG) = eigh_vals(C)
+corner_spectrum(C::DiagonalTensorMap, ::C4vCTMRG) = svd_vals(C)
+
+"""
+    convergence_tensors(env::CTMRGEnv, alg::C4vCTMRG) -> (corners, edges)
+
+The corners and edges whose singular values determine convergence.
+
+For C₄ᵥ-symmetric CTMRG, only one corner and one edge are needed since
+the corners are identical, and the edges have identical singular values.
+"""
+convergence_tensors(env::CTMRGEnv, ::C4vCTMRG) =
+    (view(env.corners, 1:1, :, :), view(env.edges, 1:1, :, :))
 
 function ctmrg_iteration(network, env::CTMRGEnv, ::C4vCTMRG{P}) where {P}
     throw(ArgumentError("Unknown C4v projector algorithm $P"))

--- a/src/algorithms/ctmrg/c4v.jl
+++ b/src/algorithms/ctmrg/c4v.jl
@@ -141,7 +141,6 @@ end
 # the same information. For the QR projector, off-diagonal elements are still
 # present until CTMRG converges, so we need a fallback for the non-diagonal case.
 corner_spectrum(C::AbstractTensorMap, ::C4vCTMRG) = eigh_vals(C)
-corner_spectrum(C::DiagonalTensorMap, ::C4vCTMRG) = svd_vals(C)
 
 """
     convergence_tensors(env::CTMRGEnv, alg::C4vCTMRG) -> (corners, edges)

--- a/src/algorithms/ctmrg/ctmrg.jl
+++ b/src/algorithms/ctmrg/ctmrg.jl
@@ -115,7 +115,7 @@ function leading_boundary(
     return LoggingExtras.withlevel(; alg.verbosity) do
         env = deepcopy(env₀)
         CS, TS = ignore_derivatives() do
-            return map(svd_vals, env₀.corners), map(svd_vals, env₀.edges)
+            return convergence_spectra(env₀, alg)
         end
         η = one(real(scalartype(network)))
         ctmrg_loginit!(log, η, network, env₀)
@@ -123,7 +123,7 @@ function leading_boundary(
         converged = false
         for iter in 1:(alg.maxiter)
             env, info_iter = ctmrg_iteration(network, env, alg)
-            η, CS, TS = calc_convergence(env, CS, TS)
+            η, CS, TS = calc_convergence(env, CS, TS, alg)
 
             if η ≤ alg.tol && iter ≥ alg.miniter
                 ctmrg_logfinish!(log, iter, η, network, env)
@@ -202,11 +202,47 @@ _singular_value_distance(S₁::DiagonalTensorMap, S₂::DiagonalTensorMap) =
     _singular_value_distance(diagview(S₁), diagview(S₂))
 
 """
+    convergence_tensors(env, alg) -> (corners, edges)
+
+The corners and edges whose spectra determine convergence.
+
+For generic CTMRG, we need all corners and edges.
+"""
+convergence_tensors(env::CTMRGEnv, alg) = (env.corners, env.edges)
+
+"""
+    convergence_spectra(env, alg)
+
+Spectra of the tensors that [`convergence_tensors`](@ref) selects.
+"""
+function convergence_spectra(env::CTMRGEnv, alg)
+    corners, edges = convergence_tensors(env, alg)
+    return map(C -> corner_spectrum(C, alg), corners), map(T -> edge_spectrum(T, alg), edges)
+end
+
+"""
+    corner_spectrum(C, alg)
+    edge_spectrum(T, alg)
+
+The spectrum of a corner or edge, used to measure CTMRG convergence.
+"""
+corner_spectrum(C, alg) = svd_vals(C)
+edge_spectrum(T, alg) = svd_vals(T)
+
+function calc_convergence(env, CS_old, TS_old, alg)
+    CS_new, TS_new = convergence_spectra(env, alg)
+    ΔCS = maximum(splat(_singular_value_distance), zip(CS_old, CS_new))
+    ΔTS = maximum(splat(_singular_value_distance), zip(TS_old, TS_new))
+    @debug "maxᵢ|Cⁿ⁺¹ - Cⁿ|ᵢ = $ΔCS   maxᵢ|Tⁿ⁺¹ - Tⁿ|ᵢ = $ΔTS"
+    return max(ΔCS, ΔTS), CS_new, TS_new
+end
+
+"""
     calc_convergence(env, CS_old, TS_old)
     calc_convergence(env_new, env_old)
 
-Given a new environment `env`, compute the maximal singular value distance.
-This determined either from the previous corner and edge singular values
+Given a new environment `env`, compute the maximal spectral distance.
+This determined either from the previous corner and edge spectra
 `CS_old` and `TS_old`, or alternatively, directly from the old environment.
 """
 function calc_convergence(env, CS_old, TS_old)


### PR DESCRIPTION
Also switch to using `eigh_vals` in the QR decomposition case, as that will be a lot less expensive than `svd_vals` for the GPU. I think it should still be valid for the check, but I can get rid of that if needed. It's sort of a kludge to fix https://github.com/QuantumKitHub/PEPSKit.jl/issues/418 without reworking all the environments.