### PR TITLE
Collect twistdual utility functions

### DIFF
--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -54,6 +54,7 @@ include("Defaults.jl")  # Include first to allow for docstring interpolation wit
 include("utility/util.jl")
 include("utility/indexing.jl")
 include("utility/diffable_threads.jl")
+include("utility/twistdual.jl")
 include("utility/eigh.jl")
 include("utility/svd.jl")
 include("utility/qr.jl")

--- a/src/algorithms/contractions/ctmrg/characteristic_equations.jl
+++ b/src/algorithms/contractions/ctmrg/characteristic_equations.jl
@@ -317,38 +317,6 @@ function eachcoordinate(tensor_unitcell::Array{<:AbstractTensorMap, 3})
     return collect(Iterators.product(axes(tensor_unitcell)...))
 end
 
-# add rrule for twistdual through dummy out-of-place function
-function _twistdual(t::AbstractTensorMap, i::Int)
-    isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function _twistdual(t::AbstractTensorMap, is)
-    is′ = filter(i -> isdual(space(t, i)), is)
-    return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
-    )
-    tout, twistdual_pullback = rrule_via_ad(config, _twistdual, t, i)
-    return tout, twistdual_pullback
-end
-
-# add rrule for twistnondual through dummy out-of-place function
-function _twistnondual(t::AbstractTensorMap, i::Int)
-    !isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function _twistnondual(t::AbstractTensorMap, is)
-    is′ = filter(i -> !isdual(space(t, i)), is)
-    return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
-    )
-    tout, twistnondual_pullback = rrule_via_ad(config, _twistnondual, t, i)
-    return tout, twistnondual_pullback
-end
-
 function absorb_left(
         E::AbstractTensorMap{T, S}, C::CornerTensor{S}
     ) where {T, S}

--- a/src/algorithms/truncation/fullenv_truncation.jl
+++ b/src/algorithms/truncation/fullenv_truncation.jl
@@ -52,21 +52,6 @@ function inner_prod(
     return @tensor conj(b1[1; 2]) * benv[1 2; 3 4] * b2[3; 4]
 end
 
-"""
-$(SIGNATURES)
-
-Apply a twist to domain or codomain indices that correspond to dual spaces
-"""
-function _linearmap_twist!(t::AbstractTensorMap)
-    for ax in 1:numout(t)
-        isdual(codomain(t, ax)) && twist!(t, ax)
-    end
-    for ax in 1:numin(t)
-        isdual(domain(t, ax)) && twist!(t, numout(t) + ax)
-    end
-    return nothing
-end
-
 function _fet_message(
         iter::Int, fid::Float64, Δfid::Float64, Δwt::Float64, time_elapsed::Float64
     )

--- a/src/algorithms/truncation/fullenv_truncation.jl
+++ b/src/algorithms/truncation/fullenv_truncation.jl
@@ -207,8 +207,8 @@ function fullenv_truncate(
         @tensor r[-1 -2] := s[-1; 1] * vh[1; -2]
         @tensor p[-1 -2] := conj(u[1; -1]) * benv_b0[1 -2]
         @tensor B[-1 -2; -3 -4] := conj(u[1; -1]) * benv[1 -2; 3 -4] * u[3; -3]
-        _linearmap_twist!(p)
-        _linearmap_twist!(B)
+        twist_linearmap!(p)
+        twist_linearmap!(B)
         r, info_r = linsolve(Base.Fix1(*, B), p, r, 0, 1)
         @tensor b1[-1; -2] = u[-1; 1] * r[1 -2]
         u, s, vh = svd_trunc(b1; trunc = alg.trunc)
@@ -216,8 +216,8 @@ function fullenv_truncate(
         @tensor l[-1 -2] := u[-1; 1] * s[1; -2]
         @tensor p[-1 -2] := conj(vh[-2; 2]) * benv_b0[-1 2]
         @tensor B[-1 -2; -3 -4] := conj(vh[-2; 2]) * benv[-1 2; -3 4] * vh[-4; 4]
-        _linearmap_twist!(p)
-        _linearmap_twist!(B)
+        twist_linearmap!(p)
+        twist_linearmap!(B)
         l, info_l = linsolve(Base.Fix1(*, B), p, l, 0, 1)
         @debug "Bond truncation info" info_l info_r
         @tensor b1[-1; -2] = l[-1 1] * vh[1; -2]

--- a/src/utility/twistdual.jl
+++ b/src/utility/twistdual.jl
@@ -1,0 +1,78 @@
+"""
+$(SIGNATURES)
+
+Twist the i-th leg of a tensor `t` in place if it represents a dual space.
+"""
+function twistdual!(t::AbstractTensorMap, i::Int)
+    isdual(space(t, i)) || return t
+    return twist!(t, i)
+end
+function twistdual!(t::AbstractTensorMap, is)
+    is′ = filter(i -> isdual(space(t, i)), is)
+    return twist!(t, is′)
+end
+
+"""
+$(SIGNATURES)
+
+Twist the i-th leg of a tensor `t` if it represents a dual space.
+"""
+function twistdual(t::AbstractTensorMap, i::Int)
+    isdual(space(t, i)) || return t
+    return twist(t, i)
+end
+function twistdual(t::AbstractTensorMap, is)
+    is′ = filter(i -> isdual(space(t, i)), is)
+    return twist(t, is′)
+end
+function ChainRulesCore.rrule(
+        config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
+    )
+    tout, twistdual_pullback = rrule_via_ad(config, twistdual, t, i)
+    return tout, twistdual_pullback
+end
+
+"""
+$(SIGNATURES)
+
+Twist the i-th leg of a tensor `t` in place if it represents a non-dual space.
+"""
+function twistnondual!(t::AbstractTensorMap, i::Int)
+    !isdual(space(t, i)) || return t
+    return twist!(t, i)
+end
+function twistnondual!(t::AbstractTensorMap, is)
+    is′ = filter(i -> !isdual(space(t, i)), is)
+    return twist!(t, is′)
+end
+
+"""
+$(SIGNATURES)
+
+Twist the i-th leg of a tensor `t` if it represents a non-dual space.
+"""
+function twistnondual(t::AbstractTensorMap, i::Int)
+    !isdual(space(t, i)) || return t
+    return twist(t, i)
+end
+function twistnondual(t::AbstractTensorMap, is)
+    is′ = filter(i -> !isdual(space(t, i)), is)
+    return twist(t, is′)
+end
+function ChainRulesCore.rrule(
+        config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
+    )
+    tout, twistnondual_pullback = rrule_via_ad(config, twistnondual, t, i)
+    return tout, twistnondual_pullback
+end
+
+"""
+$(SIGNATURES)
+
+Apply a twist to domain or codomain indices that correspond to dual spaces.
+"""
+function _linearmap_twist!(t::AbstractTensorMap)
+    twistdual!(t, 1:numout(t))
+    twistnondual!(t, (numout(t) + 1):numind(t))
+    return t
+end

--- a/src/utility/twistdual.jl
+++ b/src/utility/twistdual.jl
@@ -17,21 +17,13 @@ $(SIGNATURES)
 
 Twist the i-th leg of a tensor `t` if it represents a dual space.
 """
-twistdual(t::AbstractTensorMap, i) = _twistdual(t, i)
-# add rrule through dummy versions
-function _twistdual(t::AbstractTensorMap, i::Int)
+function twistdual(t::AbstractTensorMap, i::Int)
     isdual(space(t, i)) || return t
     return twist(t, i)
 end
-function _twistdual(t::AbstractTensorMap, is)
+function twistdual(t::AbstractTensorMap, is)
     is′ = filter(i -> isdual(space(t, i)), is)
     return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
-    )
-    tout, twistdual_pullback = rrule_via_ad(config, _twistdual, t, i)
-    return tout, twistdual_pullback
 end
 
 """
@@ -53,21 +45,13 @@ $(SIGNATURES)
 
 Twist the i-th leg of a tensor `t` if it represents a non-dual space.
 """
-twistnondual(t::AbstractTensorMap, i) = _twistnondual(t, i)
-# add rrule through dummy versions
-function _twistnondual(t::AbstractTensorMap, i::Int)
+function twistnondual(t::AbstractTensorMap, i::Int)
     !isdual(space(t, i)) || return t
     return twist(t, i)
 end
-function _twistnondual(t::AbstractTensorMap, is)
+function twistnondual(t::AbstractTensorMap, is)
     is′ = filter(i -> !isdual(space(t, i)), is)
     return twist(t, is′)
-end
-function ChainRulesCore.rrule(
-        config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
-    )
-    tout, twistnondual_pullback = rrule_via_ad(config, _twistnondual, t, i)
-    return tout, twistnondual_pullback
 end
 
 """

--- a/src/utility/twistdual.jl
+++ b/src/utility/twistdual.jl
@@ -1,57 +1,41 @@
-"""
-$(SIGNATURES)
+for (twistdual, twist, inplace) in zip(
+        (:twistdual!, :twistdual), (:twist!, :twist), (" in place ", " ")
+    )
+    @eval begin
+        """
+        $(SIGNATURES)
 
-Twist the i-th leg of a tensor `t` in place if it represents a dual space.
-"""
-function twistdual!(t::AbstractTensorMap, i::Int)
-    isdual(space(t, i)) || return t
-    return twist!(t, i)
-end
-function twistdual!(t::AbstractTensorMap, is)
-    is′ = filter(i -> isdual(space(t, i)), is)
-    return twist!(t, is′)
-end
-
-"""
-$(SIGNATURES)
-
-Twist the i-th leg of a tensor `t` if it represents a dual space.
-"""
-function twistdual(t::AbstractTensorMap, i::Int)
-    isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function twistdual(t::AbstractTensorMap, is)
-    is′ = filter(i -> isdual(space(t, i)), is)
-    return twist(t, is′)
+        Twist the i-th leg of a tensor `t`$($(inplace))if it represents a dual space.
+        """
+        function $twistdual(t::AbstractTensorMap, i::Int)
+            isdual(space(t, i)) || return t
+            return $twist(t, i)
+        end
+        function $twistdual(t::AbstractTensorMap, is)
+            is′ = filter(i -> isdual(space(t, i)), is)
+            return $twist(t, is′)
+        end
+    end
 end
 
-"""
-$(SIGNATURES)
+for (twistnondual, twist, inplace) in zip(
+        (:twistnondual!, :twistnondual), (:twist!, :twist), (" in place ", " ")
+    )
+    @eval begin
+        """
+        $(SIGNATURES)
 
-Twist the i-th leg of a tensor `t` in place if it represents a non-dual space.
-"""
-function twistnondual!(t::AbstractTensorMap, i::Int)
-    !isdual(space(t, i)) || return t
-    return twist!(t, i)
-end
-function twistnondual!(t::AbstractTensorMap, is)
-    is′ = filter(i -> !isdual(space(t, i)), is)
-    return twist!(t, is′)
-end
-
-"""
-$(SIGNATURES)
-
-Twist the i-th leg of a tensor `t` if it represents a non-dual space.
-"""
-function twistnondual(t::AbstractTensorMap, i::Int)
-    !isdual(space(t, i)) || return t
-    return twist(t, i)
-end
-function twistnondual(t::AbstractTensorMap, is)
-    is′ = filter(i -> !isdual(space(t, i)), is)
-    return twist(t, is′)
+        Twist the i-th leg of a tensor `t`$($(inplace))if it represents a non-dual space.
+        """
+        function $twistnondual(t::AbstractTensorMap, i::Int)
+            !isdual(space(t, i)) || return t
+            return $twist(t, i)
+        end
+        function $twistnondual(t::AbstractTensorMap, is)
+            is′ = filter(i -> !isdual(space(t, i)), is)
+            return $twist(t, is′)
+        end
+    end
 end
 
 """
@@ -59,7 +43,7 @@ $(SIGNATURES)
 
 Apply a twist to domain or codomain indices that correspond to dual spaces.
 """
-function _linearmap_twist!(t::AbstractTensorMap)
+function twist_linearmap!(t::AbstractTensorMap)
     twistdual!(t, 1:numout(t))
     twistnondual!(t, (numout(t) + 1):numind(t))
     return t

--- a/src/utility/twistdual.jl
+++ b/src/utility/twistdual.jl
@@ -17,18 +17,20 @@ $(SIGNATURES)
 
 Twist the i-th leg of a tensor `t` if it represents a dual space.
 """
-function twistdual(t::AbstractTensorMap, i::Int)
+twistdual(t::AbstractTensorMap, i) = _twistdual(t, i)
+# add rrule through dummy versions
+function _twistdual(t::AbstractTensorMap, i::Int)
     isdual(space(t, i)) || return t
     return twist(t, i)
 end
-function twistdual(t::AbstractTensorMap, is)
+function _twistdual(t::AbstractTensorMap, is)
     is′ = filter(i -> isdual(space(t, i)), is)
     return twist(t, is′)
 end
 function ChainRulesCore.rrule(
         config::RuleConfig, ::typeof(twistdual), t::AbstractTensorMap, i
     )
-    tout, twistdual_pullback = rrule_via_ad(config, twistdual, t, i)
+    tout, twistdual_pullback = rrule_via_ad(config, _twistdual, t, i)
     return tout, twistdual_pullback
 end
 
@@ -51,18 +53,20 @@ $(SIGNATURES)
 
 Twist the i-th leg of a tensor `t` if it represents a non-dual space.
 """
-function twistnondual(t::AbstractTensorMap, i::Int)
+twistnondual(t::AbstractTensorMap, i) = _twistnondual(t, i)
+# add rrule through dummy versions
+function _twistnondual(t::AbstractTensorMap, i::Int)
     !isdual(space(t, i)) || return t
     return twist(t, i)
 end
-function twistnondual(t::AbstractTensorMap, is)
+function _twistnondual(t::AbstractTensorMap, is)
     is′ = filter(i -> !isdual(space(t, i)), is)
     return twist(t, is′)
 end
 function ChainRulesCore.rrule(
         config::RuleConfig, ::typeof(twistnondual), t::AbstractTensorMap, i
     )
-    tout, twistnondual_pullback = rrule_via_ad(config, twistnondual, t, i)
+    tout, twistnondual_pullback = rrule_via_ad(config, _twistnondual, t, i)
     return tout, twistnondual_pullback
 end
 

--- a/src/utility/util.jl
+++ b/src/utility/util.jl
@@ -65,38 +65,6 @@ end
 _fliptwist_s(s::DiagonalTensorMap) = twist!(DiagonalTensorMap(flip(s, 1:2)), 1)
 
 """
-    twistdual(t::AbstractTensorMap, i)
-    twistdual!(t::AbstractTensorMap, i)
-
-Twist the i-th leg of a tensor `t` if it represents a dual space.
-"""
-function twistdual!(t::AbstractTensorMap, i::Int)
-    isdual(space(t, i)) || return t
-    return twist!(t, i)
-end
-function twistdual!(t::AbstractTensorMap, is)
-    is′ = filter(i -> isdual(space(t, i)), is)
-    return twist!(t, is′)
-end
-twistdual(t::AbstractTensorMap, is) = twistdual!(copy(t), is)
-
-"""
-    twistnondual(t::AbstractTensorMap, i)
-    twistnondual!(t::AbstractTensorMap, i)
-
-Twist the i-th leg of a tensor `t` if it represents a non-dual space.
-"""
-function twistnondual!(t::AbstractTensorMap, i::Int)
-    !isdual(space(t, i)) || return t
-    return twist!(t, i)
-end
-function twistnondual!(t::AbstractTensorMap, is)
-    is′ = filter(i -> !isdual(space(t, i)), is)
-    return twist!(t, is′)
-end
-twistnondual(t::AbstractTensorMap, is) = twistnondual!(copy(t), is)
-
-"""
     str(t)
 
 Fermionic supertrace by using `@tensor`.


### PR DESCRIPTION
I think there is now a large enough family of twistdual-like functions, and it's time to collect them in one place.

The non-mutating `twistdual` is no longer implemented with `twist! + copy`, but directly using `twist`.